### PR TITLE
build: Move types[] from lcec_main into individual drivers

### DIFF
--- a/examples/testbench/ethercat.xml
+++ b/examples/testbench/ethercat.xml
@@ -1,0 +1,22 @@
+<masters>
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
+    <slave idx="0" type="EK1100" name="D0"/>
+    <slave idx="1" type="EL1018" name="D1"/>
+    <slave idx="2" type="EL1018" name="D2"/>
+    <slave idx="3" type="EL2008" name="D3"/>
+    <slave idx="4" type="EL2008" name="D4"/>
+    <slave idx="5" type="EL2084" name="D5"/>
+    <slave idx="6" type="EL2022" name="D6"/>
+    <slave idx="7" type="EL2022" name="D7"/>
+    <slave idx="8" type="EL2034" name="D8"/>
+    <slave idx="9" type="EL2798" name="D9"/>
+<!--    <slave idx="10" type="EL3068" name="D10"/> -->
+<!--    <slave idx="11" type="EL6001" name="D11"/> -->
+    <slave idx="12" type="EL6900" name="D12"/>
+    <slave idx="13" type="EL1904" name="D13"/>
+    <slave idx="14" type="EL2904" name="D14"/>
+    <slave idx="15" type="EL3403" name="D15"/>
+    <slave idx="16" type="EK1110" name="D16"/>
+  </master>
+</masters>
+    

--- a/src/Kbuild
+++ b/src/Kbuild
@@ -46,7 +46,7 @@ lcec-objs := \
     lcec_ep2316.o \
     lcec_stmds5k.o \
     lcec_deasda.o \
-	lcec_dems300.o \
+    lcec_dems300.o \
     lcec_omrg5.o \
     lcec_ph3lm2rm.o
 

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -56,6 +56,11 @@ do {                        \
 
 #define LCEC_MSG_PFX "LCEC: "
 
+// init macro
+#define ADD_TYPES(types) \
+static void AddTypes(void) __attribute__((constructor)); \
+static void AddTypes(void) { lcec_addtypes(types); }
+
 // vendor ids
 #define LCEC_BECKHOFF_VID 0x00000002
 #define LCEC_STOEBER_VID  0x000000b9
@@ -89,6 +94,17 @@ typedef int (*lcec_slave_preinit_t) (struct lcec_slave *slave);
 typedef int (*lcec_slave_init_t) (int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs);
 typedef void (*lcec_slave_cleanup_t) (struct lcec_slave *slave);
 typedef void (*lcec_slave_rw_t) (struct lcec_slave *slave, long period);
+
+typedef struct lcec_typelist {
+  char *name;
+  LCEC_SLAVE_TYPE_T type;
+  uint32_t vid;
+  uint32_t pid;
+  int pdo_entry_count;
+  int is_fsoe_logic;
+  lcec_slave_preinit_t proc_preinit;
+  lcec_slave_init_t proc_init;
+} lcec_typelist_t;
 
 typedef struct {
   int slave_data_len;
@@ -257,6 +273,8 @@ void lcec_syncs_init(lcec_syncs_t *syncs);
 void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode);
 void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
 void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);
+void lcec_addtype(lcec_typelist_t *type);
+void lcec_addtypes(lcec_typelist_t types[]);
 
 #endif
 

--- a/src/lcec_el1xxx.c
+++ b/src/lcec_el1xxx.c
@@ -26,6 +26,35 @@ typedef struct {
   unsigned int pdo_bp;
 } lcec_el1xxx_pin_t;
 
+static lcec_typelist_t types[]={
+  { "EL1002", lcecSlaveTypeEL1002, LCEC_EL1xxx_VID, LCEC_EL1002_PID, LCEC_EL1002_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1004", lcecSlaveTypeEL1004, LCEC_EL1xxx_VID, LCEC_EL1004_PID, LCEC_EL1004_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1008", lcecSlaveTypeEL1008, LCEC_EL1xxx_VID, LCEC_EL1008_PID, LCEC_EL1008_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1012", lcecSlaveTypeEL1012, LCEC_EL1xxx_VID, LCEC_EL1012_PID, LCEC_EL1012_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1014", lcecSlaveTypeEL1014, LCEC_EL1xxx_VID, LCEC_EL1014_PID, LCEC_EL1014_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1018", lcecSlaveTypeEL1018, LCEC_EL1xxx_VID, LCEC_EL1018_PID, LCEC_EL1018_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1024", lcecSlaveTypeEL1024, LCEC_EL1xxx_VID, LCEC_EL1024_PID, LCEC_EL1024_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1034", lcecSlaveTypeEL1034, LCEC_EL1xxx_VID, LCEC_EL1034_PID, LCEC_EL1034_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1084", lcecSlaveTypeEL1084, LCEC_EL1xxx_VID, LCEC_EL1084_PID, LCEC_EL1084_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1088", lcecSlaveTypeEL1088, LCEC_EL1xxx_VID, LCEC_EL1088_PID, LCEC_EL1088_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1094", lcecSlaveTypeEL1094, LCEC_EL1xxx_VID, LCEC_EL1094_PID, LCEC_EL1094_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1098", lcecSlaveTypeEL1098, LCEC_EL1xxx_VID, LCEC_EL1098_PID, LCEC_EL1098_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1104", lcecSlaveTypeEL1104, LCEC_EL1xxx_VID, LCEC_EL1104_PID, LCEC_EL1104_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1114", lcecSlaveTypeEL1114, LCEC_EL1xxx_VID, LCEC_EL1114_PID, LCEC_EL1114_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1124", lcecSlaveTypeEL1124, LCEC_EL1xxx_VID, LCEC_EL1124_PID, LCEC_EL1124_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1134", lcecSlaveTypeEL1134, LCEC_EL1xxx_VID, LCEC_EL1134_PID, LCEC_EL1134_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1144", lcecSlaveTypeEL1144, LCEC_EL1xxx_VID, LCEC_EL1144_PID, LCEC_EL1144_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1804", lcecSlaveTypeEL1804, LCEC_EL1xxx_VID, LCEC_EL1804_PID, LCEC_EL1804_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1808", lcecSlaveTypeEL1808, LCEC_EL1xxx_VID, LCEC_EL1808_PID, LCEC_EL1808_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EL1809", lcecSlaveTypeEL1809, LCEC_EL1xxx_VID, LCEC_EL1809_PID, LCEC_EL1809_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EP1008", lcecSlaveTypeEP1008, LCEC_EL1xxx_VID, LCEC_EP1008_PID, LCEC_EP1008_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EP1018", lcecSlaveTypeEP1018, LCEC_EL1xxx_VID, LCEC_EP1018_PID, LCEC_EL1018_PDOS, 0, NULL, lcec_el1xxx_init},
+  { "EP1819", lcecSlaveTypeEL1819, LCEC_EL1xxx_VID, LCEC_EL1819_PID, LCEC_EL1819_PDOS, 0, NULL, lcec_el1xxx_init},
+  { NULL },
+};
+
+ADD_TYPES(types);
+     
 static const lcec_pindesc_t slave_pins[] = {
   { HAL_BIT, HAL_OUT, offsetof(lcec_el1xxx_pin_t, in), "%s.%s.%s.din-%d" },
   { HAL_BIT, HAL_OUT, offsetof(lcec_el1xxx_pin_t, in_not), "%s.%s.%s.din-%d-not" },


### PR DESCRIPTION
Beginning of removing the global types[] list in `lcec_main.c` and
moving the code into individual drivers.  This will make patching less
complicated as it'll be one fewer file to edit when adding new drivers.

The goal is to be able to simply drop a pair of `lcec_FOO.[ch]` files
into `src/` and have them compile and work.  We're not there quite yet.

Current status:
- added code for defining types in `lcec_main.c` via a linked list as well as the static `types` array.
- added code in `lcec_main.c` for adding types to the the lined list dynamically.
- added a macro in `lcec.h` that calls the add-to-linked-list code before `main()` runs.
- moved all of the EL1xxx types `lcec_el1xxx` out of `lcec_main.c` and into `lcec_el1xxx.c`.
- added a `name` field to `lcec_typelist_t` and populated it for all devices.

Upcoming:
- remove `LCEC_SLAVE_TYPE_T` entirely and verify that everything still builds.  Use `name` for matching with configs and add a local variable instead of  `lcecSlaveTypeInvalid`.  Testing will be fun.

Issue: #35