### PR TITLE
fix(DeASDA): Add Support for B3 (untested)

### DIFF
--- a/documentation/deasda.md
+++ b/documentation/deasda.md
@@ -6,6 +6,7 @@ It currently supports 2 basic families of devices:
 
 - ASDA-A2-E series drives (type "DeASDA")
 - ASDA-A3-E series of drives (type "DeASDA3")
+- ASDA-B3-E Series of Drives (type "DeASDB3")
 
 Note that to support the legacy driver, DeASDA at CSV mode is the default setting of the driver.
 
@@ -38,9 +39,9 @@ There is 1 `<modParam>` setting:
     
 All of these settings are case insensitive.
 
-## Differences of ASDA-A2 and ASDA-A3
+## Differences of ASDA-A2 and ASDA-A3/B3 series
 
-The stnadard motors that come with either series of drives differ slightly. A2 drives will have a default encoder resolution of 1,280,000 whereas A3 series motors have a resolution of 16,777,216. Note that A3 drives support both A2 and A3 series motors. The default value in the driver is that of ASDA A2 series motors.
+The stnadard motors that come with either series of drives differ slightly. A2 drives will have a default encoder resolution of 1,280,000 whereas A3 and B3 series (henceforth X3) motors have a resolution of 16,777,216. Note that X3 drives support both x2 and x3 series motors. The default value in the driver is that of ASDA A2 series motors.
 
 To set the resolution use hal pin: %s.%s.%s.srv-pulses-per-rev  (also know as pprev). The following remark for further help on the topic.
 
@@ -55,70 +56,85 @@ TODO()
 
 ## Exposed Pins Common
 
-The following pins are exposed in both modes and for both A2 and A3 drives
+The following pins are exposed in both modes and for all drives
 
 Encoder values (servo motor and external encoder at CN5)
 ```
-u32   I/O    lcec.0.A3.enc-ext-hi
-u32   I/O    lcec.0.A3.enc-ext-lo
-bit   I/O    lcec.0.A3.enc-index-ena
-bit   OUT    lcec.0.A3.enc-on-home-neg
-bit   OUT    lcec.0.A3.enc-on-home-pos
-float OUT    lcec.0.A3.enc-pos
-float OUT    lcec.0.A3.enc-pos-abs | use for position feedback on axis
-float OUT    lcec.0.A3.enc-pos-enc
-bit   IN     lcec.0.A3.enc-pos-reset
-s32   OUT    lcec.0.A3.enc-raw
-u32   OUT    lcec.0.A3.enc-ref-hi
-u32   OUT    lcec.0.A3.enc-ref-lo
-u32   I/O    lcec.0.A3.extenc-ext-hi
-u32   I/O    lcec.0.A3.extenc-ext-lo
-bit   I/O    lcec.0.A3.extenc-index-ena
-bit   OUT    lcec.0.A3.extenc-on-home-neg
-bit   OUT    lcec.0.A3.extenc-on-home-pos
-float OUT    lcec.0.A3.extenc-pos
-float OUT    lcec.0.A3.extenc-pos-abs | use for position feedback on axis if linear scale is connected
-float OUT    lcec.0.A3.extenc-pos-enc
-bit   IN     lcec.0.A3.extenc-pos-reset
-s32   OUT    lcec.0.A3.extenc-raw
-u32   OUT    lcec.0.A3.extenc-ref-hi
-u32   OUT    lcec.0.A3.extenc-ref-lo
+37    I/O  lcec.0.A3.enc-ext-hi
+37    I/O  lcec.0.A3.enc-ext-lo
+37    I/O  lcec.0.A3.enc-index-ena
+bit   OUT  lcec.0.A3.enc-on-home-neg
+bit   OUT  lcec.0.A3.enc-on-home-pos
+float OUT  lcec.0.A3.enc-pos
+float OUT  lcec.0.A3.enc-pos-abs
+float OUT  lcec.0.A3.enc-pos-enc
+bit   IN   lcec.0.A3.enc-pos-reset
+s32   OUT  lcec.0.A3.enc-raw
+u32   OUT  lcec.0.A3.enc-ref-hi
+u32   OUT  lcec.0.A3.enc-ref-lo
+37    I/O  lcec.0.A3.extenc-ext-hi
+37    I/O  lcec.0.A3.extenc-ext-lo
+37    I/O  lcec.0.A3.extenc-index-ena
+bit   OUT  lcec.0.A3.extenc-on-home-neg
+bit   OUT  lcec.0.A3.extenc-on-home-pos
+float OUT  lcec.0.A3.extenc-pos
+float OUT  lcec.0.A3.extenc-pos-abs
+float OUT  lcec.0.A3.extenc-pos-enc
+bit   IN   lcec.0.A3.extenc-pos-reset
+s32   OUT  lcec.0.A3.extenc-raw
+u32   OUT  lcec.0.A3.extenc-ref-hi
+u32   OUT  lcec.0.A3.extenc-ref-lo
 ```
 _Slave Status_
 ```
-bit   OUT    lcec.0.A3.slave-online
-bit   OUT    lcec.0.A3.slave-oper
-bit   OUT    lcec.0.A3.slave-state-init
-bit   OUT    lcec.0.A3.slave-state-op
-bit   OUT    lcec.0.A3.slave-state-preop
-bit   OUT    lcec.0.A3.slave-state-safeop
+bit   OUT  lcec.0.A3.slave-online
+bit   OUT  lcec.0.A3.slave-oper
+bit   OUT  lcec.0.A3.slave-state-init
+bit   OUT  lcec.0.A3.slave-state-op
+bit   OUT  lcec.0.A3.slave-state-preop
+bit   OUT  lcec.0.A3.slave-state-safeop
 ```
 _Drive Status and Control_
 ```
-bit   OUT    lcec.0.A3.srv-at-speed
-bit   IN     lcec.0.A3.srv-enable | needs to be high for the servo drive to operate
-bit   IN     lcec.0.A3.srv-enable-volt | needs to be high for the servo drive to operate
-bit   OUT    lcec.0.A3.srv-fault
-bit   IN     lcec.0.A3.srv-fault-reset 
-bit   IN     lcec.0.A3.srv-halt
-bit   OUT    lcec.0.A3.srv-limit-active
-bit   OUT    lcec.0.A3.srv-on-disabled
-bit   OUT    lcec.0.A3.srv-oper-enabled
-u32   OUT    lcec.0.A3.srv-operation-mode | return info on the operation mode (8=CSP, 9=CSV)
-bit   IN     lcec.0.A3.srv-quick-stop
-bit   OUT    lcec.0.A3.srv-quick-stoped
-bit   OUT    lcec.0.A3.srv-ready
-bit   OUT    lcec.0.A3.srv-remote
-bit   IN     lcec.0.A3.srv-switch-on  | needs to be high for the servo drive to operate
-bit   OUT    lcec.0.A3.srv-switched-on
-float OUT    lcec.0.A3.srv-vel-fb
-float OUT    lcec.0.A3.srv-vel-fb-rpm
-float OUT    lcec.0.A3.srv-vel-fb-rpm-abs
-float OUT    lcec.0.A3.srv-vel-rpm
-bit   OUT    lcec.0.A3.srv-volt-enabled
-bit   OUT    lcec.0.A3.srv-warning
-bit   OUT    lcec.0.A3.srv-zero-speed
+bit   OUT  lcec.0.A3.srv-at-speed
+bit   OUT  lcec.0.A3.srv-di1 | RO status of the DIx pin  on CN1
+bit   OUT  lcec.0.A3.srv-di2
+bit   OUT  lcec.0.A3.srv-di3
+bit   OUT  lcec.0.A3.srv-di4
+bit   OUT  lcec.0.A3.srv-di5
+bit   OUT  lcec.0.A3.srv-di6
+bit   OUT  lcec.0.A3.srv-di7
+bit   IN   lcec.0.A3.srv-enable  | needs to be high for the servo drive to operate
+bit   IN   lcec.0.A3.srv-enable-volt | needs to be high for the servo drive to operate
+bit   OUT  lcec.0.A3.srv-fault
+bit   IN   lcec.0.A3.srv-fault-reset 
+bit   IN   lcec.0.A3.srv-halt
+bit   OUT  lcec.0.A3.srv-home
+bit   OUT  lcec.0.A3.srv-limit-active
+bit   OUT  lcec.0.A3.srv-neg-lim
+bit   OUT  lcec.0.A3.srv-on-disabled
+bit   OUT  lcec.0.A3.srv-oper-enabled
+u32   OUT  lcec.0.A3.srv-operation-mode | return info on the operation mode (8=CSP, 9=CSV)
+bit   OUT  lcec.0.A3.srv-pos-lim
+bit   IN   lcec.0.A3.srv-quick-stop
+bit   OUT  lcec.0.A3.srv-quick-stoped
+bit   OUT  lcec.0.A3.srv-ready
+bit   OUT  lcec.0.A3.srv-remote
+bit   IN   lcec.0.A3.srv-switch-on | needs to be high for the servo drive to operate
+bit   OUT  lcec.0.A3.srv-switched-on
+float OUT  lcec.0.A3.srv-torque-rel
+float IN   lcec.0.A3.srv-vel-cmd
+float OUT  lcec.0.A3.srv-vel-fb
+float OUT  lcec.0.A3.srv-vel-fb-rpm
+float OUT  lcec.0.A3.srv-vel-fb-rpm-abs
+float OUT  lcec.0.A3.srv-vel-rpm
+bit   OUT  lcec.0.A3.srv-volt-enabled
+bit   OUT  lcec.0.A3.srv-warning
+bit   OUT  lcec.0.A3.srv-zero-speed
 ```
+
+
+
 
 ## CSV Mode (Default)
 
@@ -153,7 +169,3 @@ if you have any problems with this driver, including:
 - hardware that should work but doesn't.
 - unexpected limitations.
 - features that the hardware supports but the driver does not.
-
-
-## Relevant open issues
-- Expose further parameters specific to drive types

--- a/documentation/deasda.md
+++ b/documentation/deasda.md
@@ -59,81 +59,84 @@ TODO()
 The following pins are exposed in both modes and for all drives
 
 Encoder values (servo motor and external encoder at CN5)
+
+_Encoder Pins_
 ```
-37    I/O  lcec.0.A3.enc-ext-hi
-37    I/O  lcec.0.A3.enc-ext-lo
-37    I/O  lcec.0.A3.enc-index-ena
-bit   OUT  lcec.0.A3.enc-on-home-neg
-bit   OUT  lcec.0.A3.enc-on-home-pos
-float OUT  lcec.0.A3.enc-pos
-float OUT  lcec.0.A3.enc-pos-abs
-float OUT  lcec.0.A3.enc-pos-enc
-bit   IN   lcec.0.A3.enc-pos-reset
-s32   OUT  lcec.0.A3.enc-raw
-u32   OUT  lcec.0.A3.enc-ref-hi
-u32   OUT  lcec.0.A3.enc-ref-lo
-37    I/O  lcec.0.A3.extenc-ext-hi
-37    I/O  lcec.0.A3.extenc-ext-lo
-37    I/O  lcec.0.A3.extenc-index-ena
-bit   OUT  lcec.0.A3.extenc-on-home-neg
-bit   OUT  lcec.0.A3.extenc-on-home-pos
-float OUT  lcec.0.A3.extenc-pos
-float OUT  lcec.0.A3.extenc-pos-abs
-float OUT  lcec.0.A3.extenc-pos-enc
-bit   IN   lcec.0.A3.extenc-pos-reset
-s32   OUT  lcec.0.A3.extenc-raw
-u32   OUT  lcec.0.A3.extenc-ref-hi
-u32   OUT  lcec.0.A3.extenc-ref-lo
+u32   I/O lcec.0.A3.enc-ext-hi
+u32   I/O lcec.0.A3.enc-ext-lo
+bit   I/O lcec.0.A3.enc-index-ena
+bit   OUT lcec.0.A3.enc-on-home-neg
+bit   OUT lcec.0.A3.enc-on-home-pos
+float OUT lcec.0.A3.enc-pos
+float OUT lcec.0.A3.enc-pos-abs 
+float OUT lcec.0.A3.enc-pos-enc
+bit   IN  lcec.0.A3.enc-pos-reset
+s32   OUT lcec.0.A3.enc-raw
+u32   OUT lcec.0.A3.enc-ref-hi
+u32   OUT lcec.0.A3.enc-ref-lo
+u32   I/O lcec.0.A3.extenc-ext-hi
+u32   I/O lcec.0.A3.extenc-ext-lo
+bit   I/O lcec.0.A3.extenc-index-ena
+bit   OUT lcec.0.A3.extenc-on-home-neg
+bit   OUT lcec.0.A3.extenc-on-home-pos
+float OUT lcec.0.A3.extenc-pos
+float OUT lcec.0.A3.extenc-pos-abs
+float OUT lcec.0.A3.extenc-pos-enc
+bit   IN  lcec.0.A3.extenc-pos-reset
+s32   OUT lcec.0.A3.extenc-raw
+u32   OUT lcec.0.A3.extenc-ref-hi
+u32   OUT lcec.0.A3.extenc-ref-lo
 ```
 _Slave Status_
 ```
-bit   OUT  lcec.0.A3.slave-online
-bit   OUT  lcec.0.A3.slave-oper
-bit   OUT  lcec.0.A3.slave-state-init
-bit   OUT  lcec.0.A3.slave-state-op
-bit   OUT  lcec.0.A3.slave-state-preop
-bit   OUT  lcec.0.A3.slave-state-safeop
+bit   OUT lcec.0.A3.slave-online
+bit   OUT lcec.0.A3.slave-oper
+bit   OUT lcec.0.A3.slave-state-init
+bit   OUT lcec.0.A3.slave-state-op
+bit   OUT lcec.0.A3.slave-state-preop
+bit   OUT lcec.0.A3.slave-state-safeop
 ```
 _Drive Status and Control_
 ```
-bit   OUT  lcec.0.A3.srv-at-speed
-bit   OUT  lcec.0.A3.srv-di1 | RO status of the DIx pin  on CN1
-bit   OUT  lcec.0.A3.srv-di2
-bit   OUT  lcec.0.A3.srv-di3
-bit   OUT  lcec.0.A3.srv-di4
-bit   OUT  lcec.0.A3.srv-di5
-bit   OUT  lcec.0.A3.srv-di6
-bit   OUT  lcec.0.A3.srv-di7
-bit   IN   lcec.0.A3.srv-enable  | needs to be high for the servo drive to operate
-bit   IN   lcec.0.A3.srv-enable-volt | needs to be high for the servo drive to operate
-bit   OUT  lcec.0.A3.srv-fault
-bit   IN   lcec.0.A3.srv-fault-reset 
-bit   IN   lcec.0.A3.srv-halt
-bit   OUT  lcec.0.A3.srv-home
-bit   OUT  lcec.0.A3.srv-limit-active
-bit   OUT  lcec.0.A3.srv-neg-lim
-bit   OUT  lcec.0.A3.srv-on-disabled
-bit   OUT  lcec.0.A3.srv-oper-enabled
-u32   OUT  lcec.0.A3.srv-operation-mode | return info on the operation mode (8=CSP, 9=CSV)
-bit   OUT  lcec.0.A3.srv-pos-lim
-bit   IN   lcec.0.A3.srv-quick-stop
-bit   OUT  lcec.0.A3.srv-quick-stoped
-bit   OUT  lcec.0.A3.srv-ready
-bit   OUT  lcec.0.A3.srv-remote
-bit   IN   lcec.0.A3.srv-switch-on | needs to be high for the servo drive to operate
-bit   OUT  lcec.0.A3.srv-switched-on
-float OUT  lcec.0.A3.srv-torque-rel
-float IN   lcec.0.A3.srv-vel-cmd
-float OUT  lcec.0.A3.srv-vel-fb
-float OUT  lcec.0.A3.srv-vel-fb-rpm
-float OUT  lcec.0.A3.srv-vel-fb-rpm-abs
-float OUT  lcec.0.A3.srv-vel-rpm
-bit   OUT  lcec.0.A3.srv-volt-enabled
-bit   OUT  lcec.0.A3.srv-warning
-bit   OUT  lcec.0.A3.srv-zero-speed
+bit   OUT lcec.0.A3.srv-at-speed
+bit   IN  lcec.0.A3.srv-enable 
+bit   IN  lcec.0.A3.srv-enable-volt
+bit   OUT lcec.0.A3.srv-fault
+bit   IN  lcec.0.A3.srv-fault-reset 
+bit   IN  lcec.0.A3.srv-halt
+bit   OUT lcec.0.A3.srv-on-disabled
+bit   OUT lcec.0.A3.srv-limit-active
+bit   OUT lcec.0.A3.srv-oper-enabled
+u32   OUT lcec.0.A3.srv-operation-mode
+bit   IN  lcec.0.A3.srv-quick-stop
+bit   OUT lcec.0.A3.srv-quick-stoped
+bit   OUT lcec.0.A3.srv-ready
+bit   OUT lcec.0.A3.srv-remote
+bit   IN  lcec.0.A3.srv-switch-on
+bit   OUT lcec.0.A3.srv-switched-on
+float OUT lcec.0.A3.srv-torque-rel
+float IN  lcec.0.A3.srv-vel-cmd 
+float OUT lcec.0.A3.srv-vel-fb
+float OUT lcec.0.A3.srv-vel-fb-rpm
+float OUT lcec.0.A3.srv-vel-fb-rpm-abs
+float OUT lcec.0.A3.srv-vel-rpm
+bit   OUT lcec.0.A3.srv-volt-enabled
+bit   OUT lcec.0.A3.srv-warning
+bit   OUT lcec.0.A3.srv-zero-speed
 ```
-
-
+_Digital In (RO) at CN1_
+```
+bit   OUT lcec.0.A3.din-1
+bit   OUT lcec.0.A3.din-2
+bit   OUT lcec.0.A3.din-3
+bit   OUT lcec.0.A3.din-4
+bit   OUT lcec.0.A3.din-5
+bit   OUT lcec.0.A3.din-6
+bit   OUT lcec.0.A3.din-7
+bit   OUT lcec.0.A3.din-home
+bit   OUT lcec.0.A3.din-neg-lim
+bit   OUT lcec.0.A3.din-pos-lim
+```
 
 
 ## CSV Mode (Default)

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -166,16 +166,16 @@ static const lcec_pindesc_t slave_pins[] = {{HAL_FLOAT, HAL_OUT, offsetof(lcec_d
     {HAL_BIT, HAL_IN, offsetof(lcec_deasda_data_t, halt), "%s.%s.%s.srv-halt"},
     {HAL_U32, HAL_OUT, offsetof(lcec_deasda_data_t, operation_mode), "%s.%s.%s.srv-operation-mode"},
     {HAL_FLOAT, HAL_OUT, offsetof(lcec_deasda_data_t, torque), "%s.%s.%s.srv-torque-rel"}, // relative value (5) - hence current would be redundant
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_1), "%s.%s.%s.srv-di1"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_2), "%s.%s.%s.srv-di2"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_3), "%s.%s.%s.srv-di3"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_4), "%s.%s.%s.srv-di4"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_5), "%s.%s.%s.srv-di5"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_6), "%s.%s.%s.srv-di6"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_7), "%s.%s.%s.srv-di7"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, neg_lim_switch), "%s.%s.%s.srv-neg-lim"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, pos_lim_switch), "%s.%s.%s.srv-pos-lim"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, home_switch), "%s.%s.%s.srv-home"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_1), "%s.%s.%s.din-1"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_2), "%s.%s.%s.din-2"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_3), "%s.%s.%s.din-3"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_4), "%s.%s.%s.din-4"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_5), "%s.%s.%s.din-5"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_6), "%s.%s.%s.din-6"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, di_7), "%s.%s.%s.din-7"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, neg_lim_switch), "%s.%s.%s.din-neg-lim"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, pos_lim_switch), "%s.%s.%s.din-pos-lim"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_deasda_data_t, home_switch), "%s.%s.%s.din-home"},
     
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
 

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -24,13 +24,13 @@
 #include "../lcec.h"
 #include "lcec_class_enc.h"
 
-#define FLAG_A2 1 << 0  // Device is A2 series
-#define FLAG_A3 1 << 1  // Device is A3 series
+#define FLAG_LOWRES_ENC 1 << 0  // Device is A2 series
+#define FLAG_HIGHRES_ENC 1 << 1  // Device is A3 series
 
 #define LCEC_DESDA_MODPARAM_OPERATIONMODE 0
 
-#define DEASDA_PULSES_PER_REV_DEFLT_A2 (1280000)   // this is the default value for A2 (default value)
-#define DEASDA_PULSES_PER_REV_DEFLT_A3 (16777216)  // this is the default value for A3
+#define DEASDA_PULSES_PER_REV_DEFLT_LOWRES (1280000)   // this is the default value for A2 (default value)
+#define DEASDA_PULSES_PER_REV_DEFLT_HIGHRES (16777216)  // this is the default value for A3
 
 #define DEASDA_RPM_FACTOR (0.1)
 #define DEASDA_RPM_RCPT   (1.0 / DEASDA_RPM_FACTOR)
@@ -64,8 +64,9 @@ static const drive_operationmodes_t drive_operationmodes[] = {
 // Note that DeASDA refers to A2-E series of drives and is deliberatly not refering to A2 in its name to ensure compatability with legace
 // configurations.
 static lcec_typelist_t types[] = {
-    {"DeASDA", LCEC_DELTA_VID, 0x10305070, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_A2},
-    {"DeASDA3", LCEC_DELTA_VID, 0x00006010, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_A3},
+    {"DeASDA", LCEC_DELTA_VID, 0x10305070, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_LOWRES_ENC},
+    {"DeASDA3", LCEC_DELTA_VID, 0x00006010, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_HIGHRES_ENC},
+    {"DeASDB3", LCEC_DELTA_VID, 0x00006080, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_HIGHRES_ENC},    
     {NULL},
 };
 
@@ -320,13 +321,13 @@ static int lcec_deasda_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
   hal_data->pos_scale_old = hal_data->pos_scale + 1.0;
   hal_data->pos_scale_rcpt = 1.0;
 
-  // change based on FLAG_A2/FLAG_A3
-  if (flags & FLAG_A2) {
-    hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_A2;
-    rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting A2 Preset for device %s.%s.\n", master->name, slave->name);
-  } else if (flags & FLAG_A3) {
-    hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_A3;
-    rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting A3 Preset for device %s.%s.\n", master->name, slave->name);
+  // change based on FLAG_LOWRES_ENC/FLAG_HIGHRES_ENC
+  if (flags & FLAG_LOWRES_ENC) {
+    hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_LOWRES;
+    rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting pprev to Low Res Encoder (1,280,000) for device %s.%s.\n", master->name, slave->name);
+  } else if (flags & FLAG_HIGHRES_ENC) {
+    hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_HIGHRES;
+    rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting pprev to High Res Encoder (16,777,216) for device %s.%s.\n", master->name, slave->name);
   }
 
   hal_data->last_switch_on = 0;

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -24,8 +24,11 @@
 #include "../lcec.h"
 #include "lcec_class_enc.h"
 
-#define FLAG_LOWRES_ENC 1 << 0  // Device is A2 series
-#define FLAG_HIGHRES_ENC 1 << 1  // Device is A3 series
+#define FLAG_LOWRES_ENC 1 << 0  // Device uses low res encoder as default 
+#define FLAG_HIGHRES_ENC 1 << 1  // Device uses high res encoder as default x3 series
+
+#define FLAG_SERVO_X2 1 << 2    // A2 series drive
+#define FLAG_SERVO_X3 1 << 3    // x3 Series Drive, e.g. A3 or B3
 
 #define LCEC_DESDA_MODPARAM_OPERATIONMODE 0
 
@@ -64,9 +67,9 @@ static const drive_operationmodes_t drive_operationmodes[] = {
 // Note that DeASDA refers to A2-E series of drives and is deliberatly not refering to A2 in its name to ensure compatability with legace
 // configurations.
 static lcec_typelist_t types[] = {
-    {"DeASDA", LCEC_DELTA_VID, 0x10305070, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_LOWRES_ENC},
-    {"DeASDA3", LCEC_DELTA_VID, 0x00006010, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_HIGHRES_ENC},
-    {"DeASDB3", LCEC_DELTA_VID, 0x00006080, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_HIGHRES_ENC},    
+    {"DeASDA", LCEC_DELTA_VID, 0x10305070, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_LOWRES_ENC, FLAG_SERVO_X2},
+    {"DeASDA3", LCEC_DELTA_VID, 0x00006010, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_HIGHRES_ENC,FLAG_SERVO_X3},
+    {"DeASDB3", LCEC_DELTA_VID, 0x00006080, LCEC_DEASDA_PDOS, 0, NULL, lcec_deasda_init, lcec_deasda_modparams, FLAG_HIGHRES_ENC, FLAG_SERVO_X3},    
     {NULL},
 };
 
@@ -329,6 +332,9 @@ static int lcec_deasda_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_
     hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_HIGHRES;
     rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting pprev to High Res Encoder (16,777,216) for device %s.%s.\n", master->name, slave->name);
   }
+
+  // TODO: Add additional registers here if avialalbe: e.g. DIDO based on servo type FLAG_SERVO_X2/FLAG_SERVO_X3
+
 
   hal_data->last_switch_on = 0;
   hal_data->internal_fault = 0;

--- a/src/devices/lcec_deasda.h
+++ b/src/devices/lcec_deasda.h
@@ -142,5 +142,5 @@ Parameters:
 
 #define LCEC_DEASDA_VID LCEC_DELTA_VID
 
-#define LCEC_DEASDA_PDOS 6
+#define LCEC_DEASDA_PDOS 8
 #endif


### PR DESCRIPTION
Added PID config for Delta ASDA B3 drives based on ESI file comparison and PID 6080. I do not have a B3 but expect this to work just fine.
Relates to #248  