### PR TITLE
fix(el4xxx): Fix EL4xx1 devices

### DIFF
--- a/src/devices/lcec_el4xxx.c
+++ b/src/devices/lcec_el4xxx.c
@@ -25,7 +25,7 @@
 static int lcec_el4xxx_init(int comp_id, struct lcec_slave *slave, ec_pdo_entry_reg_t *pdo_entry_regs);
 
 /// Flags for describing devices
-#define F_S11 1 ///< Uses subindex 11 instead of sub-index 1 for ports.
+#define F_S11 1<<8 ///< Uses subindex 11 instead of sub-index 1 for ports.
 #define F_CHANNELS(x) (x)  ///< Number of output channels
 
 #define OUTPORTS(flag) ((flag)&0xf)      // Number of output channels


### PR DESCRIPTION
Okay, this was dumb, somehow I overlapped the "use subindex 11" flag with the "number of channels" range.  The upshot is that all EL4xx1 devices (really all devices with odd numbers of ports, but that's only the xxx1 variant, I think) are flagged as using `0x7000:11` instead of `0x7000:01` for outputs, which doesn't work at all.

Fixes #257 
