### PR TITLE
test: Add C test harness and lookup tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
               id: cache-ethercatmaster
               uses: actions/cache@v3
               env:
-                  cache-name: cache-ethercatmaster
+                  cache-name: cache-ethercatmaster2
               with:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}
                   path: ethercat/
@@ -100,7 +100,7 @@ jobs:
                   set -x
                   cd ethercat
                   ./bootstrap
-                  ./configure --disable-kernel
+                  ./configure --disable-kernel --libdir=/usr/lib
                   make -j$((1+$(nproc))) all
                   #sudo make install
 
@@ -135,7 +135,7 @@ jobs:
             - name: Restore Ethercat Master cache
               uses: actions/cache/restore@v3
               env:
-                  cache-name: cache-ethercatmaster
+                  cache-name: cache-ethercatmaster2
               with:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}
                   path: ethercat/
@@ -157,28 +157,7 @@ jobs:
               run: |
                   make COMP=$GITHUB_WORKSPACE/linuxcnc/bin/halcompile -j$((1+$(nproc)))
 
-    # Build LinuxCNC-Ethercat debian package
-    prep-debian-package:
-        env:
-            CHANGELOG_AUTHOR_NAME: "Scott Laird"
-            CHANGELOG_AUTHOR_EMAIL: "scott@sigkill.org"
-        needs:
-            - build
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-
-            - name: Patch changelog (snapshot)
-              uses: pi-top/git-debian-changelog-bump-action@master
-              with:
-                  release: false
-                  author_name: ${{ env.CHANGELOG_AUTHOR_NAME }}
-                  author_email: ${{ env.CHANGELOG_AUTHOR_EMAIL }}
-
-            - name: Determine current version
+            - name: make test
               run: |
-                  sudo apt install -y dpkg-dev
-                  echo "CURRENT_VERSION=$(dpkg-parsechangelog -Sversion)" >> $GITHUB_ENV
+                  make COMP=$GITHUB_WORKSPACE/linuccnc/bin/halcompile test
+

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ src/lcec_conf
 src/lcec_devices
 src/Module.symvers
 
+# Test files
+src/tests/*.bin
+
 # debian pkgbuild files
 debian/.debhelper/
 debian/files

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all configure install clean
+.PHONY: all configure install clean test
 
 all: configure
 	@$(MAKE) -C src all
@@ -6,6 +6,9 @@ all: configure
 clean:
 	@$(MAKE) -C src -f Makefile.clean clean
 	rm -f config.mk config.mk.tmp
+
+test:
+	@$(MAKE) -C src test
 
 install: configure
 	@$(MAKE) -C src install

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 all: all-deps realtime user
-.PHONY: all all-deps install install-user install-realtime user realtime
+.PHONY: all all-deps install install-user install-realtime user realtime all-tests test
 
 -include ../config.mk
 -include $(MODINC)
@@ -18,8 +18,10 @@ lcec-conf-srcs := $(wildcard lcec_conf*.c)
 lcec-conf-objs = $(subst .c,.o,$(lcec-conf-srcs))
 device-srcs := $(wildcard devices/*.c)
 device-objs := $(subst .c,.o,$(device-srcs))
-all-srcs := $(wildcard *.c devices/*.c)
+all-srcs := $(wildcard *.c devices/*.c tests/*.c)
 all-deps := $(all-srcs:.c=.d)
+all-tests-srcs := $(wildcard tests/test_*.c)
+all-tests := $(all-tests-srcs:.c=.bin)
 
 ## target-specific variables
 
@@ -79,6 +81,10 @@ install: install-user install-realtime
 realtime: lcec.so
 user: lcec_conf lcec_devices
 
+# Run all tests (auto-generated above from tests/test_*.c).
+test: $(all-tests)
+	$(foreach var, $(all-tests), $(var);)
+
 install-user: user
 	mkdir -p $(DESTDIR)$(EMC2_HOME)/bin
 	cp lcec_conf $(DESTDIR)$(EMC2_HOME)/bin/
@@ -101,3 +107,8 @@ lcec_conf: $(lcec-conf-objs) $(lcec-common-objs) liblcecdevices.a
 
 lcec_devices: lcec_devices.o $(lcec-common-objs) liblcecdevices.a
 	$(CC) -o $@ lcec_devices.o $(lcec-common-objs) -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal -lexpat -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -lethercat -lm
+
+# Rule for compiling tests/*.bin files.  We're naming test excutables *.bin so we can use wildcards in .gitignore and `make clean` to match them.
+tests/%.bin: tests/%.o $(lcec-common-objs) liblcecdevices.a
+	$(CC) -o $@ $(subst .bin,.o,$@) $(lcec-common-objs) -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal -lexpat -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -lethercat -lm
+

--- a/src/Makefile.clean
+++ b/src/Makefile.clean
@@ -8,5 +8,6 @@ clean:
 	rm -f modules.order Module.symvers
 	rm -rf .tmp_versions
 	rm -f lcec_conf
+	rm -f tests/*.bin
 
 

--- a/src/tests/test_lookup.c
+++ b/src/tests/test_lookup.c
@@ -1,0 +1,107 @@
+#include <stdio.h>
+
+#include "../../src/lcec.h"
+#include "tests.h"
+
+static const lcec_lookuptable_int_t table1[] = {
+    {"Pt100", 0},          // Pt100 sensor,
+    {"Ni100", 1},          // Ni100 sensor, -60 to 250C
+    {"Pt1000", 2},         // Pt1000 sensor, -200 to 850C
+    {"Pt500", 3},          // Pt500 sensor, -200 to 850C
+    {"Pt200", 4},          // Pt200 sensor, -200 to 850C
+    {"Ni1000", 5},         // Ni1000 sensor, -60 to 250C
+    {"Ni1000-TK5000", 6},  // Ni1000-TK5000, -30 to 160C
+    {"Ni120", 7},          // Ni120 sensor, -60 to 320C
+    {"Ohm/16", 8},         // no sensor, report Ohms directly.  0-4095 Ohms
+    {"Ohm/64", 9},         // no sensor, report Ohms directly.  0-1023 Ohms
+    {NULL},
+};
+
+static const lcec_lookuptable_int_t table2[] = {
+    {"Ohm/16", 1},
+    {"Ohm/64", 1},
+    {NULL},
+};
+
+static const lcec_lookuptable_double_t table3[] = {
+    {"Ohm/16", 1.0 / 16},
+    {"Ohm/64", 1.0 / 64},
+    {NULL},
+};
+
+int test_lookupint(void) {
+  TESTSETUP;
+
+  // Looking up "Pt100" should return 0.
+  TESTINT(lcec_lookupint(table1, "Pt100", -1), 0);
+  // Looking up "Pt101" (which isn't in the table) should return -1.
+  TESTINT(lcec_lookupint(table1, "Pt101", -1), -1);
+  // Looking up "Pt101" (which isn't in the table) should return -10, if we use -10 as the default value for lookups.
+  TESTINT(lcec_lookupint(table1, "Pt101", -10), -10);
+  // Looking up "pt100" (which isn't in the table) should return -1.
+  TESTINT(lcec_lookupint(table1, "pt100", -1), -1);
+
+  TESTRESULTS;
+}
+
+int test_lookupint_i(void) {
+  TESTSETUP;
+
+  // Looking up "Pt100" should return 0.
+  TESTINT(lcec_lookupint_i(table1, "Pt100", -1), 0);
+  // Looking up "Pt101" (which isn't in the table) should return -1.
+  TESTINT(lcec_lookupint_i(table1, "Pt101", -1), -1);
+  // Looking up "Pt101" (which isn't in the table) should return -10, if we use -10 as the default value for lookups.
+  TESTINT(lcec_lookupint_i(table1, "Pt101", -10), -10);
+  // Looking up "pt100" (which is in the table, when doing case-insensitive lookups) should return 0.
+  TESTINT(lcec_lookupint_i(table1, "pt100", -1), 0);
+
+  TESTRESULTS;
+}
+
+int test_sparsedefault(void) {
+  TESTSETUP;
+
+  TESTINT(lcec_lookupint(table2, "Pt100", 0), 0);
+  TESTINT(lcec_lookupint(table2, "Pt102", 0), 0);
+  TESTINT(lcec_lookupint(table2, "Ohm/16", 0), 1);
+  TESTINT(lcec_lookupint(table2, "Ohm/64", 0), 1);
+
+  TESTRESULTS;
+}
+
+int test_lookupdouble(void) {
+  TESTSETUP;
+
+  // I should really create a TESTDOUBLE() macro, but this works well enough for now.
+  TESTINT(lcec_lookupdouble(table3, "Pt100", 1.0), 1);
+  TESTINT(lcec_lookupdouble(table3, "ohm/16", 1.0), 1);
+  TESTINT(lcec_lookupdouble(table3, "Ohm/16", 1.0), 0);
+  TESTINT(lcec_lookupdouble(table3, "Ohm/64", 1.0), 0);
+
+  TESTRESULTS;
+}
+
+int test_lookupdouble_i(void) {
+  TESTSETUP;
+
+  // I should really create a TESTDOUBLE() macro, but this works well enough for now.
+  TESTINT(lcec_lookupdouble_i(table3, "Pt100", 1.0), 1);
+  TESTINT(lcec_lookupdouble_i(table3, "ohm/16", 1.0), 0);
+  TESTINT(lcec_lookupdouble_i(table3, "Ohm/16", 1.0), 0);
+  TESTINT(lcec_lookupdouble_i(table3, "Ohm/64", 1.0), 0);
+
+  TESTRESULTS;
+}
+
+int main(int argc, char **argv) {
+  TESTMAINSETUP;
+
+  TESTMAIN(test_lookupint);
+  TESTMAIN(test_lookupint_i);
+  TESTMAIN(test_sparsedefault);
+  TESTMAIN(test_lookupdouble);
+  TESTMAIN(test_lookupdouble_i);
+
+  TESTMAINRESULTS;
+}

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -1,0 +1,63 @@
+/// Very simple test setup for LinuxCNC-Ethercat.
+///
+/// To define tests, create a function called `int test_foo(void)`.
+/// In the first line, call `TESTSETUP;`.  In the last line, call
+/// `TESTRESULTS;`.  In between, do whatever setup is needed and call
+/// the `TEST()` macro to actually run tests.  It should be called
+/// like `TEST(int, lcec_lookupint(foo), 10, "Wanted %d, got %d");`
+/// The first arg is the result type, the next arg is the actual call
+/// that you're testing, and the third (and following) args are a
+/// printf format string (plus optional args) to print when the test
+/// fails.  There will be two additional args passed to printf, the
+/// result, and what was expected.  I'm generally following the way
+/// that Go does tests here, with `got=%d, want=%d` as the expected
+/// pattern for test failures.
+
+#define TESTSETUP int pass = 0, fail = 0
+
+#define TESTINT(call, want)                                             \
+  do {                                                                  \
+    int got;                                                            \
+    if (got = call, got != want) {                                      \
+      fprintf(stderr, "fail: %s, got %d, want %d\n", #call, got, want); \
+      fail++;                                                           \
+    } else {                                                            \
+      pass++;                                                           \
+    }                                                                   \
+  } while (0)
+
+#define TEST_MESSAGE(t, call, want, ...)       \
+  do {                                         \
+    t got;                                     \
+    if (got = call, got != want) {             \
+      fprintf(stderr, __VA_ARGS__, got, want); \
+      fail++;                                  \
+    } else {                                   \
+      pass++;                                  \
+    }                                          \
+  } while (0)
+
+#define TESTRESULTS                                                                    \
+  do {                                                                                 \
+    if (fail == 0) {                                                                   \
+      fprintf(stderr, "%s: PASS: %d tests pass.\n", __func__, pass);                   \
+      return 0;                                                                        \
+    } else {                                                                           \
+      fprintf(stderr, "%s: FAIL: %d tests passed, %d failed\n", __func__, pass, fail); \
+      return -1;                                                                       \
+    }                                                                                  \
+  } while (0)
+
+#define TESTMAINSETUP int result = 0
+#define TESTMAIN(func) \
+  if (func() != 0) result = 1
+#define TESTMAINRESULTS                     \
+  do {                                      \
+    if (result != 0) {                      \
+      fprintf(stderr, "Tests failed!\n");   \
+      return result;                        \
+    } else {                                \
+      fprintf(stderr, "All tests pass.\n"); \
+      return 0;                             \
+    }                                       \
+  } while (0)


### PR DESCRIPTION
Hey, look, it's preprocessor abuse day!

This adds a few tests in `src/tests`, enough `make` magic to make `make test` run them all, and updates the CI workflow to trigger `make test`.  It also removes the unused debian prep CI step, which should speed things up a bit.

Fixes #265 

