### PR TITLE
feat(generic): Preliminary support for 64-bit floats

### DIFF
--- a/src/devices/lcec_generic.c
+++ b/src/devices/lcec_generic.c
@@ -78,7 +78,7 @@ int lcec_generic_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t 
 
       case HAL_FLOAT:
         // check data size
-        if (hal_data->bitLength > 32) {
+        if ((hal_data->bitLength > 32) && (hal_data->subType != lcecPdoEntTypeFloatDoubleIeee)) {
           rtapi_print_msg(RTAPI_MSG_WARN, LCEC_MSG_PFX "unable to export pin %s.%s.%s.%s: invalid process data bitlen!\n", LCEC_MODULE_NAME, master->name, slave->name, hal_data->name);
           continue;
         }
@@ -133,6 +133,8 @@ void lcec_generic_read(struct lcec_slave *slave, long period) {
           fval = lcec_generic_read_u32(pd, hal_data);
         } else if(hal_data->subType == lcecPdoEntTypeFloatIeee){
           fval = EC_READ_REAL(&pd[hal_data->pdo_os]);
+        } else if(hal_data->subType == lcecPdoEntTypeFloatDoubleIeee){
+          fval = EC_READ_LREAL(&pd[hal_data->pdo_os]);
         } else {
           fval = lcec_generic_read_s32(pd, hal_data);
         }
@@ -187,6 +189,8 @@ void lcec_generic_write(struct lcec_slave *slave, long period) {
           lcec_generic_write_u32(pd, hal_data, (hal_u32_t) fval);
 	} else if(hal_data->subType == lcecPdoEntTypeFloatIeee){
           EC_WRITE_REAL(&pd[hal_data->pdo_os], fval);
+	} else if(hal_data->subType == lcecPdoEntTypeFloatDoubleIeee){
+          EC_WRITE_LREAL(&pd[hal_data->pdo_os], fval);
         } else {
           lcec_generic_write_s32(pd, hal_data, (hal_s32_t) fval);
         }

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -940,7 +940,7 @@ static void parsePdoEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
         p->subType = lcecPdoEntTypeSimple;
         p->halType = HAL_U32;
         continue;
-      }
+      }      
       if (strcasecmp(val, "float") == 0) {
         p->subType = lcecPdoEntTypeFloatSigned;
         p->halType = HAL_FLOAT;
@@ -957,6 +957,11 @@ static void parsePdoEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
       }
       if (strcasecmp(val, "float-ieee") == 0) {
         p->subType = lcecPdoEntTypeFloatIeee;
+        p->halType = HAL_FLOAT;
+        continue;
+      }
+      if (strcasecmp(val, "float-double-ieee") == 0) {
+        p->subType = lcecPdoEntTypeFloatDoubleIeee;
         p->halType = HAL_FLOAT;
         continue;
       }
@@ -1100,6 +1105,11 @@ static void parseComplexEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const c
       }
       if (strcasecmp(val, "float-ieee") == 0) {
         p->subType = lcecPdoEntTypeFloatIeee;
+        p->halType = HAL_FLOAT;
+        continue;
+      }
+      if (strcasecmp(val, "float-double-ieee") == 0) {
+        p->subType = lcecPdoEntTypeFloatDoubleIeee;
         p->halType = HAL_FLOAT;
         continue;
       }

--- a/src/lcec_conf.h
+++ b/src/lcec_conf.h
@@ -56,7 +56,8 @@ typedef enum {
   lcecPdoEntTypeFloatSigned,
   lcecPdoEntTypeFloatUnsigned,
   lcecPdoEntTypeComplex,
-  lcecPdoEntTypeFloatIeee
+  lcecPdoEntTypeFloatIeee,
+  lcecPdoEntTypeFloatDoubleIeee,
 } LCEC_PDOENT_TYPE_T;
 
 typedef struct {


### PR DESCRIPTION
To use this, declare a PDO in `ethercat.xml` with
`halType="float-double-ieee"`.

This is currently *completely* untested.  It compiles.  That's all I can
promise.

Issue #115