### PR TITLE
release: disable sid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
                     - "debian:buster"
                     #- "debian:bullseye"
                     #- "debian:bookworm"
-                    - "debian:sid"
+                    #- "debian:sid"
                 #arch:
                 #  - amd64
         env:


### PR DESCRIPTION
Remove Debian Unstable from the list of images that we build for.  It's *also* failing randomly.  Concentrate on buster for now.

Gbp-Dch: ignore
Issue: #36