### PR TITLE
Simplify CI dependencies and add YAML pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,98 +1,103 @@
-# vim: sw=2
-
-# Copied from Linuxcnc's ci.yml action
+---
+# Adapted from Linuxcnc's ci.yml action
 
 name: Build CI
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-  release:
-    types: [published]
-  check_suite:
-    types: [rerequested]
+on:  # yamllint disable-line rule:truthy
+    push:
+        branches: [master]
+    pull_request:
+    release:
+        types: [published]
+    check_suite:
+        types: [rerequested]
 
 permissions:
-  contents: read #  to fetch code (actions/checkout)
+    contents: read  # to fetch code (actions/checkout)
 
 jobs:
-  build:
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - uses: actions/checkout@v4
-      name: Checkout linuxcnc-ethercat
+    build:
+        runs-on: ubuntu-20.04
+        steps:
+            - name: Dump GitHub context
+              env:
+                  GITHUB_CONTEXT: ${{ toJson(github) }}
+              run: echo "$GITHUB_CONTEXT"
+            - uses: actions/checkout@v4
+              name: Checkout linuxcnc-ethercat
 
-    - name: cache linuxcnc
-      id: cache-linuxcnc
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-linuxcnc
-      with:
-        key: ${{ runner.os }}-build-${{ env.cache-name }}
-        path: linuxcnc/
+            - name: cache linuxcnc
+              id: cache-linuxcnc
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-linuxcnc
+              with:
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}
+                  path: linuxcnc/
 
-    - name: Checkout linuxcnc
-      if: ${{ steps.cache-linuxcnc.outputs.cache-hit != 'true' }}
-      uses: actions/checkout@v4
-      with:
-        repository: 'linuxcnc/linuxcnc'
-        path: linuxcnc/
-        submodules: true
-        fetch-depth: 0
+            - name: Checkout linuxcnc
+              if: ${{ steps.cache-linuxcnc.outputs.cache-hit != 'true' }}
+              uses: actions/checkout@v4
+              with:
+                  repository: linuxcnc/linuxcnc
+                  path: linuxcnc/
+                  submodules: true
+                  fetch-depth: 0
 
-    - name: install linuxcnc deps
-      run: |
-        set -x
-        cd linuxcnc
-        sudo apt-get install -y eatmydata
-        eatmydata ./scripts/travis-install-build-deps.sh
-        eatmydata curl -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
-        sudo eatmydata apt install --yes ./po4a_0.67-2_all.deb
-        sudo eatmydata apt --quiet --yes upgrade
+            - name: install linuxcnc deps
+              run: |
+                  set -x
+                  cd linuxcnc
+                  # LinuxCNC provides a script to install deps, but it installs *way* too many things,
+                  # including TeX and most of X
+                  ./scripts/travis-install-build-deps.sh
 
-    - name: Build linuxcnc
-      if: ${{ steps.cache-linuxcnc.outputs.cache-hit != 'true' }}
-      run: |
-        set -x
-        cd linuxcnc
-        cd src
-        eatmydata ./autogen.sh
-        eatmydata ./configure --with-realtime=uspace --disable-check-runtime-deps --disable-gtk --enable-non-distributable=yes 
-        eatmydata make -O -j$((1+$(nproc))) default pycheck V=1
+                  #curl -O https://snapshot.debian.org/archive/debian/20220716T154603Z/pool/main/p/po4a/po4a_0.67-2_all.deb
+                  #sudo apt install --yes ./po4a_0.67-2_all.deb
+                  #sudo apt --quiet --yes upgrade
 
-    - name: Install linuxcnc locally
-      run: |
-        set -x
-        cd linuxcnc/src
-        sudo make install-kernel-indep
-        echo "$GITHUB_WORKSPACE/linuxcnc/bin" >> $GITHUB_PATH
+            - name: Build linuxcnc
+              if: ${{ steps.cache-linuxcnc.outputs.cache-hit != 'true' }}
+              run: |
+                  set -x
+                  cd linuxcnc
+                  cd src
+                  ./autogen.sh
+                  ./configure \
+                    --with-realtime=uspace \
+                    --disable-check-runtime-deps \
+                    --disable-gtk \
+                    --enable-non-distributable=yes
+                  make -O -j$((1+$(nproc))) default pycheck V=1
 
-    - name: Fetch EtherCAT Master
-      run: |
-        set -x
-        git clone https://gitlab.com/etherlab.org/ethercat.git
+            - name: Install linuxcnc locally
+              run: |
+                  set -x
+                  cd linuxcnc/src
+                  sudo make install-kernel-indep
+                  echo "$GITHUB_WORKSPACE/linuxcnc/bin" >> $GITHUB_PATH
 
-    - name: Build EtherCAT Master
-      run: |
-        set -x
-        cd ethercat
-        ./bootstrap
-        ./configure --disable-kernel
-        make -j$((1+$(nproc))) all
-        sudo make install
+            - name: Fetch EtherCAT Master
+              run: |
+                  set -x
+                  git clone https://gitlab.com/etherlab.org/ethercat.git
 
-    - name: Print linuxcnc bin
-      run: |
-        ls -l $GITHUB_WORKSPACE/linuxcnc/bin
-        echo "Path is:"
-        echo $PATH
-        $GITHUB_WORKSPACE/linuxcnc/bin/halcompile --help
+            - name: Build EtherCAT Master
+              run: |
+                  set -x
+                  cd ethercat
+                  ./bootstrap
+                  ./configure --disable-kernel
+                  make -j$((1+$(nproc))) all
+                  sudo make install
 
-    - name: make
-      run: |
-        make COMP=$GITHUB_WORKSPACE/linuxcnc/bin/halcompile
+            - name: Print linuxcnc bin
+              run: |
+                  ls -l $GITHUB_WORKSPACE/linuxcnc/bin
+                  echo "Path is:"
+                  echo $PATH
+                  $GITHUB_WORKSPACE/linuxcnc/bin/halcompile --help
+
+            - name: make
+              run: |
+                  make COMP=$GITHUB_WORKSPACE/linuxcnc/bin/halcompile

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ debian/*.log
 debian/*.substvars
 debian/linuxcnc-ethercat/
 
+# emacs tmp files
+\#*\#
+.\#*
+*~

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+---
+repos:
+    - repo: https://github.com/adrienverge/yamllint.git
+      rev: v1.21.0 # or higher tag
+      hooks:
+          - id: yamllint
+            args: [--format, parsable, -d, '{extends: default, rules: {line-length: {max: 200}}}']
+
+    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+      rev: 0.2.1 # or other specific tag
+      hooks:
+          - id: yamlfmt


### PR DESCRIPTION
First pass at simplifying the number of apt packages installed; this seems to lop a couple minutes off of the build time.  Verified with and without the cache.

Also added a YAML link/format pre-commit hook.  I've had way too many issues with malformed `ci.yml` files; this should prevent them.

This is part of issue #3.
