### PR TITLE
feat(lookup): Add a generic lookup table for making modParams easier

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ RTEXTRA_LDFLAGS += -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -
 EXTRA_CFLAGS += -Wall  # Increase debugging level
 
 ## targets
-lcec-common-objs := lcec_devicelist.o lcec_ethercat.o lcec_pins.o
+lcec-common-objs := lcec_devicelist.o lcec_ethercat.o lcec_pins.o lcec_lookup.o
 lcec-objs := lcec_main.o $(lcec-common-objs)
 lcec-conf-srcs := $(wildcard lcec_conf*.c)
 lcec-conf-objs = $(subst .c,.o,$(lcec-conf-srcs))

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -114,7 +114,7 @@ typedef struct {
   lcec_modparam_type_t type;  ///< The type (bit, int, float, string) of this modParam.
 } lcec_modparam_desc_t;
 
-/// \brief Definition of a device that LinuxCNC-Ethercat supports.
+/// @brief Definition of a device that LinuxCNC-Ethercat supports.
 typedef struct {
   char *name;                             ///< The device's name ("EL1008")
   uint32_t vid;                           ///< The EtherCAT vendor ID
@@ -128,7 +128,7 @@ typedef struct {
   char *sourcefile;                       ///< Source filename, autopopulated.
 } lcec_typelist_t;
 
-/// \brief Linked list for holding device type definitions.
+/// @brief Linked list for holding device type definitions.
 typedef struct lcec_typelinkedlist {
   const lcec_typelist_t *type;       ///< The type definition.
   struct lcec_typelinkedlist *next;  ///< Pointer to the next `lcec_typelinkedlist` in the linked list.
@@ -268,7 +268,7 @@ typedef struct lcec_slave {
   uint64_t flags;                            ///< Flags, as defined by the driver itself.
 } lcec_slave_t;
 
-/// \brief HAL pin description.
+/// @brief HAL pin description.
 typedef struct {
   hal_type_t type;    ///< HAL type of this pin (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
   hal_pin_dir_t dir;  ///< Direction for this pin (`HAL_IN`, `HAL_OUT`, or `HAL_IO`).
@@ -276,7 +276,7 @@ typedef struct {
   const char *fmt;    ///< Format string for generating pin names via sprintf().
 } lcec_pindesc_t;
 
-/// \brief Sync manager configuration.
+/// @brief Sync manager configuration.
 typedef struct {
   int sync_count;                                 ///< Number of syncs.
   ec_sync_info_t *curr_sync;                      ///< Current sync.
@@ -290,6 +290,18 @@ typedef struct {
   ec_pdo_entry_info_t *curr_pdo_entry;                        ///< Current PDO entry.
   ec_pdo_entry_info_t pdo_entries[LCEC_MAX_PDO_ENTRY_COUNT];  ///< PDO entry definitions.
 } lcec_syncs_t;
+
+/// @brief Lookup table mapping string to int
+typedef struct {
+  const char *key;
+  const int value;
+} lcec_lookuptable_int_t;
+
+/// @brief Lookup table mapping string to double
+typedef struct {
+  const char *key;
+  const double value;
+} lcec_lookuptable_double_t;
 
 int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size);
 int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size);
@@ -316,5 +328,9 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
 const lcec_typelist_t *lcec_findslavetype(const char *name);
 void lcec_addtype(lcec_typelist_t *type, char *sourcefile);
 void lcec_addtypes(lcec_typelist_t types[], char *sourcefile);
+int lcec_lookupint(const lcec_lookuptable_int_t *table, const char *key, int default_value);
+int lcec_lookupint_i(const lcec_lookuptable_int_t *table, const char *key, int default_value);
+double lcec_lookupdouble(const lcec_lookuptable_double_t *table, const char *key, double default_value);
+double lcec_lookupdouble_i(const lcec_lookuptable_double_t *table, const char *key, double default_value);
 
 #endif

--- a/src/lcec_lookup.c
+++ b/src/lcec_lookup.c
@@ -1,0 +1,121 @@
+//
+//    Copyright (C) 2024 Scott Laird <scott@sigkill.org>
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+#include <strings.h>
+
+#include "lcec.h"
+
+/// @file
+/// @brief Code for implementing string lookup tables.
+///
+/// These are intended to make `<modParam>` decoding easier by
+/// allowing generic string->int and string->double mapping, with
+/// configurable default values.
+
+/// @brief Perform a lookup in a lookup table.
+///
+/// This maps a string onto an int, looking in a predefined table.
+/// This is intended to be used for looking up string->value maps in
+/// `<modParam>`s, for example figuring out what the correct hardware
+/// sensor type for a EL32xx is for a "Pt100" sensor.
+///
+/// @param table The table to do lookups in.
+/// @param key The string to look for.
+/// @param default_value The value to return if the lookup fails.
+/// @return The value that matches the key, or default if it is not found.
+int lcec_lookupint(const lcec_lookuptable_int_t *table, const char *key, int default_value) {
+  while (table && table->key) {
+    if (!strcmp(table->key, key)) {
+      return table->value;
+    }
+    table++;
+  }
+
+  return default_value;
+}
+
+/// @brief Perform a case-insensitive lookup in a lookup table.
+///
+/// This maps a string onto an int, looking in a predefined table.
+/// This is intended to be used for looking up string->value maps in
+/// `<modParam>`s, for example figuring out what the correct hardware
+/// sensor type for a EL32xx is for a "Pt100" sensor.
+///
+/// This version is case-insensitive.
+///
+/// @param table The table to do lookups in.
+/// @param key The string to look for.
+/// @param default_value The value to return if the lookup fails.
+/// @return The value that matches the key, or default if it is not found.
+int lcec_lookupint_i(const lcec_lookuptable_int_t *table, const char *key, int default_value) {
+  while (table && table->key) {
+    if (!strcasecmp(table->key, key)) {
+      return table->value;
+    }
+    table++;
+  }
+
+  return default_value;
+}
+
+/// @brief Perform a lookup in a lookup table.
+///
+/// This maps a string onto an double, looking in a predefined table.
+/// This is intended to be used for looking up string->value maps in
+/// `<modParam>`s, for example figuring out what the correct hardware
+/// sensor type for a EL32xx is for a "Pt100" sensor.
+///
+/// @param table The table to do lookups in.
+/// @param key The string to look for.
+/// @param default_value The value to return if the lookup fails.
+/// @return The value that matches the key, or default if it is not found.
+double lcec_lookupdouble(const lcec_lookuptable_double_t *table, const char *key, double default_value) {
+  while (table && table->key) {
+    if (!strcmp(table->key, key)) {
+      return table->value;
+    }
+    table++;
+  }
+
+  return default_value;
+}
+
+/// @brief Perform a case-insensitive lookup in a lookup table.
+///
+/// This maps a string onto an double, looking in a predefined table.
+/// This is intended to be used for looking up string->value maps in
+/// `<modParam>`s, for example figuring out what the correct hardware
+/// sensor type for a EL32xx is for a "Pt100" sensor.
+///
+/// This version is case-insensitive.
+///
+/// @param table The table to do lookups in.
+/// @param key The string to look for.
+/// @param default_value The value to return if the lookup fails.
+/// @return The value that matches the key, or default if it is not found.
+double lcec_lookupdouble_i(const lcec_lookuptable_double_t *table, const char *key, double default_value) {
+  while (table && table->key) {
+    if (!strcasecmp(table->key, key)) {
+      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "Found\n");
+      return table->value;
+    }
+    table++;
+  }
+
+  return default_value;
+}


### PR DESCRIPTION
A lot of `<modParam>`s really want to provide a string value, which then maps onto a specific integer for setting an SDO.  For example, with `el3xxx`, there is a list of known temperature sensors, used to configure the hardware so that it returns the correct value for the type of sensor attached.  Instead of making the user look up which numeric code is used for Pt1000 sensors in a 300 page PDF, they can just say `<modParam name="sensor" value="Pt1000"/>` and the code does the lookup for them.

This pattern keeps getting repeated all over the place, so instead of re-implementing lookups everywhere, I wrote a shared implementation.

There are 2 flavors, string->int and string->double.  Each flavor has 2 lookup functions, one that is case-sensitive and once that is case-insensitive.  In all 4 cases, you need to pass a `default` parameter, which is the value returned if the lookup fails.  This seems more natural than returning a possibly-NULL pointer, and leads to relatively clean code in my test cases.

This implementation just does a linear search through the list.  It's not very fast, but it should only run during the setup portion of the code, and we're *generally* only going to have a handful of entries in each lookup table, so there's no point in doing anything clever.

This also fixes #259 in `el3xxx`, where it iterated until the next entry was `NULL`, where it should have been checking that the *name* was NULL. 