### PR TITLE
feat(el3xxx): Add new driver for analog inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,3 +65,16 @@ or heavily modified code, using the style included in `.clang-format`
 in the root of the LinuxCNC-Ethercat directory.  This is a lightly
 modified version of Google's standard format, and comes fairly close
 to matching most of the existing code.
+
+## Using `scripts/esi.yml`
+
+To generate a list of all PIDs for devices that match a specific regex, you can try something like this:
+
+```
+$ yq '.[] | select(.Name | test("E[LPM][A-Z]*3[01][-0-9]+")) | [.ProductCode + "," + .Name]' scripts/esi.yml  | cut -d' ' -f2 | cut -c2- | cut -d- -f1| sort -u | awk -F,  '{print "#define LCEC_" $2 "_PID" ,  $1; }'
+#define LCEC_EL3001_PID 0x0bb93052
+#define LCEC_EL3002_PID 0x0bba3052
+#define LCEC_EL3004_PID 0x0bbc3052
+#define LCEC_EL3008_PID 0x0bc03052
+...
+```

--- a/documentation/DEVICES.md
+++ b/documentation/DEVICES.md
@@ -65,17 +65,46 @@ Description | Source | EtherCAT VID:PID | Device Type | Testing Status | Notes
 [Beckhoff EL2808 8Ch. Dig. Output 24V, 0.5A](http://www.beckhoff.com/EL2808) | [EL2808](../src/lcec_el2xxx.c) | 0x00000002:0x0af83052 | Digital Output | Uncertain; @scottlaird has several | 
 [Beckhoff EL2809 16Ch. Dig. Output 24V, 0.5A](http://www.beckhoff.com/EL2809) | [EL2809](../src/lcec_el2xxx.c) | 0x00000002:0x0af93052 | Digital Output |  | 
 [Beckhoff EL2904, 4 Ch. Safety Output 24V, 0.5A, TwinSAFE](http://www.beckhoff.com/EL2904) | [EL2904](../src/lcec_el2904.c) | 0x00000002:0x0b583052 | Safety Terminals | Part of @scottlaird's test suite, but not currently being evaluated. | 
+[Beckhoff EL3001 1Ch. Ana. Input +/-10V](http://www.beckhoff.com/EL3001) | [EL3001](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bb93052 | Analog Input | New, untested. | 
+[Beckhoff EL3002 2Ch. Ana. Input +/-10V](http://www.beckhoff.com/EL3002) | [EL3002](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bba3052 | Analog Input | New, untested. | 
 [Beckhoff EL3004 4Ch. Ana. Input +/-10V](http://www.beckhoff.com/EL3004) | [EL3004](../src/lcec_el30x4.c) | 0x00000002:0x0bbc3052 | Analog Input |  | 
+[Beckhoff EL3008 8Ch. Ana. Input +/-10V](http://www.beckhoff.com/EL3008) | [EL3008](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bc03052 | Analog Input | New, untested. | 
+[Beckhoff EL3011 4Ch. Ana. Input 0-20mA DIFF](http://www.beckhoff.com/EL3011) | [EL3011](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bc33052 | Analog Input | New, untested. | 
+[Beckhoff EL3012 4Ch. Ana. Input 0-20mA DIFF](http://www.beckhoff.com/EL3012) | [EL3012](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bc43052 | Analog Input | New, untested. | 
+[Beckhoff EL3014 4Ch. Ana. Input 0-20mA DIFF](http://www.beckhoff.com/EL3014) | [EL3014](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bc63052 | Analog Input | New, untested. | 
+[Beckhoff EL3021 4Ch. Ana. Input 4-20mA DIFF](http://www.beckhoff.com/EL3021) | [EL3021](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bcd3052 | Analog Input | New, untested. | 
+[Beckhoff EL3022 4Ch. Ana. Input 4-20mA DIFF](http://www.beckhoff.com/EL3022) | [EL3022](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bce3052 | Analog Input | New, untested. | 
+[Beckhoff EL3024 4Ch. Ana. Input 4-20mA DIFF](http://www.beckhoff.com/EL3024) | [EL3024](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bd03052 | Analog Input | New, untested. | 
+[Beckhoff EL3041 1Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3041) | [EL3041](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0be13052 | Analog Input | New, untested. | 
+[Beckhoff EL3042 2Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3042) | [EL3042](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0be23052 | Analog Input | New, untested. | 
 [Beckhoff EL3044 4Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3044) | [EL3044](../src/lcec_el30x4.c) | 0x00000002:0x0be43052 | Analog Input |  | 
+[Beckhoff EL3048 8Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3048) | [EL3048](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0be83052 | Analog Input | New, untested. | 
+[Beckhoff EL3051 1Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3051) | [EL3051](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0beb3052 | Analog Input | New, untested. | 
+[Beckhoff EL3052 2Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3052) | [EL3052](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bec3052 | Analog Input | New, untested. | 
 [Beckhoff EL3054 4Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3054) | [EL3054](../src/lcec_el30x4.c) | 0x00000002:0x0bee3052 | Analog Input |  | 
+[Beckhoff EL3058 8Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3058) | [EL3058](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bf23052 | Analog Input | New, untested. | 
+[Beckhoff EL3061 1Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3061) | [EL3061](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bf53052 | Analog Input | New, untested. | 
+[Beckhoff EL3062 2Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3062) | [EL3062](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bf63052 | Analog Input | New, untested. | 
 [Beckhoff EL3064 4Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3064) | [EL3064](../src/lcec_el30x4.c) | 0x00000002:0x0bf83052 | Analog Input |  | 
+[Beckhoff EL3068 8Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3068) | [EL3068](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0bfc3052 | Analog Input | Part of @scottlaird's test suite, hardware is actively exercised for most releases. | 
+[Beckhoff EL3101 1Ch. Ana. Input +/-10V Diff.](http://www.beckhoff.com/EL3101) | [EL3101](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c1d3052 | Analog Input | New, untested. | 
 [Beckhoff EL3102 2Ch. Ana. Input +/-10V, Diff.](http://www.beckhoff.com/EL3102) | [EL3102](../src/lcec_el31x2.c) | 0x00000002:0x0c1e3052 | Analog Input |  | 
+[Beckhoff EL3104 4Ch. Ana. Input +/-10V Diff.](http://www.beckhoff.com/EL3104) | [EL3104](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c203052 | Analog Input | New, untested. | 
+[Beckhoff EL3111 1Ch. Ana. Input 0-20mA, Diff.](http://www.beckhoff.com/EL3111) | [EL3111](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c273052 | Analog Input | New, untested. | 
 [Beckhoff EL3112 2Ch. Ana. Input 0-20mA, Diff.](http://www.beckhoff.com/EL3112) | [EL3112](../src/lcec_el31x2.c) | 0x00000002:0x0c283052 | Analog Input |  | 
+[Beckhoff EL3114 4Ch. Ana. Input 0-20mA, Diff.](http://www.beckhoff.com/EL3114) | [EL3114](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c2a3052 | Analog Input | New, untested. | 
+[Beckhoff EL3121 1Ch. Ana. Input 4-20mA Diff.](http://www.beckhoff.com/EL3121) | [EL3121](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c313052 | Analog Input | New, untested. | 
 [Beckhoff EL3122 2Ch. Ana. Input 4-20mA, Diff.](http://www.beckhoff.com/EL3122) | [EL3122](../src/lcec_el31x2.c) | 0x00000002:0x0c323052 | Analog Input |  | 
+[Beckhoff EL3141 1Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3141) | [EL3141](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c453052 | Analog Input | New, untested. | 
 [Beckhoff EL3142 2Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3142) | [EL3142](../src/lcec_el31x2.c) | 0x00000002:0x0c463052 | Analog Input |  | 
+[Beckhoff EL3144 4Ch. Ana. Input 0-20mA](http://www.beckhoff.com/EL3144) | [EL3144](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c483052 | Analog Input | New, untested. | 
+[Beckhoff EL3151 1Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3151) | [EL3151](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c4f3052 | Analog Input | New, untested. | 
 [Beckhoff EL3152 2Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3152) | [EL3152](../src/lcec_el31x2.c) | 0x00000002:0x0c503052 | Analog Input |  | 
+[Beckhoff EL3154 4Ch. Ana. Input 4-20mA](http://www.beckhoff.com/EL3154) | [EL3154](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c523052 | Analog Input | New, untested. | 
+[Beckhoff EL3161 1Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3161) | [EL3161](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c593052 | Analog Input | New, untested. | 
 [Beckhoff EL3162 2Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3162) | [EL3162](../src/lcec_el31x2.c) | 0x00000002:0x0c5a3052 | Analog Input | Uncertain; @scottlaird has one | 
 [Beckhoff EL3164 4Ch. Ana. Input 0-10V](http://www.beckhoff.com/EL3164) | [EL3164](../src/lcec_el31x4.c) | 0x00000002:0x0c5c3052 | Analog Input |  | 
+[Beckhoff EL3182 2Ch. Ana. Input 4-20mA, HART](http://www.beckhoff.com/EL3182) | [EL3182](../src/devices/lcec_el3xxx.c) | 0x00000002:0x0c6e3052 | Analog Input | New, untested. | 
 [Beckhoff EL3202 2Ch. Ana. Input PT100 (RTD)](http://www.beckhoff.com/EL3202) | [EL3202](../src/lcec_el3202.c) | 0x00000002:0x0c823052 | Analog Input |  | 
 [Beckhoff EL3255 5Ch. potentiometer measurement with sensor supply](http://www.beckhoff.com/EL3255) | [EL3255](../src/lcec_el3255.c) | 0x00000002:0x0cb73052 | Analog Input |  | 
 [Beckhoff EL3403 3Ch. Power Measuring](http://www.beckhoff.com/EL3403) | [EL3403](../src/lcec_el3403.c) | 0x00000002:0x0d4b3052 | Analog Input | Uncertain; @scottlaird has several | 3-phase AC power measurement
@@ -136,6 +165,7 @@ Description | Source | EtherCAT VID:PID | Device Type | Testing Status | Notes
 [Beckhoff EP2809-0021 16 Ch. Dig. Output 24V, 0,5A, M8](https://www.beckhoff.com/EP2809-0021) | [EP2809](../src/lcec_el2xxx.c) | 0x00000002:0x0af94052 | Digital Output |  | 
 [Beckhoff EL7041 1Ch. Stepper motor output stage (50V, 5A)](http://www.beckhoff.com/EL7041) | [EP7041](../src/lcec_el7041.c) | 0x00000002:0x1b813052 | Stepper Drive | Uncertain; @scottlaird has several EP7041-0002 | 
 [AB&T EpoCAT FR4000](https://www.bausano.net/en/hardware/epocat-fr-1000.html) | [EPOCAT](../src/devices/lcec_epocat.c) | 0x0000079A:0x00decade | Stepper Drive | Merged 2023-12-31, untested | by @abausano
+[Beckhoff EPX3158 8Ch. Ana. Input 4-20mA, Ex i](http://www.beckhoff.com/EPX3158) | [EPX3158](../src/devices/lcec_el3xxx.c) | 0x00000002:0x9809ab69 | Analog Input | New, untested. | 
 [SMC EX260-SEC1](https://www.smcpneumatics.com/EX260-SEC1.html) | [EX260_SEC1](../src/devices/lcec_ex260.c) | 0x00000114:0x01000001 | Valve Controller | Merged 2023-12-31, untested | by @satiowadahc
 [SMC EX260-SEC1](https://www.smcpneumatics.com/EX260-SEC2.html) | [EX260_SEC2](../src/devices/lcec_ex260.c) | 0x00000114:0x01000002 | Valve Controller | Merged 2023-12-31, untested | by @satiowadahc
 [SMC EX260-SEC3](https://www.smcpneumatics.com/EX260-SEC3.html) | [EX260_SEC3](../src/devices/lcec_ex260.c) | 0x00000114:0x01000003 | Valve Controller | Merged 2023-12-31, untested | by @satiowadahc

--- a/documentation/devices/EL3001.yml
+++ b/documentation/devices/EL3001.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3001
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bb93052"
+Description: Beckhoff EL3001 1Ch. Ana. Input +/-10V
+DocumentationURL: http://www.beckhoff.com/EL3001
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3002.yml
+++ b/documentation/devices/EL3002.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3002
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bba3052"
+Description: Beckhoff EL3002 2Ch. Ana. Input +/-10V
+DocumentationURL: http://www.beckhoff.com/EL3002
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3008.yml
+++ b/documentation/devices/EL3008.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3008
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bc03052"
+Description: Beckhoff EL3008 8Ch. Ana. Input +/-10V
+DocumentationURL: http://www.beckhoff.com/EL3008
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3011.yml
+++ b/documentation/devices/EL3011.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3011
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bc33052"
+Description: Beckhoff EL3011 4Ch. Ana. Input 0-20mA DIFF
+DocumentationURL: http://www.beckhoff.com/EL3011
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3012.yml
+++ b/documentation/devices/EL3012.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3012
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bc43052"
+Description: Beckhoff EL3012 4Ch. Ana. Input 0-20mA DIFF
+DocumentationURL: http://www.beckhoff.com/EL3012
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3014.yml
+++ b/documentation/devices/EL3014.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3014
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bc63052"
+Description: Beckhoff EL3014 4Ch. Ana. Input 0-20mA DIFF
+DocumentationURL: http://www.beckhoff.com/EL3014
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3021.yml
+++ b/documentation/devices/EL3021.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3021
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bcd3052"
+Description: Beckhoff EL3021 4Ch. Ana. Input 4-20mA DIFF
+DocumentationURL: http://www.beckhoff.com/EL3021
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3022.yml
+++ b/documentation/devices/EL3022.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3022
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bce3052"
+Description: Beckhoff EL3022 4Ch. Ana. Input 4-20mA DIFF
+DocumentationURL: http://www.beckhoff.com/EL3022
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3024.yml
+++ b/documentation/devices/EL3024.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3024
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bd03052"
+Description: Beckhoff EL3024 4Ch. Ana. Input 4-20mA DIFF
+DocumentationURL: http://www.beckhoff.com/EL3024
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3041.yml
+++ b/documentation/devices/EL3041.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3041
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0be13052"
+Description: Beckhoff EL3041 1Ch. Ana. Input 0-20mA
+DocumentationURL: http://www.beckhoff.com/EL3041
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3042.yml
+++ b/documentation/devices/EL3042.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3042
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0be23052"
+Description: Beckhoff EL3042 2Ch. Ana. Input 0-20mA
+DocumentationURL: http://www.beckhoff.com/EL3042
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3048.yml
+++ b/documentation/devices/EL3048.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3048
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0be83052"
+Description: Beckhoff EL3048 8Ch. Ana. Input 0-20mA
+DocumentationURL: http://www.beckhoff.com/EL3048
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3051.yml
+++ b/documentation/devices/EL3051.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3051
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0beb3052"
+Description: Beckhoff EL3051 1Ch. Ana. Input 4-20mA
+DocumentationURL: http://www.beckhoff.com/EL3051
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3052.yml
+++ b/documentation/devices/EL3052.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3052
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bec3052"
+Description: Beckhoff EL3052 2Ch. Ana. Input 4-20mA
+DocumentationURL: http://www.beckhoff.com/EL3052
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3058.yml
+++ b/documentation/devices/EL3058.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3058
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bf23052"
+Description: Beckhoff EL3058 8Ch. Ana. Input 4-20mA
+DocumentationURL: http://www.beckhoff.com/EL3058
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3061.yml
+++ b/documentation/devices/EL3061.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3061
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bf53052"
+Description: Beckhoff EL3061 1Ch. Ana. Input 0-10V
+DocumentationURL: http://www.beckhoff.com/EL3061
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3062.yml
+++ b/documentation/devices/EL3062.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3062
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bf63052"
+Description: Beckhoff EL3062 2Ch. Ana. Input 0-10V
+DocumentationURL: http://www.beckhoff.com/EL3062
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3068.yml
+++ b/documentation/devices/EL3068.yml
@@ -1,0 +1,12 @@
+---
+Device: EL3068
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0bfc3052"
+Description: Beckhoff EL3068 8Ch. Ana. Input 0-10V
+DocumentationURL: http://www.beckhoff.com/EL3068
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "Part of @scottlaird's test suite, hardware is actively exercised for most releases."
+

--- a/documentation/devices/EL3101.yml
+++ b/documentation/devices/EL3101.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3101
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c1d3052"
+Description: Beckhoff EL3101 1Ch. Ana. Input +/-10V Diff.
+DocumentationURL: http://www.beckhoff.com/EL3101
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3104.yml
+++ b/documentation/devices/EL3104.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3104
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c203052"
+Description: Beckhoff EL3104 4Ch. Ana. Input +/-10V Diff.
+DocumentationURL: http://www.beckhoff.com/EL3104
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3111.yml
+++ b/documentation/devices/EL3111.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3111
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c273052"
+Description: Beckhoff EL3111 1Ch. Ana. Input 0-20mA, Diff.
+DocumentationURL: http://www.beckhoff.com/EL3111
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3114.yml
+++ b/documentation/devices/EL3114.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3114
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c2a3052"
+Description: Beckhoff EL3114 4Ch. Ana. Input 0-20mA, Diff.
+DocumentationURL: http://www.beckhoff.com/EL3114
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3121.yml
+++ b/documentation/devices/EL3121.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3121
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c313052"
+Description: Beckhoff EL3121 1Ch. Ana. Input 4-20mA Diff.
+DocumentationURL: http://www.beckhoff.com/EL3121
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3141.yml
+++ b/documentation/devices/EL3141.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3141
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c453052"
+Description: Beckhoff EL3141 1Ch. Ana. Input 0-20mA
+DocumentationURL: http://www.beckhoff.com/EL3141
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3144.yml
+++ b/documentation/devices/EL3144.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3144
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c483052"
+Description: Beckhoff EL3144 4Ch. Ana. Input 0-20mA
+DocumentationURL: http://www.beckhoff.com/EL3144
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3151.yml
+++ b/documentation/devices/EL3151.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3151
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c4f3052"
+Description: Beckhoff EL3151 1Ch. Ana. Input 4-20mA
+DocumentationURL: http://www.beckhoff.com/EL3151
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3154.yml
+++ b/documentation/devices/EL3154.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3154
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c523052"
+Description: Beckhoff EL3154 4Ch. Ana. Input 4-20mA
+DocumentationURL: http://www.beckhoff.com/EL3154
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3161.yml
+++ b/documentation/devices/EL3161.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3161
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c593052"
+Description: Beckhoff EL3161 1Ch. Ana. Input 0-10V
+DocumentationURL: http://www.beckhoff.com/EL3161
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EL3182.yml
+++ b/documentation/devices/EL3182.yml
@@ -1,0 +1,11 @@
+---
+Device: EL3182
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x0c6e3052"
+Description: Beckhoff EL3182 2Ch. Ana. Input 4-20mA, HART
+DocumentationURL: http://www.beckhoff.com/EL3182
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/documentation/devices/EPX3158.yml
+++ b/documentation/devices/EPX3158.yml
@@ -1,0 +1,11 @@
+---
+Device: EPX3158
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x9809ab69"
+Description: Beckhoff EPX3158 8Ch. Ana. Input 4-20mA, Ex i
+DocumentationURL: http://www.beckhoff.com/EPX3158
+DeviceType: Analog Input
+Notes: ""
+SrcFile: src/devices/lcec_el3xxx.c
+TestingStatus: "New, untested."

--- a/src/devices/lcec_el3xxx.c
+++ b/src/devices/lcec_el3xxx.c
@@ -1,0 +1,258 @@
+//
+//    Copyright (C) 2011 Sascha Ittner <sascha.ittner@modusoft.de>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "../lcec.h"
+#include "lcec_el3xxx.h"
+
+// There's no simple way to pass parameters into _init, so we have a
+// couple variants here that set up a few different minor variants.
+//
+// Right now, the options are:
+//
+// - lcec_el3xxx_init_16_sync: for EL31xx devices.  Expects 16-bit
+//   values and supports the `-sync-err` PDO.  
+//
+// - lcec_el3xxx_init_12_nosync: for EL30xx devices.  Expects 12-bit
+//   values and does not support the `-sync-err` PDO.
+//
+// TODO(scottlaird): add support for additional EL31xx operating modes, as per
+//   https://download.beckhoff.com/download/Document/io/ethercat-terminals/el31xxen.pdf#page=251
+//   Specifically, support disabling the filter (0x8000:06) and DC mode.
+//
+// TODO(scottlaird): add support framework for almost-but-not-quite analog
+//   devices with different pin names and read() functions.
+
+// TODO(scottlaird): using generic support, add EL32xx temperature
+//   sensors family.  The EL32xxs seem to be 16-bit devices with no
+//   sync.  The existing EL3202 driver has slightly different pin
+//   names, and the read() function is calibrated slightly
+//   differently.
+//
+// TODO(scottlaird): using generic support, add EL3255 pot input.
+//
+// TODO(scottlaird): using generic support, add EM37xx pressure sensor input.
+//
+// TODO(scottlaird): support weird multifunction analog devices like
+//   the ELM3246 and EL3751?  This are weird enough that they may make
+//   sense as an indpendent driver, if anyone ever actually turns up
+//   with hardware.
+static int lcec_el3xxx_init_16_sync(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs);
+static int lcec_el3xxx_init_12_nosync(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs);
+
+static lcec_typelist_t types[]={
+  { "EL3001", LCEC_EL3XXX_VID, LCEC_EL3001_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3002", LCEC_EL3XXX_VID, LCEC_EL3002_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  //  { "EL3004", LCEC_EL3XXX_VID, LCEC_EL3004_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3011", LCEC_EL3XXX_VID, LCEC_EL3011_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3012", LCEC_EL3XXX_VID, LCEC_EL3012_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3014", LCEC_EL3XXX_VID, LCEC_EL3014_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3021", LCEC_EL3XXX_VID, LCEC_EL3021_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3022", LCEC_EL3XXX_VID, LCEC_EL3022_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3024", LCEC_EL3XXX_VID, LCEC_EL3024_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3041", LCEC_EL3XXX_VID, LCEC_EL3041_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3042", LCEC_EL3XXX_VID, LCEC_EL3042_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  //  { "EL3044", LCEC_EL3XXX_VID, LCEC_EL3044_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3048", LCEC_EL3XXX_VID, LCEC_EL3048_PID, LCEC_EL3XX8_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3051", LCEC_EL3XXX_VID, LCEC_EL3051_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3052", LCEC_EL3XXX_VID, LCEC_EL3052_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  //  { "EL3054", LCEC_EL3XXX_VID, LCEC_EL3054_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3058", LCEC_EL3XXX_VID, LCEC_EL3058_PID, LCEC_EL3XX8_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3061", LCEC_EL3XXX_VID, LCEC_EL3061_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3062", LCEC_EL3XXX_VID, LCEC_EL3062_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  //  { "EL3064", LCEC_EL3XXX_VID, LCEC_EL3064_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+  { "EL3068", LCEC_EL3XXX_VID, LCEC_EL3068_PID, LCEC_EL3XX8_PDOS, 0, NULL, lcec_el3xxx_init_12_nosync},
+
+  { "EL3101", LCEC_EL3XXX_VID, LCEC_EL3101_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3102", LCEC_EL3XXX_VID, LCEC_EL3102_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3104", LCEC_EL3XXX_VID, LCEC_EL3104_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3111", LCEC_EL3XXX_VID, LCEC_EL3111_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3112", LCEC_EL3XXX_VID, LCEC_EL3112_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3114", LCEC_EL3XXX_VID, LCEC_EL3114_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3121", LCEC_EL3XXX_VID, LCEC_EL3121_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3122", LCEC_EL3XXX_VID, LCEC_EL3122_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3124", LCEC_EL3XXX_VID, LCEC_EL3124_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3141", LCEC_EL3XXX_VID, LCEC_EL3141_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3142", LCEC_EL3XXX_VID, LCEC_EL3142_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3144", LCEC_EL3XXX_VID, LCEC_EL3144_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3151", LCEC_EL3XXX_VID, LCEC_EL3151_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3152", LCEC_EL3XXX_VID, LCEC_EL3152_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3154", LCEC_EL3XXX_VID, LCEC_EL3154_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3161", LCEC_EL3XXX_VID, LCEC_EL3161_PID, LCEC_EL3XX1_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3162", LCEC_EL3XXX_VID, LCEC_EL3162_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  //  { "EL3164", LCEC_EL3XXX_VID, LCEC_EL3164_PID, LCEC_EL3XX4_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EL3182", LCEC_EL3XXX_VID, LCEC_EL3182_PID, LCEC_EL3XX2_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { "EPX3158", LCEC_EL3XXX_VID, LCEC_EPX3158_PID, LCEC_EL3XX8_PDOS, 0, NULL, lcec_el3xxx_init_16_sync},
+  { NULL },
+};
+ADD_TYPES(types);
+
+typedef struct {
+  hal_bit_t *overrange;
+  hal_bit_t *underrange;
+  hal_bit_t *error;
+  hal_bit_t *sync_err;
+  hal_s32_t *raw_val;
+  hal_float_t *scale;
+  hal_float_t *bias;
+  hal_float_t *val;
+  unsigned int ovr_pdo_os;
+  unsigned int ovr_pdo_bp;
+  unsigned int udr_pdo_os;
+  unsigned int udr_pdo_bp;
+  unsigned int error_pdo_os;
+  unsigned int error_pdo_bp;
+  unsigned int sync_err_pdo_os;
+  unsigned int sync_err_pdo_bp;
+  unsigned int val_pdo_os;
+} lcec_el3xxx_chan_t;
+
+static const lcec_pindesc_t slave_pins[] = {
+  { HAL_BIT, HAL_OUT, offsetof(lcec_el3xxx_chan_t ,error), "%s.%s.%s.ain-%d-error" },
+  { HAL_BIT, HAL_OUT, offsetof(lcec_el3xxx_chan_t ,sync_err), "%s.%s.%s.ain-%d-sync-err" },
+  { HAL_BIT, HAL_OUT, offsetof(lcec_el3xxx_chan_t ,overrange), "%s.%s.%s.ain-%d-overrange" },
+  { HAL_BIT, HAL_OUT, offsetof(lcec_el3xxx_chan_t ,underrange), "%s.%s.%s.ain-%d-underrange" },
+  { HAL_S32, HAL_OUT, offsetof(lcec_el3xxx_chan_t ,raw_val), "%s.%s.%s.ain-%d-raw" },
+  { HAL_FLOAT, HAL_OUT, offsetof(lcec_el3xxx_chan_t ,val), "%s.%s.%s.ain-%d-val" },
+  { HAL_FLOAT, HAL_IO, offsetof(lcec_el3xxx_chan_t ,scale), "%s.%s.%s.ain-%d-scale" },
+  { HAL_FLOAT, HAL_IO, offsetof(lcec_el3xxx_chan_t ,bias), "%s.%s.%s.ain-%d-bias" },
+  { HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL }
+};
+
+typedef struct {
+  lcec_el3xxx_chan_t chans[LCEC_EL3XXX_MAXCHANS];
+} lcec_el3xxx_data_t;
+
+static void lcec_el3xxx_read(struct lcec_slave *slave, long period, uint32_t mask);
+static void lcec_el3xxx_read_16(struct lcec_slave *slave, long period);
+static void lcec_el3xxx_read_12(struct lcec_slave *slave, long period);
+
+static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs, int bitdepth, int has_sync) {
+  lcec_master_t *master = slave->master;
+  lcec_el3xxx_data_t *hal_data;
+  lcec_el3xxx_chan_t *chan;
+  int i;
+  int err;
+  int channels;
+
+  channels = slave->pdo_entry_count / LCEC_EL3XXX_PDOS_PER_CHANNEL;
+
+  rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "initing device as %s, bitdepth %d, channels %d\n", slave->name, bitdepth, channels);
+
+  // initialize settings that vary per bitdepth
+  switch(bitdepth) {
+  case 12:
+    slave->proc_read = lcec_el3xxx_read_12;
+    break;
+  case 16:
+    slave->proc_read = lcec_el3xxx_read_16;
+    break;
+  default:
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "Can't handle bitdepth %d for device %s\n", bitdepth, slave->name);
+  }
+
+
+  // alloc hal memory
+  if ((hal_data = hal_malloc(sizeof(lcec_el3xxx_data_t))) == NULL) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
+    return -EIO;
+  }
+  memset(hal_data, 0, sizeof(lcec_el3xxx_data_t));
+  slave->hal_data = hal_data;
+
+  rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "setting up pins\n");
+
+  // initialize pins
+  for (i=0; i<channels; i++) {
+    chan = &hal_data->chans[i];
+
+    // initialize POD entries
+    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + (i << 4), 0x01, &chan->udr_pdo_os, &chan->udr_pdo_bp);
+    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + (i << 4), 0x02, &chan->ovr_pdo_os, &chan->ovr_pdo_bp);
+    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + (i << 4), 0x07, &chan->error_pdo_os, &chan->error_pdo_bp);
+    if (has_sync) {
+      // Only EL31xx devices have this PDO, if we try to initialize it
+      // with 30xxs, then we get a PDO error and fail out.
+      LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + (i << 4), 0x0E, &chan->sync_err_pdo_os, &chan->sync_err_pdo_bp);
+    }
+    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000 + (i << 4), 0x11, &chan->val_pdo_os, NULL);
+
+    // export pins
+    if ((err = lcec_pin_newf_list(chan, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {
+      return err;
+    }
+
+    // initialize pins
+    *(chan->scale) = 1.0;
+  }
+  rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "done\n");
+
+  return 0;
+}
+
+static int lcec_el3xxx_init_16_sync(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs) {
+  lcec_el3xxx_init(comp_id, slave, pdo_entry_regs, 16, 1);  // 16 bits, with has_sync=1
+}
+
+static int lcec_el3xxx_init_12_nosync(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs) {
+  lcec_el3xxx_init(comp_id, slave, pdo_entry_regs, 12, 0);  // 12 bits, with has_syhc=0
+}
+
+
+static void lcec_el3xxx_read_16(struct lcec_slave *slave, long period) {
+  lcec_el3xxx_read(slave, period, 0x7fff);
+}
+
+static void lcec_el3xxx_read_12(struct lcec_slave *slave, long period) {
+  lcec_el3xxx_read(slave, period, 0x7ff);
+}
+
+static void lcec_el3xxx_read(struct lcec_slave *slave, long period, uint32_t mask) {
+  lcec_master_t *master = slave->master;
+  lcec_el3xxx_data_t *hal_data = (lcec_el3xxx_data_t *) slave->hal_data;
+  uint8_t *pd = master->process_data;
+  int i;
+  lcec_el3xxx_chan_t *chan;
+  int16_t value;
+  int channels;
+
+  // really shouldn't need to do this on every read.
+  channels = slave->pdo_entry_count / LCEC_EL3XXX_PDOS_PER_CHANNEL;
+
+  // wait for slave to be operational
+  if (!slave->state.operational) {
+    return;
+  }
+
+  // check inputs
+  for (i=0; i<channels; i++) {
+    chan = &hal_data->chans[i];
+
+    // update state
+    // update state
+    *(chan->overrange) = EC_READ_BIT(&pd[chan->ovr_pdo_os], chan->ovr_pdo_bp);
+    *(chan->underrange) = EC_READ_BIT(&pd[chan->udr_pdo_os], chan->udr_pdo_bp);
+    *(chan->error) = EC_READ_BIT(&pd[chan->error_pdo_os], chan->error_pdo_bp);
+    *(chan->sync_err) = EC_READ_BIT(&pd[chan->sync_err_pdo_os], chan->sync_err_pdo_bp);
+
+    // update value
+    value = EC_READ_S16(&pd[chan->val_pdo_os]);
+    *(chan->raw_val) = value;
+    *(chan->val) = *(chan->bias) + *(chan->scale) * (double)value * ((double)1/(double)mask);
+  }
+}
+

--- a/src/devices/lcec_el3xxx.h
+++ b/src/devices/lcec_el3xxx.h
@@ -1,0 +1,102 @@
+//
+//    Copyright (C) 2011 Sascha Ittner <sascha.ittner@modusoft.de>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+#ifndef _LCEC_EL3XXX_H_
+#define _LCEC_EL3XXX_H_
+
+#include "../lcec.h"
+
+#define LCEC_EL3XXX_VID LCEC_BECKHOFF_VID
+
+#define LCEC_EL3001_PID 0x0bb93052  // https://beckhoff.com/EL3001, 1-port +/- 10V single-ended
+#define LCEC_EL3002_PID 0x0bba3052  // https://beckhoff.com/EL3002, 2-port +/- 10V single-ended
+//#define LCEC_EL3004_PID 0x0bbc3052  // https://beckhoff.com/EL3004, 1-port +/- 10V  single-ended // covered by lcec_el30x4 for now
+#define LCEC_EL3008_PID 0x0bc03052  // https://beckhoff.com/EL3008, 8-port +/- 10V single-ended
+#define LCEC_EL3011_PID 0x0bc33052  // https://beckhoff.com/EL3011, 1-port 0...20mA diff
+#define LCEC_EL3012_PID 0x0bc43052  // https://beckhoff.com/EL3012, 2-port 0...20mA diff
+#define LCEC_EL3014_PID 0x0bc63052  // https://beckhoff.com/EL3014, 4-port 0...20mA diff
+#define LCEC_EL3021_PID 0x0bcd3052  // https://beckhoff.com/EL3011, 1-port 4...20mA diff
+#define LCEC_EL3022_PID 0x0bce3052  // https://beckhoff.com/EL3011, 1-port 4...20mA diff
+#define LCEC_EL3024_PID 0x0bd03052  // https://beckhoff.com/EL3011, 1-port 4...20mA diff
+#define LCEC_EL3041_PID 0x0be13052  // https://beckhoff.com/EL3041, 1-port 0...20mA single-ended
+#define LCEC_EL3042_PID 0x0be23052  // https://beckhoff.com/EL3042, 2-port 0...20mA single-ended
+//#define LCEC_EL3044_PID 0x0be43052  // https://beckhoff.com/EL3044, 4-port 0...20mA single-ended  // covered by lcec_el30x4 for now
+#define LCEC_EL3048_PID 0x0be83052  // https://beckhoff.com/EL3048, 8-port 0...20mA single-ended
+#define LCEC_EL3051_PID 0x0beb3052  // https://beckhoff.com/EL3051, 1-port 4...20mA single-ended
+#define LCEC_EL3052_PID 0x0bec3052  // https://beckhoff.com/EL3052, 2-port 4...20mA single-ended
+//#define LCEC_EL3054_PID 0x0bee3052  // https://beckhoff.com/EL3054, 4-port 4...20mA single-ended  // covered by lcec_el30x4 for now
+#define LCEC_EL3058_PID 0x0bf23052  // https://beckhoff.com/EL3058, 8-port 4...20mA single-ended
+#define LCEC_EL3061_PID 0x0bf53052  // https://beckhoff.com/EL3061, 1-port 0...10V single-ended
+#define LCEC_EL3062_PID 0x0bf63052  // https://beckhoff.com/EL3062, 2-port 0...10V single-ended
+//#define LCEC_EL3064_PID 0x0bf83052  // https://beckhoff.com/EL3064, 4-port 0...10V single-ended // covered by lcec_el30x4 for now
+#define LCEC_EL3068_PID 0x0bfc3052  // https://beckhoff.com/EL3068, 8-port 0...10V single-ended
+
+#define LCEC_EL3101_PID 0x0c1d3052  // https://beckhoff.com/EL3101, 1-port +/- 10V diff
+//#define LCEC_EL3102_PID 0x0c1e3052  // https://beckhoff.com/EL3102, 2-port +/- 10V diff  // covered by lcec_el31x2 for now
+#define LCEC_EL3104_PID 0x0c203052  // https://beckhoff.com/EL3104, 4-port +/- 10V diff
+#define LCEC_EL3111_PID 0x0c273052  // https://beckhoff.com/EL3111, 1-port 0...20mA diff
+//#define LCEC_EL3112_PID 0x0c283052  // https://beckhoff.com/EL3112, 2-port 0...20mA diff  // covered by lcec_el31x2 for now
+#define LCEC_EL3114_PID 0x0c2a3052  // https://beckhoff.com/EL3114, 4-port 0...20mA diff
+#define LCEC_EL3121_PID 0x0c313052  // https://beckhoff.com/EL3121, 1-port 4...20mA diff
+//#define LCEC_EL3122_PID 0x0c323052  // https://beckhoff.com/EL3122, 2-port 4...20mA diff  // covered by lcec_el31x2 for now
+//#define LCEC_EL3124_PID 0x0c343052  // https://beckhoff.com/EL3124, 4-port 4...20mA diff  // covered by lcec_el31x4 for now
+#define LCEC_EL3141_PID 0x0c453052  // https://beckhoff.com/EL3141, 1-port 0...20mA single-ended
+//#define LCEC_EL3142_PID 0x0c463052  // https://beckhoff.com/EL3142, 2-port 0...20mA single-ended  // covered by lcec_el31x2 for now
+#define LCEC_EL3144_PID 0x0c483052  // https://beckhoff.com/EL3144, 4-port 0...20mA single-ended
+#define LCEC_EL3151_PID 0x0c4f3052  // https://beckhoff.com/EL3151, 1-port 4...20mA single-ended
+//#define LCEC_EL3152_PID 0x0c503052  // https://beckhoff.com/EL3152, 2-port 4...20mA single-ended  // covered by lcec_el31x2 for now
+#define LCEC_EL3154_PID 0x0c523052  // https://beckhoff.com/EL3154, 4-port 4...20mA single-ended
+#define LCEC_EL3161_PID 0x0c593052  // https://beckhoff.com/EL3161, 1-port 0...10V single-ended
+//#define LCEC_EL3162_PID 0x0c5a3052  // https://beckhoff.com/EL3162, 2-port 0...10V single-ended  // covered by lcec_el31x2 for now
+//#define LCEC_EL3164_PID 0x0c5c3052  // https://beckhoff.com/EL3164, 4-port 0...10V single-ended  // covered by lcec_el31x4 for now
+#define LCEC_EL3182_PID 0x0c6e3052  // https://beckhoff.com/EL3182, 2-port 0/4...20mA single-ended HART
+#define LCEC_EPX3158_PID 0x9809ab69  // https://beckhoff.com/EPX5185, 8-port 4..20mA single-ended, hazardous area
+
+// Related-but-not-quite-the-same devices, kept here for the moment.
+//#define LCEC_EL3072_PID 0x0c003052  // https://beckhoff.com/EL3072, 2-port multifunction
+//#define LCEC_EL3074_PID 0x0c023052  // https://beckhoff.com/EL3074, 4-port multifunction
+//#define LCEC_EL3172_PID 0x0c643052  // https://beckhoff.com/EL3172, 2-port multifunction
+//#define LCEC_EL3174_PID 0x0c663052  // https://beckhoff.com/EL3174, 4-port multifunction
+//#define LCEC_EP3162_PID 0x0c5a4052  // https://beckhoff.com/EP3162, 2-port multifunction
+//#define LCEC_EP3174_PID 0x0c664052  // https://beckhoff.com/EP3174, 4-port multifunction differential
+//#define LCEC_EP3182_PID 0x0c6e4052  // https://beckhoff.com/EP3182, 2-port multifunction
+//#define LCEC_EP3184_PID 0x0c704052  // https://beckhoff.com/EP3184, 4-port multifunction
+//#define LCEC_EPP3174_PID 0x64768c69  // https://beckhoff.com/EP3174, 4-port multifunction differential
+//#define LCEC_EPP3184_PID 0x64768d09  // https://beckhoff.com/EP3184, 4-port multifunction
+
+//#define LCEC_ELM3002_PID 0x50216da9
+//#define LCEC_ELM3004_PID 0x50216dc9
+//#define LCEC_ELM3102_PID 0x502173e9
+//#define LCEC_ELM3104_PID 0x50217409
+//#define LCEC_ELM3142_PID 0x50217669
+//#define LCEC_ELM3144_PID 0x50217689
+//#define LCEC_ELM3146_PID 0x502176a9
+//#define LCEC_ELM3148_PID 0x502176c9
+//#define LCEC_ELX3152_PID 0x970bc309
+//#define LCEC_ELX3158_PID 0x970bc369
+//#define LCEC_ELX3181_PID 0x970bc4d9
+//#define LCEC_ELX3184_PID 0x970bc509
+
+#define LCEC_EL3XXX_MAXCHANS 8  // for sizing arrays
+
+#define LCEC_EL3XXX_PDOS_PER_CHANNEL 5
+#define LCEC_EL3XX1_PDOS  (LCEC_EL3XXX_PDOS_PER_CHANNEL * 1)
+#define LCEC_EL3XX2_PDOS  (LCEC_EL3XXX_PDOS_PER_CHANNEL * 2)
+#define LCEC_EL3XX4_PDOS  (LCEC_EL3XXX_PDOS_PER_CHANNEL * 4)
+#define LCEC_EL3XX8_PDOS  (LCEC_EL3XXX_PDOS_PER_CHANNEL * 8)
+#endif
+


### PR DESCRIPTION
This *should* suport all of the EL3[01]* devices today, except for the
multifunction models (EL307x, EL317x, EP3162, EP3174, EP318x).  It's
been verified (lightly) with the EL3068.

This should be able to replace the `el30x4`, `el31x2`, and `el31x4` drivers,
but the devices that overlap are currently commented out in
`lcec_el3xxx.[ch]`  Once we've had a bit of testing, we can delete some code.

Issue: #80 
Issue: #41 