### PR TITLE
feat(el7041): Add modparams for stepper config settings

### DIFF
--- a/documentation/el7041.md
+++ b/documentation/el7041.md
@@ -1,0 +1,86 @@
+# Driver for Beckhoff EL7041 Stepper Controllers
+
+The [`lcec_el7041`](../src/devices/lcec_el7041.c) driver supports
+Bekchoff's [EL7041](http://beckhoff.com/EL7041) EtherCAT stepper
+driver as well as a couple close relatives.  There is also a
+`lcec_el70x1` driver that overlaps somewhat.  These two drivers will
+probably be unified in the near future.
+
+## How to configure an EL7041 in LinuxCNC-Ethercat
+
+To use an EL7041, you will need to add a line to your `ethercat.xml` file to tell LinuxCNC about the module.  This should look like this:
+
+
+```xml
+<masters>
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
+    ...
+
+    <slave idx="5" type="EL7041" name="X"/>
+
+    ...
+  </master>
+</masters>
+```
+
+The index number (`5`, above) needs to match the slave ID of your
+EL7041; run `ethercat slaves` if you don't know its ID.  The name
+provided (`X` here) has no special meaning, but it's used in your
+LinuxCNC `hal` config to refer to the stepper, so it's generally a
+good practice to use the name of whichever axis this stepper controls.
+
+In addition, the EL7041 has a number of configuration settings that
+can be controlled via the XML file.  See [Beckhoff's PDF documentation
+for the EL70x1
+family](https://download.beckhoff.com/download/Document/io/ethercat-terminals/el70x1en.pdf#page=226)
+for more in-depth information about each setting.
+
+You can control these by adding `<modParam>` settings under the EL7041's `<slave>` entry:
+
+```xml
+<masters>
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
+    ...
+
+    <slave idx="5" type="EL7041" name="X">
+	  <modParam name="maxCurrent" value="2.5"/>
+	  <modParam name="nominalVoltage" value="48"/>
+	</slave>
+
+    ...
+  </master>
+</masters>
+```
+
+Notice that instead of `<slave ... />`, we now have `<slave ... >
+... </slave>`, without the trailing `/` on the first `<slave/>` tag.
+
+Each `<modParam/>` line has a `name="..."` and a `value="..."` setting.
+
+Supported parameters:
+
+* `maxCurrent`: the maximum current for the stepper.  In Amps.  Default depends on the device, EL7041 defaults to 5.0A.
+* `reducedCurrent`: reduced current for reduced torque.  In Amps.  EL7041 defaults to 2.5A. (Unsupported on `EL7041-1000`)
+* `nominalVoltage`: the nominal voltage of the motor, in Volts.  EL7041 defaults to 50.0V
+* `coilResistance`: the internal resistance of a motol coil, in Ohms.  EL7041 defaults to 1.0 Ohm. (Unsupported on `EL7041-1000`)
+* `motorEMF`: Motor countervoltage, in V/(rad/S).  Defaults to 0. (Unsupported on `EL7041-1000`)
+* `motorFullsteps`: number of motor steps per full revolution.  Defaults to 200.
+* `encoderIncrements`: number of encoder increments per revolution.
+* `startVelocity`: Maximum possible start velocity of the motor.  Unit unknown, default varies.
+* `driveOnDelay`: Switch-on delay of the driver stage, in ms.  Defaults to 100ms.
+* `driveOffDelay`: Switch-off delay of the driver stage, in ms.  Defaults to 150ms.
+* `maxSpeed`: maximum supported speed in full steps/second.  1000, 2000, 4000, 8000, 16000, or 32000.   (Unsupported on `EL7041-1000`)
+* `encoder`: `true` if an encoder is connected.  The EL7041 will report "fake" encoder data if this is not set.
+* `microsteps`: Number of microsteps used.  Valid values are 1, 2, 4, 8, 16, 32, or 64. (*Only* supported on `EL7041-1000`)
+
+Note that not all hardware will support all of these parameters.
+Attempting to set a parameter that the hardware does not support will
+cause LinuxCNC to fail to start and report an error message.  Check
+`ethercat sdos` to see which SDOs your hardware supports.
+
+
+## How to file a bug
+
+See
+[gitub.com/linuxcnc-ethercat/linuxcnc-ethercat](https://github.com/linuxcnc-ethercat/linuxcnc-ethercat/issues)
+for view existing bugs and file new issues.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -16,3 +16,4 @@
 ## Device-specific documentation
 
 - [EL3xxx: Beckhoff analog I/O devices](el3xxx.md)
+- [EL7041: Beckhoff EL7041 Stepper driver](el7041.md)

--- a/src/devices/lcec_el7041.h
+++ b/src/devices/lcec_el7041.h
@@ -25,8 +25,6 @@
 
 #include "../lcec.h"
 
-#define LCEC_EL7041_PDOS      34
-#define LCEC_EL7041_1000_PDOS 34
-#define LCEC_EP7041_PDOS      34
+#define LCEC_EL7041_PDOS 34
 
 #endif

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -293,6 +293,9 @@ typedef struct {
 
 int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size);
 int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size);
+int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size);
+int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value);
+int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value);
 
 int lcec_pin_newf(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_addr, const char *fmt, ...);
 int lcec_pin_newf_list(void *base, const lcec_pindesc_t *list, ...);

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -124,6 +124,82 @@ int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, ui
   return 0;
 }
 
+/// @brief Write an SDO configuration to a slave device.
+///
+/// This writes an SDO config to a specified slave device.  It can
+/// only be called before going into readtime mode as it blocks.  This
+/// sets the SDO in two phases.  First, it calls
+/// `ecrt_master_sdo_download`, which blocks until it's heard back
+/// from the slave.  This way, we can return an error if the SDO that
+/// we're trying to set does not exist.  Then, after that, we call
+/// `ecrt_slave_config_sdo`, which *also* sets the SDO, but does it
+/// asynchronously and saves the value in case the slave is
+/// power-cycled at some point in the future.
+///
+/// We need to call both, because without the call to
+/// `ecrt_master_sdo_download` we can't know if an error occurred, and
+/// without the call to `ecrt_slave_config_sdo` the config will be
+/// lost if the slave reboots.
+///
+/// @param slave The slave.
+/// @param index The SDO index to set (`0x8000` or similar).
+/// @param subindex The SDO sub-index to be set.
+/// @param value A pointer to the value to be set.
+/// @param size The number of bytes to set.
+/// @return 0 for success or -1 for failure.
+int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size) {
+  lcec_master_t *master = slave->master;
+  int err;
+  uint32_t abort_code;
+
+  if ((err = ecrt_master_sdo_download(master->master, slave->index, index, subindex, value, size, &abort_code))) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "slave %s.%s: Failed to execute SDO download (0x%04x:0x%02x, size %d, byte0=%d, error %d, abort_code %08x)\n",
+        master->name, slave->name, index, subindex, (int)size, (int)value[0], err, abort_code);
+    return -1;
+  }
+
+  if (ecrt_slave_config_sdo(slave->config, index, subindex, value, size) != 0) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "slave %s.%s: Failed to configure slave SDO (0x%04x:0x%02x)\n", master->name, slave->name,
+        index, subindex);
+    return -1;
+  }
+
+  return 0;
+}
+
+/// @brief Write an 8-bit SDO configuration to a slave device.
+///
+/// See `lcec_write_sdo` for details.
+///
+/// @param slave The slave.
+/// @param index The SDO index to set (`0x8000` or similar).
+/// @param subindex The SDO sub-index to be set.
+/// @param value An 8-bit value to set.
+/// @return 0 for success or -1 for failure.
+int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value) {
+  uint8_t data[1];
+
+  EC_WRITE_U8(data, value);
+  return lcec_write_sdo(slave, index, subindex, data, 1);
+}
+
+/// @brief Write a 16-bit SDO configuration to a slave device.
+///
+/// See `lcec_write_sdo` for details.
+///
+/// @param slave The slave.
+/// @param index The SDO index to set (`0x8000` or similar).
+/// @param subindex The SDO sub-index to be set.
+/// @param value An 8-bit value to set.
+/// @return 0 for success or -1 for failure.
+int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value) {
+  uint8_t data[2];
+
+  EC_WRITE_U16(data, value);
+  return lcec_write_sdo(slave, index, subindex, data, 2);
+}
+
 /// @brief Read IDN data from a slave device.
 int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size) {
   lcec_master_t *master = slave->master;

--- a/tests/test2.xml
+++ b/tests/test2.xml
@@ -93,7 +93,20 @@
 <!--    <slave idx="17" type="EL9410" name="D17"/> -->
     <slave idx="18" type="EL1859" name="D18"/>
     <slave idx="19" type="EL4032" name="D19"/>
-    <slave idx="20" type="EL7041" name="D20"/>
+    <slave idx="20" type="EL7041" name="D20">
+      <modParam name="maxCurrent" value="1.0"/>
+      <!--<modParam name="reducedCurrent" value="0.8"/>-->
+      <modParam name="nominalVoltage" value="24"/>
+      <modParam name="encoder" value="true"/>
+      <!-- <modParam name="coilResistance" value="1.0"/> -->
+      <!-- <modParam name="motorEMF" value="0"/> -->
+      <modParam name="encoderIncrements" value="4000"/>
+      <modParam name="startVelocity" value="100"/>
+      <modParam name="driveOnDelay" value="100"/>
+      <modParam name="driveOffDelay" value="150"/>
+      <!-- <modParam name="maxSpeed" value="4000"/> -->
+      <modParam name="microsteps" value="16"/>
+    </slave>
     <slave idx="21" type="EK1110" name="D21"/>
     <slave idx="22" type="EP2308" name="D22"/>
   </master>


### PR DESCRIPTION
The goal here is to be able to control all of the settings for the EL7041 via `<modParams>` and not need explicit SDO tweaking.

Also includes the start at EL7041 documentation.

This includes a fix for #243.  It adds a set of `lcec_write_sdo()` functions that will fail fast when the SDO isn't correct.  The same basic fix will need to be applied to other users of `ecrt_slave_config_sdo*`.