### PR TITLE
fix(el1859): Fix multiple digital out problems

### DIFF
--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -93,7 +93,7 @@ lcec_class_din_pin_t *lcec_din_register_pin(
 void lcec_din_read(struct lcec_slave *slave, lcec_class_din_pin_t *data) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
-  int s;
+  hal_bit_t s;
 
   s = EC_READ_BIT(&pd[data->pdo_os], data->pdo_bp);
   *(data->in) = s;


### PR DESCRIPTION
Yeah, so it turns out that you can have the world's best test suite, but when you rsync your code into the wrong directory and still run the old code, it doesn't actually do you much good.

There were several problems with digital outputs with this week's `class_dout`:

- The pins were registered as going the wrong direction.
- `invert` was registered as a pin, not a param.
- Because it was a half-pin, half-param, it had about a 50% chance of setting the wrong output value.
- Also, the EL1859's output pins are actually based at 0x7080, not 0x7000, so the EL1859 driver stopped working.  Which is embarrassing, because I have one here.

Anyway, this should fix the known bugs, *and* add a framework for adding the remaining EP23* and EK18* devices.

Issue: #42 