### PR TITLE
fix(generic): Un-break generic in lcec_conf

### DIFF
--- a/src/devices/lcec_generic.c
+++ b/src/devices/lcec_generic.c
@@ -19,6 +19,13 @@
 #include "../lcec.h"
 #include "lcec_generic.h"
 
+
+static const lcec_typelist_t types[] = {
+    {"generic", 0, 0, 0, 0, NULL, lcec_generic_init },
+    {NULL},
+};
+ADD_TYPES(types);
+
 void lcec_generic_read(struct lcec_slave *slave, long period);
 void lcec_generic_write(struct lcec_slave *slave, long period);
 
@@ -26,6 +33,8 @@ hal_s32_t lcec_generic_read_s32(uint8_t *pd, lcec_generic_pin_t *hal_data);
 hal_u32_t lcec_generic_read_u32(uint8_t *pd, lcec_generic_pin_t *hal_data);
 void lcec_generic_write_s32(uint8_t *pd, lcec_generic_pin_t *hal_data, hal_s32_t sval);
 void lcec_generic_write_u32(uint8_t *pd, lcec_generic_pin_t *hal_data, hal_u32_t uval);
+
+
 
 int lcec_generic_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs) {
   lcec_master_t *master = slave->master;

--- a/tests/haltest.sh
+++ b/tests/haltest.sh
@@ -126,9 +126,10 @@ fi
 
 # This doesn't really *do* anything, but it's reasonable to verify
 # that it's in a sane state.
-echo "=== Testing initial config of D0 (EK1100)"
-test-pin-true D0 slave-online
-test-slave-oper D0
+
+#echo "=== Testing initial config of D0 (EK1100)"
+#test-pin-true D0 slave-online
+#test-slave-oper D0
 
 
 echo "=== Testing initial config of D1 (EL1008)"

--- a/tests/test2.xml
+++ b/tests/test2.xml
@@ -1,6 +1,6 @@
 <masters>
   <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000">
-    <slave idx="0" type="EK1100" name="D0"/>
+    <slave idx="0" type="generic" name="D0"/>
     <slave idx="1" type="EL1018" name="D1"/>
     <slave idx="2" type="EL1018" name="D2"/>
     <slave idx="3" type="EL2008" name="D3"/>


### PR DESCRIPTION
Oops.

Issue #115 