### PR TITLE
fix(el5032): Add additional hardware

### DIFF
--- a/src/devices/lcec_el5032.c
+++ b/src/devices/lcec_el5032.c
@@ -23,6 +23,8 @@ static int lcec_el5032_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
 
 static lcec_typelist_t types[]={
   { "EL5032", LCEC_BECKHOFF_VID, 0x13a83052, LCEC_EL5032_PDOS, 0, NULL, lcec_el5032_init},
+  { "EL5042", LCEC_BECKHOFF_VID, 0x13b23052, LCEC_EL5032_PDOS, 0, NULL, lcec_el5032_init},
+  { "EJ5042", LCEC_BECKHOFF_VID, 0x13b22852, LCEC_EL5032_PDOS, 0, NULL, lcec_el5032_init},
   { NULL },
 };
 ADD_TYPES(types);


### PR DESCRIPTION
This adds additional EJ, EP, and EPP hardware with identical PDOs to
existing el[56]* drivers.

Issue #127