### PR TITLE
refactor: move el1252 driver to use class_din

### DIFF
--- a/documentation/DEVICES.md
+++ b/documentation/DEVICES.md
@@ -41,7 +41,7 @@ Description | Driver | EtherCAT VID:PID | Device Type | Testing Status | Notes
 [Beckhoff EL1124 4Ch. Dig. Input 5V, 10µs, Sensor Power](http://www.beckhoff.com/EL1124) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x2:0x04643052 | Digital Input |  | 
 [Beckhoff EL1134 4Ch. Dig. Input 48V, 10µs, Sensor Power](http://www.beckhoff.com/EL1134) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x2:0x046e3052 | Digital Input |  | 
 [Beckhoff EL1144 4Ch. Dig. Input 12V, 10µs, Sensor Power](http://www.beckhoff.com/EL1144) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x2:0x04783052 | Digital Input |  | 
-[Beckhoff EL1252 2Ch. Fast Dig. Input 24V, 1µs, DC Latch](http://www.beckhoff.com/EL1252) | [el1252](../src/devices/lcec_el1252.c) | 0x2:0x04e43052 | Digital Input |  | 
+[Beckhoff EL1252 2Ch. Fast Dig. Input 24V, 1µs, DC Latch](http://www.beckhoff.com/EL1252) | [el1252](../src/devices/lcec_el1252.c) | 0x2:0x04e43052 | Digital Input |  | Driver does not support hardware timestamping
 [Beckhoff EL1804 4Ch. Dig. Input 24V, 3ms](http://www.beckhoff.com/EL1804) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x2:0x070c3052 | Digital Input |  | 
 [Beckhoff EL1808 8Ch. Dig. Input 24V, 3ms](http://www.beckhoff.com/EL1808) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x2:0x07103052 | Digital Input | Uncertain; @scottlaird has one | 
 [Beckhoff EL1809 16Ch. Dig. Input 24V, 3ms](http://www.beckhoff.com/EL1809) | [el1xxx](../src/devices/lcec_el1xxx.c) | 0x2:0x07113052 | Digital Input |  | 

--- a/documentation/devices/EL1252.yml
+++ b/documentation/devices/EL1252.yml
@@ -6,6 +6,6 @@ PID: "0x04e43052"
 Description: Beckhoff EL1252 2Ch. Fast Dig. Input 24V, 1µs, DC Latch
 DocumentationURL: http://www.beckhoff.com/EL1252
 DeviceType: Digital Input
-Notes: ""
+Notes: "Driver does not support hardware timestamping"
 SrcFile: src/devices/lcec_el1252.c
 TestingStatus: ""

--- a/src/devices/lcec_el1252.c
+++ b/src/devices/lcec_el1252.c
@@ -31,159 +31,47 @@
 
       http://www.beckhoff.com/english.asp?EtherCAT/el1252.htm */
 
-#include "../lcec.h"
 #include "lcec_el1252.h"
+
+#include "../lcec.h"
+#include "lcec_class_din.h"
 
 static int lcec_el1252_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs);
 
-static lcec_typelist_t types[]={
-  { "EL1252", LCEC_BECKHOFF_VID, 0x04E43052, LCEC_EL1252_PDOS, 0, NULL, lcec_el1252_init},  // 2 fast channels with timestamp
-  { NULL },
+static lcec_typelist_t types[] = {
+    {"EL1252", LCEC_BECKHOFF_VID, 0x04E43052, LCEC_EL1252_PDOS, 0, NULL, lcec_el1252_init},  // 2 fast channels with timestamp
+    {NULL},
 };
 ADD_TYPES(types);
 
-/* Master 0, Slave 1, "EL1252"
- * Vendor ID:       0x00000002
- * Product code:    0x04e43052
- * Revision number: 0x00120000
- */
-
-/*
-SM0: PhysAddr 0x1000, DefaultSize    1, ControlRegister 0x22, Enable 1
-  TxPDO 0x1a00 "Channel 1"
-    PDO entry 0x6000:01,  1 bit, "Input"
-  TxPDO 0x1a01 "Channel 2"
-    PDO entry 0x6000:02,  1 bit, "Input"
-    PDO entry 0x0000:00,  6 bit, ""
-  TxPDO 0x1a02 "Reserved"
-SM1: PhysAddr 0x09ae, DefaultSize    0, ControlRegister 0x00, Enable 4
-  TxPDO 0x1a13 "Latch"
-    PDO entry 0x1d09:ae,  8 bit, "Status1"
-    PDO entry 0x1d09:af,  8 bit, "Status2"
-    PDO entry 0x1d09:b0, 64 bit, "LatchPos1"
-    PDO entry 0x1d09:b8, 64 bit, "LatchNeg1"
-    PDO entry 0x1d09:c0, 64 bit, "LatchPos2"
-    PDO entry 0x1d09:c8, 64 bit, "LatchNeg2"
-SM2: PhysAddr 0x0910, DefaultSize    0, ControlRegister 0x00, Enable 4
-*/
-
-ec_pdo_entry_info_t lcec_el1252_entries[] = {
-//   Index,  SIndx,Len
-    {0x6000, 0x01, 1},  /* Input */
-    {0x6000, 0x02, 1},  /* Input */
-    {0x0000, 0x00, 6},  /* gap */
-    {0x1d09, 0xae, 8},  /* Status1 */
-    {0x1d09, 0xaf, 8},  /* Status2 */
-    {0x1d09, 0xb0, 64}, /* LatchPos1 */
-    {0x1d09, 0xb8, 64}, /* LatchNeg1 */
-    {0x1d09, 0xc0, 64}, /* LatchPos2 */
-    {0x1d09, 0xc8, 64}, /* LatchNeg2 */
-};
-
-ec_pdo_info_t lcec_el1252_pdos[] = {
-//   Index,  n.PDOs, array of PDO entries
-    {0x1a00, 1, lcec_el1252_entries + 0}, /* Channel 1 */
-    {0x1a01, 2, lcec_el1252_entries + 1}, /* Channel 2 */
-    {0x1a02, 0, NULL},                    /* Reserved */
-    {0x1a13, 6, lcec_el1252_entries + 3}, /* Status and Latches */
-};
-
-ec_sync_info_t lcec_el1252_syncs[] = {
-//  Indx, SM direction, n.PDOs, array of PDOs, WD mode
-    {0, EC_DIR_INPUT, 3, lcec_el1252_pdos + 0, EC_WD_DISABLE},
-    {1, EC_DIR_INPUT, 1, lcec_el1252_pdos + 3, EC_WD_DISABLE},
-    {2, EC_DIR_INPUT, 0, NULL, EC_WD_DISABLE},
-    {0xff}
-};
-
-/** \brief data structure of one channel of the device */
-typedef struct {
-  // data exposed as PIN to Linuxcnc/Machinekit
-  hal_bit_t *in;
-  
-  uint8_t    Status;
-  uint64_t   LatchPos;
-  uint64_t   LatchNeg;
-  
-  // OffSets and BitPositions used to access data in EC PDOs
-  unsigned int in_offs;
-  unsigned int in_bitp;
-
-  unsigned int Status_offs;
-  unsigned int LatchPos_offs;
-  unsigned int LatchNeg_offs;
-
-} lcec_el1252_chan_t;
-
-static const lcec_pindesc_t slave_pins[] = {
-  { HAL_BIT, HAL_OUT, offsetof(lcec_el1252_chan_t, in), "%s.%s.%s.din-%d" },
-  { HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL }
-};
-
-/** \brief complete data structure for EL1252 */
-typedef struct {
-  lcec_el1252_chan_t chans[LCEC_EL1252_CHANS];
-} lcec_el1252_data_t;
-
-/** \brief callback for periodic IO data access*/ 
 static void lcec_el1252_read(struct lcec_slave *slave, long period);
 
 static int lcec_el1252_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs) {
-  lcec_master_t *master = slave->master;
-  lcec_el1252_data_t *hal_data;
+  lcec_class_din_pins_t *hal_data;
   int i;
-  lcec_el1252_chan_t *chan;
-  int err;
 
   // initialize callbacks
   slave->proc_read = lcec_el1252_read;
 
-  // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el1252_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
+  hal_data = lcec_din_allocate_pins(2);
+  if (hal_data == NULL) {
     return -EIO;
   }
-  memset(hal_data, 0, sizeof(lcec_el1252_data_t));
   slave->hal_data = hal_data;
 
-  // initializer sync info
-  slave->sync_info = lcec_el1252_syncs;
-
-  for (i=0; i<LCEC_EL1252_CHANS; i++) {
-    chan = &hal_data->chans[i];
-
-    // initialize PDO entries     position      vend.id     prod.code   index   sindx            offset                             bit pos
-    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x6000, 0x01 + i,        &hal_data->chans[i].in_offs,       &hal_data->chans[i].in_bitp);
-    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x1d09, 0xae + i,        &hal_data->chans[i].Status_offs,   NULL);
-    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x1d09, 0xb0 + (i << 4), &hal_data->chans[i].LatchPos_offs, NULL);
-    LCEC_PDO_INIT(pdo_entry_regs, slave->index, slave->vid, slave->pid, 0x1d09, 0xb8 + (i << 4), &hal_data->chans[i].LatchNeg_offs, NULL);
-
-    // export pins
-    if ((err = lcec_pin_newf_list(chan, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {
-      return err;
-    }
+  for (i = 0; i < 2; i++) {
+    hal_data->pins[i] = lcec_din_register_pin(&pdo_entry_regs, slave, i, 0x6000, 0x01 + i);
   }
 
   return 0;
 }
 
 static void lcec_el1252_read(struct lcec_slave *slave, long period) {
-  lcec_master_t *master = slave->master;
-  uint8_t *pd = master->process_data;
-  lcec_el1252_data_t *hal_data = (lcec_el1252_data_t *) slave->hal_data;
-  int i;
-  lcec_el1252_chan_t *chan;
+  lcec_class_din_pins_t *hal_data = (lcec_class_din_pins_t *)slave->hal_data;
 
-  for (i=0; i<LCEC_EL1252_CHANS; i++) {
-    chan = &hal_data->chans[i];
-
-    // read inputs
-    *(chan->in) = EC_READ_BIT(&pd[chan->in_offs], chan->in_bitp);
-
-    /** TODO: do-something with timestamp data! */
-    chan->Status = EC_READ_U8(&pd[chan->Status_offs]);
-    chan->LatchPos = EC_READ_U8(&pd[chan->LatchPos_offs]);
-    chan->LatchNeg = EC_READ_U8(&pd[chan->LatchNeg_offs]);
+  if (!slave->state.operational) {
+    return;
   }
-}
 
+  lcec_din_read_all(slave, hal_data);
+}

--- a/src/devices/lcec_el1252.h
+++ b/src/devices/lcec_el1252.h
@@ -19,13 +19,7 @@
 #ifndef _LCEC_EL1252_H_
 #define _LCEC_EL1252_H_
 
-/** \brief Product Code */
-
-/** \brief Number of channels */
 #define LCEC_EL1252_CHANS 2
+#define LCEC_EL1252_PDOS  LCEC_EL1252_CHANS  // Should match what we register, not what the device publishes.  I think.
 
-/** \brief Number of PDO */
-#define LCEC_EL1252_PDOS (4 * LCEC_EL1252_CHANS)
-
-/** \brief Vendor ID */
 #endif


### PR DESCRIPTION
This moves the EL1252 driver to use the `lcec_class_din` framework from #189.  It removes a bunch of functionality that was never actually finished, including reading timestamps, but the code is *much* less complex now.

Note that the PDO addresses are different from other el1xxx devices.

Issue: #42 
