### PR TITLE
fix(el6090): Add additional hardware

### DIFF
--- a/src/devices/lcec_el6090.c
+++ b/src/devices/lcec_el6090.c
@@ -28,6 +28,8 @@ static int lcec_el6090_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
 
 static lcec_typelist_t types[]={
   { "EL6090", LCEC_BECKHOFF_VID, 0x17ca3052, LCEC_EL6090_PDOS, 0, NULL, lcec_el6090_init},
+  { "EP6090", LCEC_BECKHOFF_VID, 0x17ca4052, LCEC_EL6090_PDOS, 0, NULL, lcec_el6090_init},
+  { "EPP6090", LCEC_BECKHOFF_VID, 0x647742a9, LCEC_EL6090_PDOS, 0, NULL, lcec_el6090_init},
   { NULL },
 };
 ADD_TYPES(types);


### PR DESCRIPTION
This adds additional EJ, EP, and EPP hardware with identical PDOs to
existing el[56]* drivers.

Issue #127