### PR TITLE
initial per-device documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ debian/*.log
 debian/*.substvars
 debian/linuxcnc-ethercat/
 
+# Binaries
+scripts/devicetable/devicetable
+
 # emacs tmp files
 \#*\#
 .\#*

--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ and it intended to become the new default version LinuxCNC EtherCAT.
 Please bear with us while we do a bit of cleanup here, and then we'll
 start looking at adding additional maintainers and merging the backlog
 of drivers that has built up over the past few years.
+
+
+## Devices Supported
+
+See [the device documentation](documentation/DEVICES.md) for a partial
+list of Ethercat devices supported by this project.

--- a/documentation/DEVICES.md
+++ b/documentation/DEVICES.md
@@ -1,0 +1,52 @@
+# Devices Supported by LinuxCNC-Ethercat
+
+*This is a work in progress, listing all of the devices that LinuxCNC-Ethercat
+has code to support today.  Not all of these are well-tested.*
+
+Description | Name in Source Code | EtherCAT VID:PID | Device Type | Channels | Notes
+----------- | ------------------- | ---------------- | ----------- | -------: | ------
+[Beckhoff AX5101 Digital Compact Servo Drive, 1-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5101.html) | AX5101 | 0x00000002:0x13ed6012 | Servo Controller | 1 | 1.5A current limit
+[Beckhoff AX5103 Digital Compact Servo Drive, 1-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5103.html) | AX5103 | 0x00000002:0x13ef6012 | Servo Controller | 1 | 3A current limit
+[Beckhoff AX5106 Digital Compact Servo Drive, 1-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5106.html) | AX5106 | 0x00000002:0x13f26012 | Servo Controller | 1 | 6A current limit
+[Beckhoff AX5112 Digital Compact Servo Drive, 1-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5112.html) | AX5112 | 0x00000002:0x13f86012 | Servo Controller | 1 | 12A current limit
+[Beckhoff AX5118 Digital Compact Servo Drives, 1-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5118.html) | AX5118 | 0x00000002:0x13fe6012 | Servo Controller | 1 | 18A current limit
+[Beckhoff AX5203 Digial Compact Servo Drives, 2-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5203.html) | AX5203 | 0x00000002:0x14536012 | Servo Controller | 2 | 3A CURRENT LIMIT
+[Beckhoff AX5206 Digital Compact Servo Drive, 2-channel](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5206.html) | AX5206 | 0x00000002:0x14566012 | Servo Controller | 2 | 6A current limit
+[Beckhoff AX5805 TwinSAFE drive option card](https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5805.html) | AX5805 | 0x00000002:0x16AD6012 | Servo Accessory |  | 
+[Delta ASDA-A2-E](https://www.deltaww.com/en-us/products/Servo-Systems-AC-Servo-Motors-and-Drives/23) | DeASDA | 0x000001dd:0x10305070 | Servo Controller | 1 | Includes 2 digital inputs
+[Delta MS300 AC Motor Controller](https://www.deltaww.com/en-us/products/AC-Motor-Drives/3449) | DeMS300 | 0x000001dd:0x10400200 | AC Controller |  | 
+[Beckhoff EK1100 EtherCAT Coupler](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1100.html) | EK1100 | 0x00000002:0x044C2C52 | Coupler |  | Connects Beckhoff EL* modules to 100base-TX networks, and injects DC power into the EL bus.
+[Beckhoff EK1101 EtherCAT Coupler with ID switch](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1101.html) | EK1101 | 0x00000002:0x044D2C52 | Coupler |  | Connects Beckhoff EL* modules to 100base-TX networks, and injects DC power into the EL bus.
+[Beckhoff EK1101 EtherCAT extension](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1110.html) | EK1110 | 0x00000002:0x04562C52 | Coupler |  | Connects Beckhoff EL* modules to 100base-TX networks
+[Beckhoff EK1122 2-port EtherCAT junction](https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1122.html) | EK1122 | 0x00000002:0x04622C52 | Coupler |  | Adds 2 RJ45 Ethernet ports in-line, allowing star topologies.
+[Beckhoff EL1002 2-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1002 | 0x00000002:0x03EA3052 | Digital Input | 2 | 24 VDC, 3 ms input filter
+[Beckhoff EL1004 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1004 | 0x00000002:0x03EC3052 | Digital Input | 4 | 24 VDC, 3 ms input filter
+[Beckhoff EL1008 8-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1008 | 0x00000002:0x03F03052 | Digital Input | 8 | 24 VDC, 3 ms input filter
+[Beckhoff EL1012 2-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1012 | 0x00000002:0x03F43052 | Digital Input | 2 | 24 VDC, 10 µs input filter
+[Beckhoff EL1014 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1014 | 0x00000002:0x03F63052 | Digital Input | 4 | 24 VDC, 10 µs input filter
+[Beckhoff EL1018 8-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1018 | 0x00000002:0x03FA3052 | Digital Input | 8 | 24 VDC, 10 µs input filter
+[Beckhoff EL1024 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1024 | 0x00000002:0x04003052 | Digital Input | 4 | 24 VDC, for type 2 sensors
+[Beckhoff EL1034 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1034 | 0x00000002:0x040A3052 | Digital Input | 4 | 24 VDC, potential-free inputs
+[Beckhoff EL1084 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1084 | 0x00000002:0x043C3052 | Digital Input | 4 | 24 VDC, switching to negative potential, 3 ms
+[Beckhoff EL1088 8-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1088 | 0x00000002:0x04403052 | Digital Input | 8 | 24 VDC, switching to negative potential, 3 ms
+[Beckhoff EL1094 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1094 | 0x00000002:0x04463052 | Digital Input | 4 | 24 VDC, switching to negative potential, 10 µs
+[Beckhoff EL1098 8-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1098 | 0x00000002:0x044A3052 | Digital Input | 8 | 24 VDC, switching to negative potential, 10 µs
+[Beckhoff EL1104 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=) | EL1104 | 0x00000002:0x04503052 | Digital Input | 4 | 24 VDC with sensor supply, 3 ms
+[Beckhoff EL1114 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=) | EL1114 | 0x00000002:0x045A3052 | Digital Input | 4 | 24 VDC with sensor supply, 10 µs
+[Beckhoff EL1124 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1124 | 0x00000002:0x04643052 | Digital Input | 4 | 5 VDC
+[Beckhoff EL1134 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1134 | 0x00000002:0x046E3052 | Digital Input | 4 | 12 VDC
+[Beckhoff EL1144 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1144 | 0x00000002:0x04783052 | Digital Input | 4 | 48 VDC
+[Beckhoff EL1252 2-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1252 | 0x00000002:0x04E43052 | Digital Input | 2 | 24 VDC, with timestamp
+[Beckhoff EL1804 4-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1804 | 0x00000002:0x070C3052 | Digital Input | 4 | 24 VDC, high density, 3 ms
+[Beckhoff EL1808 8-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=) | EL1808 | 0x00000002:0x07103052 | Digital Input | 8 | 24 VDC, high density, 3 ms
+[Beckhoff EL1809 16-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=) | EL1809 | 0x00000002:0x07113052 | Digital Input | 16 | 24 VDC, high density, 3 ms
+[Beckhoff EL1819 16-port digital input](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=) | EL1819 | 0x00000002:0x071B3052 | Digital Input | 16 | 24 VDC, high density, 10 µs
+[Beckhoff EL1859 8-port 1-wire digital interface](https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=) | EL1859 | 0x00000002:0x07433052 | Digital Input | 8 | 24 VDC, 1-wire, 3 ms
+[Beckhoff EL1904 4-port digital input w/ TwinSAFE](https://www.beckhoff.com/en-us/products/automation/twinsafe/twinsafe-hardware/el1904.html) | EL1904 | 0x00000002:0x07703052 | Digital Input | 4 | 24 VDC, with TwinSAFE safety hardware
+[Beckhoff EL1918 8-port digital input w/ TwinSAFE Logic](https://www.beckhoff.com/en-us/products/automation/twinsafe/twinsafe-hardware/el1918.html) | EL1918_LOGIC | 0x00000002:0x077e3052 | Digital Input | 8 | 24 VDC, with TwinSAFE safety hardware and TwinSAFE logic
+[Modusoft 3lm2rm](https://www.modusoft.de/linux-cnc/) | Ph3LM2RM | 0x00000907:0x10000001 | Unknown |  | 
+[Stober POSIDRIVE MDS 5000 Servo Inverter](https://www.stoeber.de/en/solutions/inverter/) | StMDS5k | 0x000000b9:0x00001388 | Servo Controller |  | Discontinued, finding Ethercat parameter documentation is difficult.
+
+There are an additional 113 devices supported that do not have enough
+documentation to display here.  Please look at the `documentation/devices/` files
+and update them if you're able.

--- a/documentation/devices/AX5101.yml
+++ b/documentation/devices/AX5101.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5101
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13ed6012
+Description: Beckhoff AX5101 Digital Compact Servo Drive, 1-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5101.html
+DeviceType: Servo Controller
+Channels: 1
+Notes: 1.5A current limit

--- a/documentation/devices/AX5103.yml
+++ b/documentation/devices/AX5103.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5103
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13ef6012
+Description: Beckhoff AX5103 Digital Compact Servo Drive, 1-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5103.html
+DeviceType: Servo Controller
+Channels: 1
+Notes: 3A current limit

--- a/documentation/devices/AX5106.yml
+++ b/documentation/devices/AX5106.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5106
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13f26012
+Description: Beckhoff AX5106 Digital Compact Servo Drive, 1-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5106.html
+DeviceType: Servo Controller
+Channels: 1
+Notes: 6A current limit

--- a/documentation/devices/AX5112.yml
+++ b/documentation/devices/AX5112.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5112
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13f86012
+Description: Beckhoff AX5112 Digital Compact Servo Drive, 1-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5112.html
+DeviceType: Servo Controller
+Channels: 1
+Notes: 12A current limit

--- a/documentation/devices/AX5118.yml
+++ b/documentation/devices/AX5118.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5118
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13fe6012
+Description: Beckhoff AX5118 Digital Compact Servo Drives, 1-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5118.html
+DeviceType: Servo Controller
+Channels: 1
+Notes: 18A current limit

--- a/documentation/devices/AX5203.yml
+++ b/documentation/devices/AX5203.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5203
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x14536012
+Description: Beckhoff AX5203 Digial Compact Servo Drives, 2-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5203.html
+DeviceType: Servo Controller
+Channels: 2
+Notes: 3A CURRENT LIMIT

--- a/documentation/devices/AX5206.yml
+++ b/documentation/devices/AX5206.yml
@@ -1,0 +1,10 @@
+---
+Device: AX5206
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x14566012
+Description: Beckhoff AX5206 Digital Compact Servo Drive, 2-channel
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5206.html
+DeviceType: Servo Controller
+Channels: 2
+Notes: 6A current limit

--- a/documentation/devices/AX5805.yml
+++ b/documentation/devices/AX5805.yml
@@ -1,0 +1,8 @@
+---
+Device: AX5805
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x16AD6012
+Description: Beckhoff AX5805 TwinSAFE drive option card
+DocumentationURL: https://www.beckhoff.com/en-us/products/motion/servo-drives/ax5000-digital-compact-servo-drives/ax5805.html
+DeviceType: Servo Accessory

--- a/documentation/devices/DeASDA.yml
+++ b/documentation/devices/DeASDA.yml
@@ -1,0 +1,10 @@
+---
+Device: DeASDA
+VendorID: 0x000001dd
+VendorName: Delta Electronics
+PID: 0x10305070
+Description: Delta ASDA-A2-E
+DocumentationURL: https://www.deltaww.com/en-us/products/Servo-Systems-AC-Servo-Motors-and-Drives/23
+DeviceType: Servo Controller
+Channels: 1
+Notes: Includes 2 digital inputs

--- a/documentation/devices/DeMS300.yml
+++ b/documentation/devices/DeMS300.yml
@@ -1,0 +1,8 @@
+---
+Device: DeMS300
+VendorID: 0x000001dd
+VendorName: Delta Electronics
+PID: 0x10400200
+Description: Delta MS300 AC Motor Controller
+DocumentationURL: https://www.deltaww.com/en-us/products/AC-Motor-Drives/3449
+DeviceType: AC Controller

--- a/documentation/devices/EK1100.yml
+++ b/documentation/devices/EK1100.yml
@@ -1,0 +1,9 @@
+---
+Device: EK1100
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x044C2C52
+Description: Beckhoff EK1100 EtherCAT Coupler
+DocumentationURL: https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1100.html
+DeviceType: Coupler
+Notes: Connects Beckhoff EL* modules to 100base-TX networks, and injects DC power into the EL bus.

--- a/documentation/devices/EK1101.yml
+++ b/documentation/devices/EK1101.yml
@@ -1,0 +1,9 @@
+---
+Device: EK1101
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x044D2C52
+Description: Beckhoff EK1101 EtherCAT Coupler with ID switch
+DocumentationURL: https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1101.html
+DeviceType: Coupler
+Notes: Connects Beckhoff EL* modules to 100base-TX networks, and injects DC power into the EL bus.

--- a/documentation/devices/EK1110.yml
+++ b/documentation/devices/EK1110.yml
@@ -1,0 +1,9 @@
+---
+Device: EK1110
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04562C52
+Description: Beckhoff EK1101 EtherCAT extension
+DocumentationURL: https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1110.html
+DeviceType: Coupler
+Notes: Connects Beckhoff EL* modules to 100base-TX networks

--- a/documentation/devices/EK1122.yml
+++ b/documentation/devices/EK1122.yml
@@ -1,0 +1,9 @@
+---
+Device: EK1122
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04622C52
+Description: Beckhoff EK1122 2-port EtherCAT junction
+DocumentationURL: https://www.beckhoff.com/en-us/products/i-o/ethercat-terminals/ek1xxx-bk1xx0-ethercat-coupler/ek1122.html
+DeviceType: Coupler
+Notes: Adds 2 RJ45 Ethernet ports in-line, allowing star topologies.

--- a/documentation/devices/EL1002.yml
+++ b/documentation/devices/EL1002.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1002
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03EA3052
+Description: Beckhoff EL1002 2-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 2
+Notes: 24 VDC, 3 ms input filter

--- a/documentation/devices/EL1004.yml
+++ b/documentation/devices/EL1004.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1004
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03EC3052
+Description: Beckhoff EL1004 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, 3 ms input filter

--- a/documentation/devices/EL1008.yml
+++ b/documentation/devices/EL1008.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1008
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03F03052
+Description: Beckhoff EL1008 8-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, 3 ms input filter

--- a/documentation/devices/EL1012.yml
+++ b/documentation/devices/EL1012.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1012
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03F43052
+Description: Beckhoff EL1012 2-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 2
+Notes: 24 VDC, 10 µs input filter

--- a/documentation/devices/EL1014.yml
+++ b/documentation/devices/EL1014.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1014
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03F63052
+Description: Beckhoff EL1014 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, 10 µs input filter

--- a/documentation/devices/EL1018.yml
+++ b/documentation/devices/EL1018.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1018
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03FA3052
+Description: Beckhoff EL1018 8-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, 10 µs input filter

--- a/documentation/devices/EL1024.yml
+++ b/documentation/devices/EL1024.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1024
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04003052
+Description: Beckhoff EL1024 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, for type 2 sensors

--- a/documentation/devices/EL1034.yml
+++ b/documentation/devices/EL1034.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1034
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x040A3052
+Description: Beckhoff EL1034 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, potential-free inputs

--- a/documentation/devices/EL1084.yml
+++ b/documentation/devices/EL1084.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1084
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x043C3052
+Description: Beckhoff EL1084 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, switching to negative potential, 3 ms

--- a/documentation/devices/EL1088.yml
+++ b/documentation/devices/EL1088.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1088
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04403052
+Description: Beckhoff EL1088 8-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, switching to negative potential, 3 ms

--- a/documentation/devices/EL1094.yml
+++ b/documentation/devices/EL1094.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1094
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04463052
+Description: Beckhoff EL1094 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, switching to negative potential, 10 µs

--- a/documentation/devices/EL1098.yml
+++ b/documentation/devices/EL1098.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1098
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x044A3052
+Description: Beckhoff EL1098 8-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, switching to negative potential, 10 µs

--- a/documentation/devices/EL1104.yml
+++ b/documentation/devices/EL1104.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1104
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04503052
+Description: Beckhoff EL1104 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC with sensor supply, 3 ms

--- a/documentation/devices/EL1114.yml
+++ b/documentation/devices/EL1114.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1114
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x045A3052
+Description: Beckhoff EL1114 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC with sensor supply, 10 µs

--- a/documentation/devices/EL1124.yml
+++ b/documentation/devices/EL1124.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1124
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04643052
+Description: Beckhoff EL1124 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 5 VDC

--- a/documentation/devices/EL1134.yml
+++ b/documentation/devices/EL1134.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1134
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x046E3052
+Description: Beckhoff EL1134 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 12 VDC

--- a/documentation/devices/EL1144.yml
+++ b/documentation/devices/EL1144.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1144
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04783052
+Description: Beckhoff EL1144 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 48 VDC

--- a/documentation/devices/EL1252.yml
+++ b/documentation/devices/EL1252.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1252
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x04E43052
+Description: Beckhoff EL1252 2-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 2
+Notes: 24 VDC, with timestamp

--- a/documentation/devices/EL1804.yml
+++ b/documentation/devices/EL1804.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1804
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x070C3052
+Description: Beckhoff EL1804 4-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, high density, 3 ms

--- a/documentation/devices/EL1808.yml
+++ b/documentation/devices/EL1808.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1808
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07103052
+Description: Beckhoff EL1808 8-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623205643.html&id=
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, high density, 3 ms

--- a/documentation/devices/EL1809.yml
+++ b/documentation/devices/EL1809.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1809
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07113052
+Description: Beckhoff EL1809 16-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=
+DeviceType: Digital Input
+Channels: 16
+Notes: 24 VDC, high density, 3 ms

--- a/documentation/devices/EL1819.yml
+++ b/documentation/devices/EL1819.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1819
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x071B3052
+Description: Beckhoff EL1819 16-port digital input
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=
+DeviceType: Digital Input
+Channels: 16
+Notes: 24 VDC, high density, 10 µs

--- a/documentation/devices/EL1859.yml
+++ b/documentation/devices/EL1859.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1859
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07433052
+Description: Beckhoff EL1859 8-port 1-wire digital interface
+DocumentationURL: https://infosys.beckhoff.com/english.php?content=../content/1033/el10xx_el11xx/1623216395.html&id=
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, 1-wire, 3 ms

--- a/documentation/devices/EL1904.yml
+++ b/documentation/devices/EL1904.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1904
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07703052
+Description: Beckhoff EL1904 4-port digital input w/ TwinSAFE
+DocumentationURL: https://www.beckhoff.com/en-us/products/automation/twinsafe/twinsafe-hardware/el1904.html
+DeviceType: Digital Input
+Channels: 4
+Notes: 24 VDC, with TwinSAFE safety hardware

--- a/documentation/devices/EL1918_LOGIC.yml
+++ b/documentation/devices/EL1918_LOGIC.yml
@@ -1,0 +1,10 @@
+---
+Device: EL1918_LOGIC
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x077e3052
+Description: Beckhoff EL1918 8-port digital input w/ TwinSAFE Logic
+DocumentationURL: https://www.beckhoff.com/en-us/products/automation/twinsafe/twinsafe-hardware/el1918.html
+DeviceType: Digital Input
+Channels: 8
+Notes: 24 VDC, with TwinSAFE safety hardware and TwinSAFE logic

--- a/documentation/devices/EL2002.yml
+++ b/documentation/devices/EL2002.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2002
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07D23052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2004.yml
+++ b/documentation/devices/EL2004.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2004
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07D43052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2008.yml
+++ b/documentation/devices/EL2008.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2008
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07D83052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2022.yml
+++ b/documentation/devices/EL2022.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2022
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07E63052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2024.yml
+++ b/documentation/devices/EL2024.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2024
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07E83052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2032.yml
+++ b/documentation/devices/EL2032.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2032
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07F03052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2034.yml
+++ b/documentation/devices/EL2034.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2034
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07F23052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2042.yml
+++ b/documentation/devices/EL2042.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2042
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07FA3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2084.yml
+++ b/documentation/devices/EL2084.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2084
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x08243052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2088.yml
+++ b/documentation/devices/EL2088.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2088
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x08283052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2124.yml
+++ b/documentation/devices/EL2124.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2124
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x084C3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2202.yml
+++ b/documentation/devices/EL2202.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2202
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x089A3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2521.yml
+++ b/documentation/devices/EL2521.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2521
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x09d93052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2612.yml
+++ b/documentation/devices/EL2612.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2612
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0A343052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2622.yml
+++ b/documentation/devices/EL2622.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2622
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0A3E3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2634.yml
+++ b/documentation/devices/EL2634.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2634
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0A4A3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2652.yml
+++ b/documentation/devices/EL2652.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2652
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0A5C3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2798.yml
+++ b/documentation/devices/EL2798.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2798
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0AEE3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2808.yml
+++ b/documentation/devices/EL2808.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2808
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0AF83052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2809.yml
+++ b/documentation/devices/EL2809.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2809
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0AF93052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL2904.yml
+++ b/documentation/devices/EL2904.yml
@@ -1,0 +1,8 @@
+---
+Device: EL2904
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0B583052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3004.yml
+++ b/documentation/devices/EL3004.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3004
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0bbc3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3044.yml
+++ b/documentation/devices/EL3044.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3044
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0be43052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3054.yml
+++ b/documentation/devices/EL3054.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3054
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0bee3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3064.yml
+++ b/documentation/devices/EL3064.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3064
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0bf83052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3102.yml
+++ b/documentation/devices/EL3102.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3102
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C1E3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3112.yml
+++ b/documentation/devices/EL3112.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3112
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C283052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3122.yml
+++ b/documentation/devices/EL3122.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3122
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C323052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3142.yml
+++ b/documentation/devices/EL3142.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3142
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C463052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3152.yml
+++ b/documentation/devices/EL3152.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3152
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C503052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3162.yml
+++ b/documentation/devices/EL3162.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3162
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C5A3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3164.yml
+++ b/documentation/devices/EL3164.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3164
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0C5C3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3202.yml
+++ b/documentation/devices/EL3202.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3202
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0c823052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3255.yml
+++ b/documentation/devices/EL3255.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3255
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0CB73052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL3403.yml
+++ b/documentation/devices/EL3403.yml
@@ -1,0 +1,8 @@
+---
+Device: EL3403
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0d4b3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4001.yml
+++ b/documentation/devices/EL4001.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4001
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fa13052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4002.yml
+++ b/documentation/devices/EL4002.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4002
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fa23052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4008.yml
+++ b/documentation/devices/EL4008.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4008
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fa83052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4011.yml
+++ b/documentation/devices/EL4011.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4011
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fab3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4012.yml
+++ b/documentation/devices/EL4012.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4012
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fac3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4018.yml
+++ b/documentation/devices/EL4018.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4018
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fb23052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4021.yml
+++ b/documentation/devices/EL4021.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4021
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fb53052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4022.yml
+++ b/documentation/devices/EL4022.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4022
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fb63052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4028.yml
+++ b/documentation/devices/EL4028.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4028
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fbc3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4031.yml
+++ b/documentation/devices/EL4031.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4031
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fbf3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4032.yml
+++ b/documentation/devices/EL4032.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4032
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fc03052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4038.yml
+++ b/documentation/devices/EL4038.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4038
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0fc63052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4102.yml
+++ b/documentation/devices/EL4102.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4102
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x10063052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4104.yml
+++ b/documentation/devices/EL4104.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4104
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x10083052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4112.yml
+++ b/documentation/devices/EL4112.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4112
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x10103052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4122.yml
+++ b/documentation/devices/EL4122.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4122
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x101A3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4132.yml
+++ b/documentation/devices/EL4132.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4132
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x10243052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL4134.yml
+++ b/documentation/devices/EL4134.yml
@@ -1,0 +1,8 @@
+---
+Device: EL4134
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x10263052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL5002.yml
+++ b/documentation/devices/EL5002.yml
@@ -1,0 +1,8 @@
+---
+Device: EL5002
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x138a3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL5032.yml
+++ b/documentation/devices/EL5032.yml
@@ -1,0 +1,8 @@
+---
+Device: EL5032
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13a83052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL5101.yml
+++ b/documentation/devices/EL5101.yml
@@ -1,0 +1,8 @@
+---
+Device: EL5101
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x13ed3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL5151.yml
+++ b/documentation/devices/EL5151.yml
@@ -1,0 +1,8 @@
+---
+Device: EL5151
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x141f3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL5152.yml
+++ b/documentation/devices/EL5152.yml
@@ -1,0 +1,8 @@
+---
+Device: EL5152
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x14203052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL6090.yml
+++ b/documentation/devices/EL6090.yml
@@ -1,0 +1,8 @@
+---
+Device: EL6090
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x17ca3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL6900.yml
+++ b/documentation/devices/EL6900.yml
@@ -1,0 +1,8 @@
+---
+Device: EL6900
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1AF43052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7031.yml
+++ b/documentation/devices/EL7031.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7031
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1B773052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7041.yml
+++ b/documentation/devices/EL7041.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7041
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1B813052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7041_1000.yml
+++ b/documentation/devices/EL7041_1000.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7041_1000
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1B813052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7201_9014.yml
+++ b/documentation/devices/EL7201_9014.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7201_9014
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1C213052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7211.yml
+++ b/documentation/devices/EL7211.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7211
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1C2B3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7221.yml
+++ b/documentation/devices/EL7221.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7221
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1C353052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7342.yml
+++ b/documentation/devices/EL7342.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7342
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1cae3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL7411.yml
+++ b/documentation/devices/EL7411.yml
@@ -1,0 +1,8 @@
+---
+Device: EL7411
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1CF33052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL9505.yml
+++ b/documentation/devices/EL9505.yml
@@ -1,0 +1,8 @@
+---
+Device: EL9505
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x25213052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL9508.yml
+++ b/documentation/devices/EL9508.yml
@@ -1,0 +1,8 @@
+---
+Device: EL9508
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x25243052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL9510.yml
+++ b/documentation/devices/EL9510.yml
@@ -1,0 +1,8 @@
+---
+Device: EL9510
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x25263052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL9512.yml
+++ b/documentation/devices/EL9512.yml
@@ -1,0 +1,8 @@
+---
+Device: EL9512
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x25283052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL9515.yml
+++ b/documentation/devices/EL9515.yml
@@ -1,0 +1,8 @@
+---
+Device: EL9515
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x252b3052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EL9576.yml
+++ b/documentation/devices/EL9576.yml
@@ -1,0 +1,8 @@
+---
+Device: EL9576
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x25683052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EM3701.yml
+++ b/documentation/devices/EM3701.yml
@@ -1,0 +1,8 @@
+---
+Device: EM3701
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0e753452
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EM3702.yml
+++ b/documentation/devices/EM3702.yml
@@ -1,0 +1,8 @@
+---
+Device: EM3702
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0e763452
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EM3712.yml
+++ b/documentation/devices/EM3712.yml
@@ -1,0 +1,8 @@
+---
+Device: EM3712
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0e803452
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EM7004.yml
+++ b/documentation/devices/EM7004.yml
@@ -1,0 +1,8 @@
+---
+Device: EM7004
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1B5C3452
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP1008.yml
+++ b/documentation/devices/EP1008.yml
@@ -1,0 +1,8 @@
+---
+Device: EP1008
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03f04052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP1018.yml
+++ b/documentation/devices/EP1018.yml
@@ -1,0 +1,8 @@
+---
+Device: EP1018
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x03fa4052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2008.yml
+++ b/documentation/devices/EP2008.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2008
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07D84052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2028.yml
+++ b/documentation/devices/EP2028.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2028
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x07EC4052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2308.yml
+++ b/documentation/devices/EP2308.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2308
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x09044052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2316.yml
+++ b/documentation/devices/EP2316.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2316
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x090C4052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2318.yml
+++ b/documentation/devices/EP2318.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2318
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x090E4052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2328.yml
+++ b/documentation/devices/EP2328.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2328
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x09184052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2338.yml
+++ b/documentation/devices/EP2338.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2338
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x09224052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2349.yml
+++ b/documentation/devices/EP2349.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2349
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x092d4052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP2809.yml
+++ b/documentation/devices/EP2809.yml
@@ -1,0 +1,8 @@
+---
+Device: EP2809
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x0AF94052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/EP7041.yml
+++ b/documentation/devices/EP7041.yml
@@ -1,0 +1,8 @@
+---
+Device: EP7041
+VendorID: 0x00000002
+VendorName: Beckhoff
+PID: 0x1B813052
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN01H.yml
+++ b/documentation/devices/OmrG5_KN01H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN01H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000005
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN01L.yml
+++ b/documentation/devices/OmrG5_KN01L.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN01L
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000002
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN02H.yml
+++ b/documentation/devices/OmrG5_KN02H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN02H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000006
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN02L.yml
+++ b/documentation/devices/OmrG5_KN02L.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN02L
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000003
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN04H.yml
+++ b/documentation/devices/OmrG5_KN04H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN04H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000007
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN04L.yml
+++ b/documentation/devices/OmrG5_KN04L.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN04L
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000004
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN06F.yml
+++ b/documentation/devices/OmrG5_KN06F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN06F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000000B
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN08H.yml
+++ b/documentation/devices/OmrG5_KN08H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN08H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000008
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN10F.yml
+++ b/documentation/devices/OmrG5_KN10F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN10F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000000C
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN10H.yml
+++ b/documentation/devices/OmrG5_KN10H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN10H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000009
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN150F.yml
+++ b/documentation/devices/OmrG5_KN150F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN150F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000005F
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN150H.yml
+++ b/documentation/devices/OmrG5_KN150H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN150H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000005A
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN15F.yml
+++ b/documentation/devices/OmrG5_KN15F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN15F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000000D
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN15H.yml
+++ b/documentation/devices/OmrG5_KN15H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN15H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000000A
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN20F.yml
+++ b/documentation/devices/OmrG5_KN20F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN20F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000005B
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN20H.yml
+++ b/documentation/devices/OmrG5_KN20H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN20H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000056
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN30F.yml
+++ b/documentation/devices/OmrG5_KN30F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN30F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000005C
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN30H.yml
+++ b/documentation/devices/OmrG5_KN30H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN30H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000057
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN50F.yml
+++ b/documentation/devices/OmrG5_KN50F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN50F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000005D
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN50H.yml
+++ b/documentation/devices/OmrG5_KN50H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN50H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000058
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN75F.yml
+++ b/documentation/devices/OmrG5_KN75F.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN75F
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x0000005E
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KN75H.yml
+++ b/documentation/devices/OmrG5_KN75H.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KN75H
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000059
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/OmrG5_KNA5L.yml
+++ b/documentation/devices/OmrG5_KNA5L.yml
@@ -1,0 +1,8 @@
+---
+Device: OmrG5_KNA5L
+VendorID: 0x00000083
+VendorName: TODO
+PID: 0x00000001
+Description: TODO
+DocumentationURL: TODO
+DeviceType: TODO

--- a/documentation/devices/Ph3LM2RM.yml
+++ b/documentation/devices/Ph3LM2RM.yml
@@ -1,0 +1,8 @@
+---
+Device: Ph3LM2RM
+VendorID: 0x00000907
+VendorName: Modusoft
+PID: 0x10000001
+Description: Modusoft 3lm2rm
+DocumentationURL: https://www.modusoft.de/linux-cnc/
+DeviceType: Unknown

--- a/documentation/devices/StMDS5k.yml
+++ b/documentation/devices/StMDS5k.yml
@@ -1,0 +1,9 @@
+---
+Device: StMDS5k
+VendorID: 0x000000b9
+VendorName: STÖBER ANTRIEBSTECHNIK GmbH & Co. KG
+PID: 0x00001388
+Description: Stober POSIDRIVE MDS 5000 Servo Inverter
+DocumentationURL: https://www.stoeber.de/en/solutions/inverter/
+DeviceType: Servo Controller
+Notes: Discontinued, finding Ethercat parameter documentation is difficult.

--- a/scripts/devicelist.sh
+++ b/scripts/devicelist.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Create list of supported devices by decoding the `types` list in lcec_main.c
+#
+# This returns a CSV of (name, VID, PID).
+#
+# VID should match https://www.ethercat.org/en/vendor_id_list.html
+#
+# Not sure where to find a list of PID values yet.
+
+CFLAGS="$(grep EXTRA_CFLAGS config.mk | cut -d= -f2-)"
+
+gcc -E  $CFLAGS src/lcec_main.c \
+    | sed -ne '/static const lcec_typelist_t types/,$ p' \
+    | sed '/};/q' \
+    | egrep -v '^#' \
+    | grep '  {' \
+    | cut -d'{' -f2 \
+    | cut -d, -f1-3 \
+    | grep -v 'lcecSlaveTypeInvalid' \
+    | cut -c2- \
+    | sed 's/lcecSlaveType//' \
+    | tr -d ' ' \
+    | while read line; do 
+
+    DEVICE=$(echo $line | cut -d, -f1)
+    VID=$(echo $line | cut -d, -f2)
+    PID=$(echo $line | cut -d, -f3)
+
+    file=documentation/devices/$DEVICE.yml
+
+    if [ ! -f $file ]; then
+	(
+	    echo "---"
+	    echo "Device: $DEVICE"
+	    echo "VendorID: $VID"
+	    echo "VendorName: TODO"
+	    echo "PID: $PID"
+	    echo "Description: TODO"
+	    echo "DocumentationURL: TODO"
+	    echo "DeviceType: TODO"
+	) > $file
+    fi
+																	      
+done
+

--- a/scripts/devicetable/devicetable.go
+++ b/scripts/devicetable/devicetable.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type DeviceDefinition struct {
+	Device           string `yaml:"Device"`
+	VendorID         string `yaml:"VendorID"`
+	VendorName       string `yaml:"VendorName"`
+	PID              string `yaml:"PID"`
+	Description      string `yaml:"Description"`
+	DocumentationURL string `yaml:"DocumentationURL"`
+	DeviceType       string `yaml:"DeviceType"`
+	Channels         int    `yaml:"Channels"`
+	Notes            string `yaml:"Notes"`
+}
+
+var pathFlag = flag.String("path", "../../documentation/devices/", "Path to *.yml files for device documentation")
+
+func parsefile(filename string) (*DeviceDefinition, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file: %v")
+	}
+
+	entry := &DeviceDefinition{}
+
+	err = yaml.Unmarshal(data, entry)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode yaml: %v", err)
+	}
+
+	return entry, nil
+}
+
+func main() {
+	entries := []*DeviceDefinition{}
+	otherfiles := 0
+
+	files, err := os.ReadDir(*pathFlag)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, file := range files {
+		entry, err := parsefile(filepath.Join(*pathFlag, file.Name()))
+		if err != nil {
+			panic(err)
+		}
+
+		// The `devicelist.sh` script autogenerates entries
+		// with `Device: TODO`.  For now, let's filter them
+		// out.
+		//
+		// Longer-term, we may wish to gripe when we find
+		// them, or replace `TODO` with `???` or similar.
+		if strings.TrimSpace(entry.Description) != "TODO" {
+			entries = append(entries, entry)
+		} else {
+			otherfiles++
+		}
+	}
+
+	fmt.Printf("# Devices Supported by LinuxCNC-Ethercat\n")
+	fmt.Printf("\n")
+	fmt.Printf("*This is a work in progress, listing all of the devices that LinuxCNC-Ethercat\n")
+	fmt.Printf("has code to support today.  Not all of these are well-tested.*\n")
+	fmt.Printf("\n")
+
+	fmt.Printf("Description | Name in Source Code | EtherCAT VID:PID | Device Type | Channels | Notes\n")
+	fmt.Printf("----------- | ------------------- | ---------------- | ----------- | -------: | ------\n")
+	for _, e := range entries {
+		name := e.Description
+		if e.DocumentationURL[0:4] == "http" {
+			name = fmt.Sprintf("[%s](%s)", e.Description, e.DocumentationURL)
+		}
+		channels := fmt.Sprintf("%d", e.Channels)
+		if e.Channels == 0 {
+			channels = ""
+		}
+		fmt.Printf("%s | %s | %s:%s | %s | %s | %s\n", name, e.Device, e.VendorID, e.PID, e.DeviceType, channels, e.Notes)
+	}
+
+	fmt.Printf("\n")
+	if otherfiles > 0 {
+		fmt.Printf("There are an additional %d devices supported that do not have enough\n", otherfiles)
+		fmt.Printf("documentation to display here.  Please look at the `documentation/devices/` files\n")
+		fmt.Printf("and update them if you're able.\n")
+	}
+}

--- a/scripts/devicetable/go.mod
+++ b/scripts/devicetable/go.mod
@@ -1,0 +1,5 @@
+module github.com/linuxcnc-ethercat/linuxcnc-ethercat/scripts/devicetable
+
+go 1.18
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/scripts/devicetable/go.sum
+++ b/scripts/devicetable/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/update-devicetable.sh
+++ b/scripts/update-devicetable.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+cd devicetable/
+
+DEVICEDIR=../../documentation/devices
+DEVICESMD=../../documentation/DEVICES.md
+DEVICESNEW=$DEVICESMD-new
+
+go build devicetable.go
+if ./devicetable --path=$DEVICEDIR > $DEVICESNEW; then
+    mv $DEVICESNEW $DEVICESMD
+else
+    rm $DEVICESNEW
+fi
+


### PR DESCRIPTION
First pass at auto-generating per-device documentation, as per issue #8.

I'm concentrating on getting basic details in now, once that's done I'll add a place for notes about who implemented what and testing status.

The basic structure is autogenerated from `src/lcec_main.c` via the terrible shell script in `scripts/devicelist.sh`.  That writes boilerplate files into `documentation/devices/*.yml`, which is then turned into `documentation/DEVICES.md` via `scripts/update-devicetable.sh` and a bit of Go code in `scripts/devicetable/devicetable.go`.

Ideally, we'd embed at least some of this info into the source files themselves, but that's more work than I want to bite off this week.

This PR includes some of the non-Beckhoff devices, as well as all of the Beckhoff devices through `EL1999` in alphabetical order.