### PR TITLE
fix(el5151): Add additional hardware

### DIFF
--- a/src/devices/lcec_el5151.c
+++ b/src/devices/lcec_el5151.c
@@ -23,6 +23,7 @@ static int lcec_el5151_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
 
 static lcec_typelist_t types[]={
   { "EL5151", LCEC_BECKHOFF_VID, 0x141f3052, LCEC_EL5151_PDOS, 0, NULL, lcec_el5151_init},
+  { "EJ5151", LCEC_BECKHOFF_VID, 0x141f2852, LCEC_EL5151_PDOS, 0, NULL, lcec_el5151_init},
   { NULL },
 };
 ADD_TYPES(types);


### PR DESCRIPTION
This adds additional EJ, EP, and EPP hardware with identical PDOs to
existing el[56]* drivers.

Issue #127