### PR TITLE
refactor: rename din/dout "pin" to "channel"

### DIFF
--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -24,35 +24,35 @@
 #include "../lcec.h"
 
 static const lcec_pindesc_t slave_pins[] = {
-    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_pin_t, in), "%s.%s.%s.din-%d"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_pin_t, in_not), "%s.%s.%s.din-%d-not"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_channel_t, in), "%s.%s.%s.din-%d"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_channel_t, in_not), "%s.%s.%s.din-%d-not"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-/// \brief allocates a block of memory for holding the result of
+/// @brief allocates a block of memory for holding the result of
 /// `count` calls to `lcec_din_register_device()`.
 ///
 /// It is the caller's responsibility to verify that the result is not
 /// NULL.
 ///
 /// @param count The number of input pins to allocate memory for.
-lcec_class_din_pins_t *lcec_din_allocate_pins(int count) {
-  lcec_class_din_pins_t *pins;
+lcec_class_din_channels_t *lcec_din_allocate_channels(int count) {
+  lcec_class_din_channels_t *channels;
 
-  pins = hal_malloc(sizeof(lcec_class_din_pins_t));
-  if (pins == NULL) {
+  channels = hal_malloc(sizeof(lcec_class_din_channels_t));
+  if (channels == NULL) {
     return NULL;
   }
-  pins->count = count;
-  pins->pins = hal_malloc(sizeof(lcec_class_din_pin_t *) * count);
-  if (pins->pins == NULL) {
+  channels->count = count;
+  channels->channels = hal_malloc(sizeof(lcec_class_din_channel_t *) * count);
+  if (channels->channels == NULL) {
     return NULL;
   }
 
-  return pins;
+  return channels;
 }
 
-/// \brief registers a single digital-input channel and publishes it as a LinuxCNC HAL pin.
+/// @brief registers a single digital-input channel and publishes it as a LinuxCNC HAL pin.
 ///
 /// @param pdo_entry_regs a pointer to the pdo_entry_regs passed into the device `_init` function.
 /// @param slave the slave, from `_init`.
@@ -61,17 +61,17 @@ lcec_class_din_pins_t *lcec_din_allocate_pins(int count) {
 /// @param sindx the PDO sub-index for the digital input.
 ///
 /// See lcec_el1xxx.c for an example of use.
-lcec_class_din_pin_t *lcec_din_register_pin(
+lcec_class_din_channel_t *lcec_din_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx) {
-  lcec_class_din_pin_t *data;
+  lcec_class_din_channel_t *data;
   int err;
 
-  data = hal_malloc(sizeof(lcec_class_din_pin_t));
+  data = hal_malloc(sizeof(lcec_class_din_channel_t));
   if (data == NULL) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
     return NULL;
   }
-  memset(data, 0, sizeof(lcec_class_din_pin_t));
+  memset(data, 0, sizeof(lcec_class_din_channel_t));
 
   LCEC_PDO_INIT((*pdo_entry_regs), slave->index, slave->vid, slave->pid, idx, sidx, &data->pdo_os, &data->pdo_bp);
   err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, id);
@@ -86,11 +86,11 @@ lcec_class_din_pin_t *lcec_din_register_pin(
 /// \brief reads data from a single digital in port.
 ///
 /// @param slave the slave, passed from the per-device `_read`.
-/// @param data  a lcec_class_din_pin_t *, as returned by lcec_din_register_pin.
+/// @param data  a lcec_class_din_channel_t *, as returned by lcec_din_register_pin.
 ///
 /// Call this once per pin registered, from inside of your device's
 /// read function.  See `lcec_din_read_all` for an alternative approach.
-void lcec_din_read(struct lcec_slave *slave, lcec_class_din_pin_t *data) {
+void lcec_din_read(struct lcec_slave *slave, lcec_class_din_channel_t *data) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   hal_bit_t s;
@@ -102,12 +102,12 @@ void lcec_din_read(struct lcec_slave *slave, lcec_class_din_pin_t *data) {
 
 /// \brief reads data from all digital in ports.
 ///
-/// @param slave the slave, passed from the per-device `_read`.
-/// @param pins a `lcec_class_din_pins_t *`, as returned by lcec_din_register_pin.
-void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_pins_t *pins) {
-  for (int i = 0; i < pins->count; i++) {
-    lcec_class_din_pin_t *pin = pins->pins[i];
+/// @param slave The slave, passed from the per-device `_read`.
+/// @param channels An `lcec_class_din_channels_t *`, as returned by `lcec_din_allocate_channels()`.
+void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_channels_t *channels) {
+  for (int i = 0; i < channels->count; i++) {
+    lcec_class_din_channel_t *channel = channels->channels[i];
 
-    lcec_din_read(slave, pin);
+    lcec_din_read(slave, channel);
   }
 }

--- a/src/devices/lcec_class_din.h
+++ b/src/devices/lcec_class_din.h
@@ -26,15 +26,15 @@ typedef struct {
   hal_bit_t *in_not; ///< `hal_bit_t` pin for the `din-X-not` pin in LinuxCNC
   unsigned int pdo_os;  ///< This bit's offset in the master's PDO data structure.
   unsigned int pdo_bp;  ///< This bit's bit position in the master's PDO data structure.
-} lcec_class_din_pin_t;
+} lcec_class_din_channel_t;
 
 typedef struct {
-  int count;  ///< The number of pins described by this structure.
-  lcec_class_din_pin_t **pins;  ///< a dynamic array of `lcec_class_din_pin_t` pins.
-} lcec_class_din_pins_t;
+  int count;  ///< The number of channels described by this structure.
+  lcec_class_din_channel_t **channels;  ///< a dynamic array of `lcec_class_din_channel_t` channels.
+} lcec_class_din_channels_t;
 
-lcec_class_din_pins_t *lcec_din_allocate_pins(int count);
-lcec_class_din_pin_t *lcec_din_register_pin(
+lcec_class_din_channels_t *lcec_din_allocate_channels(int count);
+lcec_class_din_channel_t *lcec_din_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
-void lcec_din_read(struct lcec_slave *slave, lcec_class_din_pin_t *data);
-void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_pins_t *pins);
+void lcec_din_read(struct lcec_slave *slave, lcec_class_din_channel_t *data);
+void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_channels_t *channels);

--- a/src/devices/lcec_class_dout.h
+++ b/src/devices/lcec_class_dout.h
@@ -25,15 +25,15 @@ typedef struct {
   hal_bit_t *out;
   hal_bit_t invert;
   unsigned int pdo_os, pdo_bp;
-} lcec_class_dout_pin_t;
+} lcec_class_dout_channel_t;
 
 typedef struct {
   int count;
-  lcec_class_dout_pin_t **pins;
-} lcec_class_dout_pins_t;
+  lcec_class_dout_channel_t **channels;
+} lcec_class_dout_channels_t;
 
-lcec_class_dout_pins_t *lcec_dout_allocate_pins(int count);
-lcec_class_dout_pin_t *lcec_dout_register_pin(
+lcec_class_dout_channels_t *lcec_dout_allocate_channels(int count);
+lcec_class_dout_channel_t *lcec_dout_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
-void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_pin_t *data);
-void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_pins_t *pins);
+void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data);
+void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_channels_t *pins);

--- a/src/devices/lcec_digitalcombo.c
+++ b/src/devices/lcec_digitalcombo.c
@@ -109,8 +109,8 @@ static lcec_typelist_t types[] = {
 ADD_TYPES(types)
 
 typedef struct {
-  lcec_class_din_pins_t *pins_in;
-  lcec_class_dout_pins_t *pins_out;
+  lcec_class_din_channels_t *channels_in;
+  lcec_class_dout_channels_t *channels_out;
 } lcec_digitalcombo_data_t;
 
 static void lcec_digitalcombo_read(struct lcec_slave *slave, long period);
@@ -136,8 +136,8 @@ static int lcec_digitalcombo_init(int comp_id, struct lcec_slave *slave, ec_pdo_
   slave->hal_data = hal_data;
 
   // Allocate memory for I/O pin definitions
-  if (in_channels>0) hal_data->pins_in = lcec_din_allocate_pins(in_channels);
-  if (out_channels>0) hal_data->pins_out = lcec_dout_allocate_pins(out_channels);
+  if (in_channels>0) hal_data->channels_in = lcec_din_allocate_channels(in_channels);
+  if (out_channels>0) hal_data->channels_out = lcec_dout_allocate_channels(out_channels);
 
   // initialize input pins
   for (i = 0; i < in_channels; i++) {
@@ -151,7 +151,7 @@ static int lcec_digitalcombo_init(int comp_id, struct lcec_slave *slave, ec_pdo_
     }
 
     // Create pins
-    hal_data->pins_in->pins[i] = lcec_din_register_pin(&pdo_entry_regs, slave, i, idx, sidx);
+    hal_data->channels_in->channels[i] = lcec_din_register_channel(&pdo_entry_regs, slave, i, idx, sidx);
   }
 
   // initialize output pins
@@ -169,7 +169,7 @@ static int lcec_digitalcombo_init(int comp_id, struct lcec_slave *slave, ec_pdo_
     }
 
     // Create pins
-    hal_data->pins_out->pins[i] = lcec_dout_register_pin(&pdo_entry_regs, slave, i, idx, sidx);
+    hal_data->channels_out->channels[i] = lcec_dout_register_channel(&pdo_entry_regs, slave, i, idx, sidx);
   }
   return 0;
 }
@@ -182,7 +182,7 @@ static void lcec_digitalcombo_read(struct lcec_slave *slave, long period) {
     return;
   }
 
-  if (hal_data->pins_in != NULL) lcec_din_read_all(slave, hal_data->pins_in);
+  if (hal_data->channels_in != NULL) lcec_din_read_all(slave, hal_data->channels_in);
 }
 
 static void lcec_digitalcombo_write(struct lcec_slave *slave, long period) {
@@ -193,5 +193,5 @@ static void lcec_digitalcombo_write(struct lcec_slave *slave, long period) {
     return;
   }
 
-  if (hal_data->pins_out != NULL) lcec_dout_write_all(slave, hal_data->pins_out);
+  if (hal_data->channels_out != NULL) lcec_dout_write_all(slave, hal_data->channels_out);
 }

--- a/src/devices/lcec_el1xxx.c
+++ b/src/devices/lcec_el1xxx.c
@@ -59,28 +59,28 @@ ADD_TYPES(types)
 static void lcec_el1xxx_read(struct lcec_slave *slave, long period);
 
 static int lcec_el1xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs) {
-  lcec_class_din_pins_t *hal_data;
+  lcec_class_din_channels_t *hal_data;
   int i;
 
   // initialize callbacks
   slave->proc_read = lcec_el1xxx_read;
 
-  hal_data = lcec_din_allocate_pins(slave->pdo_entry_count);
+  hal_data = lcec_din_allocate_channels(slave->pdo_entry_count);
   if (hal_data == NULL) { return -EIO; }
   slave->hal_data = hal_data;
 
-  // initialize pins
+  // initialize channels
   for (i = 0; i < slave->pdo_entry_count; i++) {
-    hal_data->pins[i]=lcec_din_register_pin(&pdo_entry_regs, slave, i, 0x6000 + (i<<4), 0x01);
+    hal_data->channels[i]=lcec_din_register_channel(&pdo_entry_regs, slave, i, 0x6000 + (i<<4), 0x01);
 
-    if (hal_data->pins[i]==NULL) { return -EIO; }
+    if (hal_data->channels[i]==NULL) { return -EIO; }
   }
 
   return 0;
 }
 
 static void lcec_el1xxx_read(struct lcec_slave *slave, long period) {
-  lcec_class_din_pins_t *hal_data = (lcec_class_din_pins_t *)slave->hal_data;
+  lcec_class_din_channels_t *hal_data = (lcec_class_din_channels_t *)slave->hal_data;
 
   // wait for slave to be operational
   if (!slave->state.operational) {

--- a/src/devices/lcec_el2xxx.c
+++ b/src/devices/lcec_el2xxx.c
@@ -55,28 +55,28 @@ ADD_TYPES(types);
 static void lcec_el2xxx_write(struct lcec_slave *slave, long period);
 
 static int lcec_el2xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs) {
-  lcec_class_dout_pins_t *hal_data;
+  lcec_class_dout_channels_t *hal_data;
   int i;
 
   // initialize callbacks
   slave->proc_write = lcec_el2xxx_write;
 
-  hal_data = lcec_dout_allocate_pins(slave->pdo_entry_count);
+  hal_data = lcec_dout_allocate_channels(slave->pdo_entry_count);
   if (hal_data == NULL) {
     return -EIO;
   }
   slave->hal_data = hal_data;
 
-  // initialize pins
+  // initialize channels
   for (i = 0; i < slave->pdo_entry_count; i++) {
-    hal_data->pins[i] = lcec_dout_register_pin(&pdo_entry_regs, slave, i, 0x7000 + (i << 4), 0x01);
+    hal_data->channels[i] = lcec_dout_register_channel(&pdo_entry_regs, slave, i, 0x7000 + (i << 4), 0x01);
   }
 
   return 0;
 }
 
 static void lcec_el2xxx_write(struct lcec_slave *slave, long period) {
-  lcec_class_dout_pins_t *hal_data = (lcec_class_dout_pins_t *)slave->hal_data;
+  lcec_class_dout_channels_t *hal_data = (lcec_class_dout_channels_t *)slave->hal_data;
 
   if (!slave->state.operational) {
     return;


### PR DESCRIPTION
Just a cleanup, keeping nomenclature clean before it becomes more widely used.