### PR TITLE
build: add conventional-commit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,10 @@ repos:
           - id: yamlfmt
             args: [--preserve-quotes]
             exclude: scripts/esi.yml
+
+    - repo: https://github.com/compilerla/conventional-pre-commit
+      rev: v3.0.0
+      hooks:
+          - id: conventional-pre-commit
+            stages: [commit-msg]
+            args: [build, ci, docs, feat, fix, perf, revert, style, test]


### PR DESCRIPTION
This verifies that commit messages are in the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format, which should give some structure to changelogs and release notes.

Each commit message should start with a type (see below), an optional scope in parenthesis, a colon, and then a short description of the change.

Examples:
- build: add conventional-commit pre-commit hook
- ci: fix broken workflow
- fix(el_1xxx): add support for EL1111

Types currently supported:

- build
- ci
- docs
- feat
- fix
- perf
- revert
- style
- test

The `feat` and `fix` types are special; a commit with `fix` will trigger a new version release (so we'll go from v1.0.0 to v1.0.1, etc).  Commits with `feat` will trigger a new minor release (v1.0.0 to v1.1.0, etc).  In general, any change to `.c` or `.h` files that adds user-visible functionality should have `fix`, and substantial changes should get `feat`.  Since this isn't a library, we can play with the rules a bit.

There's also a way to trigger major version updates (v1.0.0 -> v2.0.0), but that should be uncommit.  If we make changes that require changes to LinuxCNC configs, then we should probably bump the major version, but we'll jump off that bridge when we get there.

Issues: #36