### PR TITLE
build: create a "passive" driver.

### DIFF
--- a/documentation/DEVICES.md
+++ b/documentation/DEVICES.md
@@ -15,10 +15,10 @@ Description | Driver | EtherCAT VID:PID | Device Type | Testing Status | Notes
 [Beckhoff AX5805 (Safety Drive Option)](http://beckhoff.com/AX5805) | [ax5805](../src/devices/lcec_ax5805.c) | 0x00000002:0x16ad6012 | Safety Terminals |  | 
 [Delta ASDA-A2-E](https://www.deltaww.com/en-us/products/Servo-Systems-AC-Servo-Motors-and-Drives/23) | [deasda](../src/devices/lcec_deasda.c) | 0x000001dd:0x10305070 | Servo Drive |  | 
 [Delta MS-300 AC Motor Drive](https://www.deltaww.com/en-us/products/AC-Motor-Drives/3449) | [dems300](../src/devices/lcec_dems300.c) | 0x000001dd:0x10400200 | AC Motor Drive |  | 
-[Beckhoff EK1100 EtherCAT Coupler (0.5A E-Bus)](http://www.beckhoff.com/EK1100) | [ek1100](../src/devices/lcec_ek1100.c) | 0x00000002:0x044c2c52 | System Terminals | Part of @scottlaird's test suite. | Passive device
-[Beckhoff EK1101 EtherCAT Coupler (2A E-Bus, ID switch)](http://www.beckhoff.com/EK1101) | [ek1100](../src/devices/lcec_ek1100.c) | 0x00000002:0x044d2c52 | System Terminals |  | Passive device
-[Beckhoff EK1110 EtherCAT extension](http://www.beckhoff.com/EK1110) | [ek1100](../src/devices/lcec_ek1100.c) | 0x00000002:0x04562c52 | System Terminals | Part of @scottlaird's test suite | Passive device
-[Beckhoff EK1122 2 port EtherCAT junction](http://www.beckhoff.com/EK1122) | [ek1100](../src/devices/lcec_ek1100.c) | 0x00000002:0x04622c52 | System Terminals |  | Passive device
+[Beckhoff EK1100 EtherCAT Coupler (0.5A E-Bus)](http://www.beckhoff.com/EK1100) | [passive](../src/devices/lcec_passive.c) | 0x00000002:0x044c2c52 | System Terminals | Part of @scottlaird's test suite. | Passive device
+[Beckhoff EK1101 EtherCAT Coupler (2A E-Bus, ID switch)](http://www.beckhoff.com/EK1101) | [passive](../src/devices/lcec_passive.c) | 0x00000002:0x044d2c52 | System Terminals |  | Passive device
+[Beckhoff EK1110 EtherCAT extension](http://www.beckhoff.com/EK1110) | [passive](../src/devices/lcec_passive.c) | 0x00000002:0x04562c52 | System Terminals | Part of @scottlaird's test suite | Passive device
+[Beckhoff EK1122 2 port EtherCAT junction](http://www.beckhoff.com/EK1122) | [passive](../src/devices/lcec_passive.c) | 0x00000002:0x04622c52 | System Terminals |  | Passive device
 [Beckhoff EL1002 2Ch. Dig. Input 24V, 3ms](http://www.beckhoff.com/EL1002) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x00000002:0x03ea3052 | Digital Input Terminals |  | 
 [Beckhoff EL1004 4Ch. Dig. Input 24V, 3ms](http://www.beckhoff.com/EL1004) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x00000002:0x03ec3052 | Digital Input Terminals |  | 
 [Beckhoff EL1008 8Ch. Dig. Input 24V, 3ms](http://www.beckhoff.com/EL1008) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x00000002:0x03f03052 | Digital Input Terminals |  | 
@@ -154,7 +154,7 @@ Description | Driver | EtherCAT VID:PID | Device Type | Testing Status | Notes
 [Beckhoff EM7004 4-Axis Interface Unit](http://www.beckhoff.com/EM7004) | [em7004](../src/devices/lcec_em7004.c) | 0x00000002:0x1b5c3452 | Servo Drive |  | 
 [Beckhoff EP1008-0001 8 Ch. Dig. Input 24V, 3ms, M8](https://www.beckhoff.com/EP1008-0001) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x00000002:0x03f04052 | Digital Input | Uncertain; @scottlaird has several | 
 [Beckhoff EP1018-0001 8 Ch. Dig. Input 24V, 10µs, M8](https://www.beckhoff.com/EP1018-0001) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x00000002:0x03fa4052 | Digital Input | Uncertain; @scottlaird has several | 
-[Beckhoff EP1122-0001 2 port EtherCAT junction](https://www.beckhoff.com/EP1122-0001) | [ek1100](../src/devices/lcec_ek1100.c) | 0x00000002:0x04624052 | System Terminals |  | Passive device
+[Beckhoff EP1122-0001 2 port EtherCAT junction](https://www.beckhoff.com/EP1122-0001) | [passive](../src/devices/lcec_passive.c) | 0x00000002:0x04624052 | System Terminals |  | Passive device
 [Beckhoff EP1819-0005 16 Ch. Dig. Input 24V, 10µs, M8 4pol](https://www.beckhoff.com/EP1819) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x00000002:0x071b4052 | Digital Input |  | 
 [Beckhoff EP2008-0001 8 Ch. Dig. Output 24V, 0,5A, M8](https://www.beckhoff.com/EP2008-0001) | [el2xxx](../src/devices/lcec_el2xxx.c) | 0x00000002:0x07d84052 | Digital Output |  | 
 [Beckhoff EP2028-0001 8 Ch. Dig. Output 24V, 2A, M8](https://www.beckhoff.com/EP2028-0001) | [el2xxx](../src/devices/lcec_el2xxx.c) | 0x00000002:0x07ec4052 | Digital Output |  | 

--- a/documentation/devices/EK1100.yml
+++ b/documentation/devices/EK1100.yml
@@ -7,5 +7,5 @@ Description: Beckhoff EK1100 EtherCAT Coupler (0.5A E-Bus)
 DocumentationURL: http://www.beckhoff.com/EK1100
 DeviceType: System Terminals
 Notes: "Passive device"
-SrcFile: src/devices/lcec_ek1100.c
 TestingStatus: "Part of @scottlaird's test suite."
+SrcFile: src/devices/lcec_passive.c

--- a/documentation/devices/EK1101.yml
+++ b/documentation/devices/EK1101.yml
@@ -7,5 +7,5 @@ Description: Beckhoff EK1101 EtherCAT Coupler (2A E-Bus, ID switch)
 DocumentationURL: http://www.beckhoff.com/EK1101
 DeviceType: System Terminals
 Notes: "Passive device"
-SrcFile: src/devices/lcec_ek1100.c
 TestingStatus: ""
+SrcFile: src/devices/lcec_passive.c

--- a/documentation/devices/EK1110.yml
+++ b/documentation/devices/EK1110.yml
@@ -7,5 +7,5 @@ Description: Beckhoff EK1110 EtherCAT extension
 DocumentationURL: http://www.beckhoff.com/EK1110
 DeviceType: System Terminals
 Notes: "Passive device"
-SrcFile: src/devices/lcec_ek1100.c
 TestingStatus: "Part of @scottlaird's test suite"
+SrcFile: src/devices/lcec_passive.c

--- a/documentation/devices/EK1122.yml
+++ b/documentation/devices/EK1122.yml
@@ -7,5 +7,5 @@ Description: Beckhoff EK1122 2 port EtherCAT junction
 DocumentationURL: http://www.beckhoff.com/EK1122
 DeviceType: System Terminals
 Notes: "Passive device"
-SrcFile: src/devices/lcec_ek1100.c
 TestingStatus: ""
+SrcFile: src/devices/lcec_passive.c

--- a/documentation/devices/EP1122.yml
+++ b/documentation/devices/EP1122.yml
@@ -7,5 +7,5 @@ Description: Beckhoff EP1122-0001 2 port EtherCAT junction
 DocumentationURL: https://www.beckhoff.com/EP1122-0001
 DeviceType: System Terminals
 Notes: "Passive device"
-SrcFile: src/devices/lcec_ek1100.c
 TestingStatus: ""
+SrcFile: src/devices/lcec_passive.c

--- a/src/devices/lcec_passive.c
+++ b/src/devices/lcec_passive.c
@@ -1,0 +1,35 @@
+//
+//    Copyright (C) 2023 Scott Laird <scott@sigkill.org>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "lcec.h"
+#include "lcec_passive.h"
+
+static lcec_typelinkedlist_t *typeslist = NULL;
+
+static lcec_typelist_t types[] = {
+  // bus coupler, no actual driver.
+  { "EK1100", LCEC_EK1100_VID, LCEC_EK1100_PID, LCEC_EK1100_PDOS, 0, NULL, NULL},
+  { "EK1101", LCEC_EK1100_VID, LCEC_EK1101_PID, LCEC_EK1101_PDOS, 0, NULL, NULL},
+  { "EK1110", LCEC_EK1100_VID, LCEC_EK1110_PID, LCEC_EK1110_PDOS, 0, NULL, NULL},
+  { "EK1122", LCEC_EK1100_VID, LCEC_EK1122_PID, LCEC_EK1122_PDOS, 0, NULL, NULL},
+  { "EP1122", LCEC_EK1100_VID, LCEC_EP1122_PID, LCEC_EP1122_PDOS, 0, NULL, NULL},
+
+  { NULL }
+};
+
+ADD_TYPES(types);

--- a/src/devices/lcec_passive.h
+++ b/src/devices/lcec_passive.h
@@ -15,8 +15,8 @@
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 //
-#ifndef _LCEC_EK1100_H_
-#define _LCEC_EK1100_H_
+#ifndef _LCEC_PASSIVE_H_
+#define _LCEC_PASSIVE_H__
 
 #define LCEC_EK1100_VID  LCEC_BECKHOFF_VID
 #define LCEC_EK1100_PID  0x044C2C52

--- a/src/lcec_devicelist.c
+++ b/src/lcec_devicelist.c
@@ -17,20 +17,8 @@
 //
 
 #include "lcec.h"
-#include "devices/lcec_ek1100.h"
 
 static lcec_typelinkedlist_t *typeslist = NULL;
-
-static const lcec_typelist_t types[] = {
-  // bus coupler, no actual driver.
-  { "EK1100", LCEC_EK1100_VID, LCEC_EK1100_PID, LCEC_EK1100_PDOS, 0, NULL, NULL},
-  { "EK1101", LCEC_EK1100_VID, LCEC_EK1101_PID, LCEC_EK1101_PDOS, 0, NULL, NULL},
-  { "EK1110", LCEC_EK1100_VID, LCEC_EK1110_PID, LCEC_EK1110_PDOS, 0, NULL, NULL},
-  { "EK1122", LCEC_EK1100_VID, LCEC_EK1122_PID, LCEC_EK1122_PDOS, 0, NULL, NULL},
-  { "EP1122", LCEC_EK1100_VID, LCEC_EP1122_PID, LCEC_EP1122_PDOS, 0, NULL, NULL},
-
-  { NULL }
-};
 
 // Add a single slave type to the `typeslist` linked-list, so it can
 // be looked up by name.
@@ -70,16 +58,8 @@ void lcec_addtypes(lcec_typelist_t types[]) {
 
 // Find a slave type by name.
 const lcec_typelist_t *lcec_findslavetype(const char *name) {
-  const lcec_typelist_t *type;
   lcec_typelinkedlist_t *tl;
-  
-  // Look in the old-stype types[] array
-  for (type = types; type->name != NULL && strcmp(type->name, name); type++);
-  if (type->name != NULL) {
-    return type;
-  }
-  
-  // Look in the newer typeslist linked-list
+
   for (tl = typeslist; tl != NULL && tl->type != NULL && strcmp(tl->type->name, name) ; tl=tl->next);
   
   if (tl != NULL) {


### PR DESCRIPTION
This lets me move EK1100 and friends out of `lcec_devicelist.c`, which lets me delete the last remnants of `types[]` in that file.

This is intended to  be used for passive Ethercat devices, where we want to be able to list them in `ethercat.xml` for whatever reason, but they don't actually have PDOs or do anything.  We probably shouldn't have added the EKxxxx devices in the first place, but they're there now, and this should be cleaner.