### PR TITLE
build: Fix clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: configure
 	@$(MAKE) -C src all
 
-clean:
+clean: config.mk
 	@$(MAKE) -C src clean
 	rm -f config.mk config.mk.tmp
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 all: configure
 	@$(MAKE) -C src all
 
-clean: config.mk
-	@$(MAKE) -C src clean
+clean:
+	@$(MAKE) -C src -f Makefile.clean clean
 	rm -f config.mk config.mk.tmp
 
 install: configure

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,9 @@
 all: all-deps realtime user
-.PHONY: all all-deps install clean install-user install-realtime user realtime
+.PHONY: all all-deps install install-user install-realtime user realtime
 
 -include ../config.mk
 -include $(MODINC)
+include Makefile.clean
 
 RTLDFLAGS += -Wl,-rpath,$(LIBDIR)
 RTEXTRA_LDFLAGS += -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -L$(LIBDIR) -llinuxcnchal -lethercat -lrt
@@ -71,15 +72,6 @@ liblcecdevices.a: $(device-objs)
 # This throws a warning about ignoring the old recipe for the target.
 install: install-user install-realtime
 	true  # override 'install' from $(MODINC)
-
-clean:
-	rm -f *.so *.ko *.o *.a devices/*.o devices/*.a
-	rm -f *.d devices/*.d
-	rm -f *.sym *.tmp *.ver
-	rm -f *.mod.c .*.cmd
-	rm -f modules.order Module.symvers
-	rm -rf .tmp_versions
-	rm -f lcec_conf
 
 realtime: lcec.so
 user: lcec_conf

--- a/src/Makefile.clean
+++ b/src/Makefile.clean
@@ -1,0 +1,12 @@
+.PHONY: clean
+
+clean:
+	rm -f *.so *.ko *.o *.a devices/*.o devices/*.a
+	rm -f *.d devices/*.d
+	rm -f *.sym *.tmp *.ver
+	rm -f *.mod.c .*.cmd
+	rm -f modules.order Module.symvers
+	rm -rf .tmp_versions
+	rm -f lcec_conf
+
+


### PR DESCRIPTION
Running `make clean` on an already cleaned working dir fails because config.mk cannot be found.

```
root@8579ec95b724:/linuxcnc-ethercat# dpkg-buildpackage -us -uc
dpkg-buildpackage: info: source package linuxcnc-ethercat
dpkg-buildpackage: info: source version 0.9.16
dpkg-buildpackage: info: source distribution unstable
dpkg-buildpackage: info: source changed by Scott Laird <scott@sigkill.org>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 debian/rules clean
dh clean 
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_auto_clean
dh_auto_clean: warning: Compatibility levels before 10 are deprecated (level 9 in use)
        make -j1 clean
make[1]: Entering directory '/linuxcnc-ethercat'
make[2]: Entering directory '/linuxcnc-ethercat/src'
make[3]: Entering directory '/linuxcnc-ethercat/src/devices'
Makefile:1: ../../config.mk: No such file or directory
make[3]: *** No rule to make target '../../config.mk'.  Stop.
make[3]: Leaving directory '/linuxcnc-ethercat/src/devices'
make[2]: *** [Makefile:16: clean] Error 2
make[2]: Leaving directory '/linuxcnc-ethercat/src'
make[1]: *** [Makefile:7: clean] Error 2
make[1]: Leaving directory '/linuxcnc-ethercat'
dh_auto_clean: error: make -j1 clean returned exit code 2
make: *** [debian/rules:13: clean] Error 255
dpkg-buildpackage: error: debian/rules clean subprocess returned exit status 2
```