### PR TITLE
fix(test): Remove TODO file

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,0 @@
-- (Re-)testing/Documentation of all devices
-- option --enable-ethercat for configure script
-- DOC: don't use EL9010
-- Debug EL5151/EL5152/EL2521 Subindex does not exist
-- DOC: Parameter A60/A61 Stoeber


### PR DESCRIPTION
This is a more-or-less bogus change, removing an 8 year old TODO file.  It's marked as 'fix' so that it triggers the release workflow, so I can verify that the deb release process works.

Issue: #36