### PR TITLE
refactor: create lcec_class_din and move el1xxx to use it

### DIFF
--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -1,0 +1,91 @@
+//
+//    Copyright (C) 2024 Scott Laird <scott@sigkill.org>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "lcec_class_din.h"
+
+#include "../lcec.h"
+
+static const lcec_pindesc_t slave_pins[] = {
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_pin_t, in), "%s.%s.%s.din-%d"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_pin_t, in_not), "%s.%s.%s.din-%d-not"},
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
+
+// lcec_din_allocate_pins returns a block of memory for holding the
+// result of `count` calls to `lcec_din_register_device()`.  It is the
+// caller's responsibility to verify that the result is not NULL.
+lcec_class_din_pin_t **lcec_din_allocate_pins(int count) {
+  return hal_malloc(sizeof(lcec_class_din_pin_t *)*count);
+}
+
+// lcec_din_register_pin registers a single digital-input channel and publishes it as a LinuxCNC HAL pin.
+//
+// Parameters:
+//
+// - pdo_entry_regs: a pointer to the pdo_entry_regs passed into the device `_init` function.
+// - slave: the slave, from `_init`.
+// - id: the pin ID.  Used for naming.  Should generally start at 0 and increment once per digital in pin.
+// - idx: the PDO index for the digital input.
+// - sindx: the PDO sub-index for the digital input.
+//
+// See lcec_el1xxx.c for an example of use.
+lcec_class_din_pin_t *lcec_din_register_pin(ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx) {
+  lcec_class_din_pin_t *data;
+  int err;
+  
+  data = hal_malloc(sizeof(lcec_class_din_pin_t));
+  if (data == NULL) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
+    return NULL;
+  }
+  memset(data, 0, sizeof(lcec_class_din_pin_t));
+  //data->idx = idx;
+  //data->sidx = sidx;
+  
+  LCEC_PDO_INIT((*pdo_entry_regs), slave->index, slave->vid, slave->pid, idx, sidx, &data->pdo_os, &data->pdo_bp);
+  err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, id);
+  if (err != 0) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
+    return NULL;
+  }
+
+  return data;
+}
+
+// lcec_din_read reads data from a digital in port.
+//
+// Parameters:
+//
+// - slave: the slave, passed from the per-device `_read`.
+// - data: a lcec_class_din_pin_t *, as returned by lcec_din_register_pin.
+//
+// Call this once per pin registered, from inside of your device's
+// read function.
+void lcec_din_read(struct lcec_slave *slave, lcec_class_din_pin_t *data) {
+  lcec_master_t *master = slave->master;
+  uint8_t *pd = master->process_data;
+  int s;
+  
+  if (!slave->state.operational) {
+    return ;
+  }
+
+  s = EC_READ_BIT(&pd[data->pdo_os],data->pdo_bp);
+  *(data->in) = s;
+  *(data->in_not) = !s;
+}

--- a/src/devices/lcec_class_din.h
+++ b/src/devices/lcec_class_din.h
@@ -1,0 +1,29 @@
+//
+//    Copyright (C) 2024 Scott Laird <scott@sigkill.org>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include "../lcec.h"
+
+typedef struct {
+  hal_bit_t *in;
+  hal_bit_t *in_not;
+  unsigned int pdo_os, pdo_bp;
+} lcec_class_din_pin_t;
+
+lcec_class_din_pin_t **lcec_din_allocate_pins(int count);
+lcec_class_din_pin_t *lcec_din_register_pin(ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
+void lcec_din_read(struct lcec_slave *slave, lcec_class_din_pin_t *data);


### PR DESCRIPTION
This creates a generic `lcec_class_din` with 3 function that can be used to implement a generic digital-input pin given a slave and PDO.  The API doesn't currently give any way to change the names of pins, other than an integer provided.  So, you can have `lcec.0.XX.din-0`, but you can't currently have `lcec.0.XX.sparkly-din-0`.  It'd be easy enough to add (add a new variant of `lcec_din_register_pin` that takes a name, and then reimplement `lcec_din_register_pin` in terms of the new function.

This moves `lcec_el1xxx.c` to use the new framework.  It's not a giant win here, but it'll make implementing random in/out devices (like the EK1814 and some of the EP modules, which *love* to put digital in/outs on random unused M12 pins) cleaner.

Issue: #42 