### PR TITLE
build: Change clang style to allow 120 character lines

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -57,7 +57,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit: 80
+ColumnLimit: 120
 CommentPragmas: '^ IWYU pragma:'
 QualifierAlignment: Leave
 CompactNamespaces: false


### PR DESCRIPTION
80 leads to too much ugly wrapping.