### PR TITLE
fix(test): Only run the release process on the pull_request, not on the push.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@
 name: Release process
 
 on:  # yamllint disable-line rule:truthy
-    pull_request:
-        branches: ['**']
-        types: [closed]
     push:
         branches: [master]
 


### PR DESCRIPTION
Trigger another semi-bogus release.  This changes the release workflow to only run on the branch, not on the push request. 
