### PR TITLE
Fix PDOs for EP2316

### DIFF
--- a/src/lcec_ep23xx.c
+++ b/src/lcec_ep23xx.c
@@ -112,8 +112,13 @@ int lcec_ep23xx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *
     // initialize POD entry
     int idx_offset = (i<<4);
     
-    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + idx_offset, 0x01, &pin->in_pdo_os, &pin->in_pdo_bp);
-    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x7000 + idx_offset, 0x01, &pin->out_pdo_os, &pin->out_pdo_bp);
+    if(slave->pid == LCEC_EP2316_PID) {
+      LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000, 0x01 + i, &pin->in_pdo_os, &pin->in_pdo_bp);
+      LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x7000, 0x01 + i, &pin->out_pdo_os, &pin->out_pdo_bp);
+    } else {
+      LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + idx_offset, 0x01, &pin->in_pdo_os, &pin->in_pdo_bp);
+      LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x7000 + idx_offset, 0x01, &pin->out_pdo_os, &pin->out_pdo_bp);
+    }
  
     // export pins
     if ((err = lcec_pin_newf_list(pin, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {

--- a/src/lcec_ep23xx.h
+++ b/src/lcec_ep23xx.h
@@ -25,7 +25,7 @@
 // Add additional EP23xx models here, as well as lcec_main.c, lcec_conf.c, and lcec_conf.h.
 #define LCEC_EP2338_PID 0x09224052
 #define LCEC_EP2349_PID 0x092d4052
-#define LCEC_EP2316_PID 0x090C4052  // Untested, may not work.
+#define LCEC_EP2316_PID 0x090C4052
 
 #define LCEC_EP2338_PDOS 16  // Can be in or out on each port, so 2 PDOs per port.
 #define LCEC_EP2349_PDOS 32  // Can be in or out on each port, so 2 PDOs per port.


### PR DESCRIPTION
The EP2316 uses `6000` and `7000` as their PDOs with an incrementing subindex where the other two implemented EP modules have PDOs that increment and a static subindex.
This fixes #11 