### PR TITLE
fix(generic): sign-extend short, offset signed reads

### DIFF
--- a/src/devices/lcec_generic.c
+++ b/src/devices/lcec_generic.c
@@ -219,6 +219,15 @@ hal_s32_t lcec_generic_read_s32(uint8_t *pd, lcec_generic_pin_t *hal_data) {
       sval |= (1 << i);
     }
   }
+
+  // sign-extend shorter length integers
+  switch (hal_data->bitLength) {
+  case 8:
+    return (int8_t)sval;
+  case 16:
+    return (int16_t)sval;
+  }
+  
   return sval;
 }
 


### PR DESCRIPTION
From https://github.com/sittner/linuxcnc-ethercat/issues/98, it looks
like we should be sign-extending reads of 8 or 16 bit signed values, and
we aren't doing that when the bit offset is nonzero.