### PR TITLE
fix: Add SDO error handling

### DIFF
--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -184,7 +184,7 @@ static int lcec_deasda_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   slave->hal_data = hal_data;
 
   // set to cyclic synchronous velocity mode
-  if (ecrt_slave_config_sdo8(slave->config, 0x6060, 0x00, 9) != 0) {
+  if (lcec_write_sdo8(slave, 0x6060, 0x00, 9) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo velo mode\n", master->name, slave->name);
   }
 
@@ -192,10 +192,10 @@ static int lcec_deasda_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   tu = master->app_time_period;
   ti = -9;
   while ((tu % 10) == 0 || tu > 255) { tu /=  10; ti++; }
-  if (ecrt_slave_config_sdo8(slave->config, 0x60C2, 0x01, (uint8_t)tu) != 0) {
+  if (lcec_write_sdo8(slave, 0x60C2, 0x01, (uint8_t)tu) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ipol time period units\n", master->name, slave->name);
   }
-  if (ecrt_slave_config_sdo8(slave->config, 0x60C2, 0x02, ti) != 0) {
+  if (lcec_write_sdo8(slave, 0x60C2, 0x02, ti) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ipol time period index\n", master->name, slave->name);
   }
 

--- a/src/devices/lcec_el3xxx.c
+++ b/src/devices/lcec_el3xxx.c
@@ -390,7 +390,7 @@ static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
           *(chan->scale) = sensor->scale;
           chan->is_unsigned = sensor->is_unsigned;
 
-          if (ecrt_slave_config_sdo16(slave->config, 0x8000 + (i << 4), 0x19, sensor->value) != 0) {
+          if (lcec_write_sdo16(slave, 0x8000 + (i << 4), 0x19, sensor->value) != 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failed to configure slave %s.%s sdo sensor!\n", master->name, slave->name);
             return -1;
           }
@@ -413,7 +413,7 @@ static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
           rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "    - setting resolution for %s %d to %d\n", slave->name, i, resolution->value);
           *(chan->scale) = *(chan->scale) * resolution->scale_multiplier;
 
-          if (ecrt_slave_config_sdo8(slave->config, 0x8000 + (i << 4), 0x2, resolution->value) != 0) {
+          if (lcec_write_sdo8(slave, 0x8000 + (i << 4), 0x2, resolution->value) != 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failed to configure slave %s.%s sdo resolution!\n", master->name, slave->name);
             return -1;
           }
@@ -435,7 +435,7 @@ static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
         if (wires != NULL) {
           rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "      - setting wires for %s %d to %d\n", slave->name, i, wires->value);
 
-          if (ecrt_slave_config_sdo16(slave->config, 0x8000 + (i << 4), 0x1a, wires->value) != 0) {
+          if (lcec_write_sdo16(slave, 0x8000 + (i << 4), 0x1a, wires->value) != 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failed to configure slave %s.%s sdo wires!\n", master->name, slave->name);
             return -1;
           }

--- a/src/devices/lcec_el5002.c
+++ b/src/devices/lcec_el5002.c
@@ -165,67 +165,67 @@ static int lcec_el5002_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
     i = (p->id & LCEC_EL5002_PARAM_CH_MASK) << 4;
     switch(p->id & LCEC_EL5002_PARAM_FNK_MASK) {
       case LCEC_EL5002_PARAM_DIS_FRAME_ERR:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x01, p->value.bit) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x01, p->value.bit) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo DisFrameErr\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_EN_PWR_FAIL_CHK:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x02, p->value.bit) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x02, p->value.bit) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo EnPwrFailChk\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_EN_INHIBIT_TIME:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x03, p->value.bit) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x03, p->value.bit) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo EnInhibitTime\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_CODING:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x06, p->value.u32) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x06, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo Coding\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_BAUDRATE:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x09, p->value.u32) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x09, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo Baudrate\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_CLK_JIT_COMP:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x0c, p->value.u32) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x0c, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ClkJitComp\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_FRAME_TYPE:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8000 + i, 0x0f, p->value.u32) != 0) {
+        if (lcec_write_sdo8(slave, 0x8000 + i, 0x0f, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo FrameType\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_FRAME_SIZE:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8000 + i, 0x11, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8000 + i, 0x11, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo FrameSize\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_DATA_LEN:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8000 + i, 0x12, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8000 + i, 0x12, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo DataLen\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_MIN_INHIBIT_TIME:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8000 + i, 0x13, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8000 + i, 0x13, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo MinInhibitTime\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL5002_PARAM_NO_CLK_BURSTS:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8000 + i, 0x14, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8000 + i, 0x14, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo NoClkBursts\n", master->name, slave->name);
           return -1;
         }

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -278,7 +278,7 @@ static int lcec_el70x1_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   slave->proc_write = lcec_el70x1_write;
 
   // set to position mode
-  if (ecrt_slave_config_sdo8(slave->config, 0x8012, 0x01, 3) != 0) {
+  if (lcec_write_sdo8(slave, 0x8012, 0x01, 3) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo position mode\n", master->name, slave->name);
     return -1;
   }
@@ -287,31 +287,31 @@ static int lcec_el70x1_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   for (p = slave->modparams; p != NULL && p->id >= 0; p++) {
     switch(p->id) {
       case LCEC_EL70x1_PARAM_MAX_CURR:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8010, 0x01, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8010, 0x01, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo maxCurrent\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL70x1_PARAM_RED_CURR:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8010, 0x02, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8010, 0x02, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo redCurrent\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL70x1_PARAM_NOM_VOLT:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8010, 0x03, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8010, 0x03, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo nomVoltage\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL70x1_PARAM_COIL_RES:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8010, 0x04, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8010, 0x04, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo coilRes\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL70x1_PARAM_MOTOR_EMF:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8010, 0x05, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8010, 0x05, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo motorEMF\n", master->name, slave->name);
           return -1;
         }

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -319,7 +319,7 @@ static int lcec_el7201_9014_init(int comp_id, struct lcec_slave *slave, ec_pdo_e
   slave->hal_data = hal_data;
 
   // set info1 to inputs
-  if (ecrt_slave_config_sdo8(slave->config, 0x8010, 0x39, 10) != 0) {
+  if (lcec_write_sdo8(slave, 0x8010, 0x39, 10) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo info1 select\n", master->name, slave->name);
     return -1;
   }

--- a/src/devices/lcec_el7411.c
+++ b/src/devices/lcec_el7411.c
@@ -58,19 +58,19 @@ static int lcec_el7411_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   lcec_slave_modparam_t *p;
 
   // set to velo mode
-  if (ecrt_slave_config_sdo8(slave->config, 0x7010, 0x03, 9) != 0) {
+  if (lcec_write_sdo8(slave, 0x7010, 0x03, 9) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo velo mode\n", master->name, slave->name);
     return -1;
   }
 
   // set commutation type to hall sensord
-  if (ecrt_slave_config_sdo8(slave->config, 0x8010, 0x64, 2) != 0) {
+  if (lcec_write_sdo8(slave, 0x8010, 0x64, 2) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo commutation type\n", master->name, slave->name);
     return -1;
   }
 
   // enable hall power supply sensord
-  if (ecrt_slave_config_sdo8(slave->config, 0x800A, 0x02, 1) != 0) {
+  if (lcec_write_sdo8(slave, 0x800A, 0x02, 1) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo hall enable supply\n", master->name, slave->name);
     return -1;
   }
@@ -79,103 +79,103 @@ static int lcec_el7411_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   for (p = slave->modparams; p != NULL && p->id >= 0; p++) {
     switch(p->id) {
       case LCEC_EL7411_PARAM_DCLINK_NOM:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8010, 0x19, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8010, 0x19, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo dcLinkNominal\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_DCLINK_MIN:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8010, 0x1A, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8010, 0x1A, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo dcLinkMin\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_DCLINK_MAX:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8010, 0x1B, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8010, 0x1B, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo dcLinkMax\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_MAX_CURR:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x11, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x11, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo maxCurrent\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_RATED_CURR:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x12, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x12, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ratedCurrent\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_RATED_VOLT:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x2F, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x2F, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ratedVoltage\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_POLE_PAIRS:
-        if (ecrt_slave_config_sdo8(slave->config, 0x8011, 0x13, p->value.u32) != 0) {
+        if (lcec_write_sdo8(slave, 0x8011, 0x13, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo polePairs\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_RESISTANCE:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x30, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x30, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo coilRes\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_INDUCTANCE:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8011, 0x19, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8011, 0x19, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo coilInd\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_TOURQUE_CONST:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x16, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x16, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo torqueConst\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_VOLTAGE_CONST:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x31, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x31, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo voltageConst\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_ROTOR_INERTIA:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x18, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x18, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo rotorInertia\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_MAX_SPEED:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x1B, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x1B, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo maxSpeed\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_RATED_SPEED:
-        if (ecrt_slave_config_sdo32(slave->config, 0x8011, 0x2E, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x8011, 0x2E, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ratedSpeed\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_TH_TIME_CONST:
-        if (ecrt_slave_config_sdo16(slave->config, 0x8011, 0x2D, p->value.u32) != 0) {
+        if (lcec_write_sdo16(slave, 0x8011, 0x2D, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo ratedSpeed\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_HALL_VOLT:
-        if (ecrt_slave_config_sdo32(slave->config, 0x800A, 0x11, p->value.u32) != 0) {
+        if (lcec_write_sdo32(slave, 0x800A, 0x11, p->value.u32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo hallVoltage\n", master->name, slave->name);
           return -1;
         }
         break;
       case LCEC_EL7411_PARAM_HALL_ADJUST:
-        if (ecrt_slave_config_sdo8(slave->config, 0x800A, 0x13, p->value.s32) != 0) {
+        if (lcec_write_sdo8(slave, 0x800A, 0x13, p->value.s32) != 0) {
           rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo hallAdjust\n", master->name, slave->name);
           return -1;
         }

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -226,7 +226,7 @@ static int lcec_omrg5_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_r
   slave->hal_data = hal_data;
 
   // set to cyclic synchronous position mode
-  if (ecrt_slave_config_sdo8(slave->config, 0x6060, 0x00, 8) != 0) {
+  if (lcec_write_sdo8(slave, 0x6060, 0x00, 8) != 0) {
     rtapi_print_msg (RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo velo mode\n", master->name, slave->name);
   }
 

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -296,6 +296,7 @@ int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint
 int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size);
 int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value);
 int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value);
+int lcec_write_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t value);
 
 int lcec_pin_newf(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_addr, const char *fmt, ...);
 int lcec_pin_newf_list(void *base, const lcec_pindesc_t *list, ...);

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -191,13 +191,29 @@ int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, 
 /// @param slave The slave.
 /// @param index The SDO index to set (`0x8000` or similar).
 /// @param subindex The SDO sub-index to be set.
-/// @param value An 8-bit value to set.
+/// @param value A 16-bit value to set.
 /// @return 0 for success or -1 for failure.
 int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value) {
   uint8_t data[2];
 
   EC_WRITE_U16(data, value);
   return lcec_write_sdo(slave, index, subindex, data, 2);
+}
+
+/// @brief Write a 32-bit SDO configuration to a slave device.
+///
+/// See `lcec_write_sdo` for details.
+///
+/// @param slave The slave.
+/// @param index The SDO index to set (`0x8000` or similar).
+/// @param subindex The SDO sub-index to be set.
+/// @param value A 32-bit value to set.
+/// @return 0 for success or -1 for failure.
+int lcec_write_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t value) {
+  uint8_t data[4];
+
+  EC_WRITE_U32(data, value);
+  return lcec_write_sdo(slave, index, subindex, data, 4);
 }
 
 /// @brief Read IDN data from a slave device.


### PR DESCRIPTION
Right now, attempts to write bogus values to SDOs aren't actually caught until after the device is started, which is too late for proper error handling.  This changes the way that SDOs are set, allowing us to catch bad SDOs immediately.  Verified w/ EL7041.

This should fix issue #243 for all drivers.
