### PR TITLE
build: symlink .clang-format into source dirs

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,1 @@
+../.clang-format

--- a/src/devices/.clang-format
+++ b/src/devices/.clang-format
@@ -1,0 +1,1 @@
+../.clang-format


### PR DESCRIPTION
This will make running `clang-format` easier and less trouble-prone.