### PR TITLE
Switch yamllint to relaxed mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       rev: v1.21.0 # or higher tag
       hooks:
           - id: yamllint
-            args: [--format, parsable, -d, '{extends: default, rules: {line-length: {max: 200}}}']
+            args: [--format, parsable, -d, '{extends: relaxed, rules: {line-length: {max: 200}}}']
             exclude: scripts/esi.yml
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt


### PR DESCRIPTION
Since we're using yamlfmt after running yamllint, there's no real reason for it to be hyper-strict.  It's currently rejecting files due to blank lines, etc, which yamlfmt will fix anyway.