### PR TITLE
Add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
         runs-on: ubuntu-latest
         needs:
             - release
+        permissions:
+            contents: write
         steps:
             - name: Checkout code
               uses: actions/checkout@v4


### PR DESCRIPTION
Allow the job that updates debian/changelog to write back to Git.
