### PR TITLE
Add semantic-release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,26 @@ name: Release process
 
 on:  # yamllint disable-line rule:truthy
     pull_request:
-        branches: [master]
-        types: closed
+        branches: ['**']
 
 permissions:
     contents: read  # to fetch code (actions/checkout)
 
 jobs:
+    # Create new releases of linuxcnc-ethercat using a version of the Semantic Release
+    # method.  This draws release notes from properly-formatted commit messages.
+    release:
+        runs-on: ubuntu-latest # Not the same as above
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-go@v3
+              with:
+                  go-version: 1.19
+            - uses: go-semantic-release/action@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     # Build LinuxCNC-Ethercat debian package
     #
@@ -22,11 +35,14 @@ jobs:
             CHANGELOG_AUTHOR_NAME: "Scott Laird"
             CHANGELOG_AUTHOR_EMAIL: "scott@sigkill.org"
         runs-on: ubuntu-latest
+        needs:
+            - release
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Patch changelog (snapshot)
               id: bump_changelog
@@ -61,6 +77,7 @@ jobs:
 
     # This is mostly copied from LinuxCNC's ci.yml as well.
     build-debian-packges:
+        if: github.event.pull_request.merged == true
         runs-on: ubuntu-latest
         needs:
             - update-debian-changelog


### PR DESCRIPTION
What this is supposed to do: automatically cut releases based on the PR descriptions.

What I *want* to have happen is to have the semantic-release action cut new releases as directed by PR descriptions, and then once that happens to update the Debian changelog and build a full set of Debian packages.

The odds of this actually working in its current state is slim., and when it does the Debian release process will almost certainly break.  Unfortunately, I kind of need to *actually merge PRs* in order to test this, so I'll be doing a short sequence of minor changes.