### PR TITLE
feat(din/dout): Digital in/out improvements

### DIFF
--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -21,11 +21,13 @@
 
 #include "lcec_class_din.h"
 
+#include <stdio.h>
+
 #include "../lcec.h"
 
 static const lcec_pindesc_t slave_pins[] = {
-    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_channel_t, in), "%s.%s.%s.din-%d"},
-    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_channel_t, in_not), "%s.%s.%s.din-%d-not"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_channel_t, in), "%s.%s.%s.%s"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_din_channel_t, in_not), "%s.%s.%s.%s-not"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
@@ -54,29 +56,94 @@ lcec_class_din_channels_t *lcec_din_allocate_channels(int count) {
 
 /// @brief registers a single digital-input channel and publishes it as a LinuxCNC HAL pin.
 ///
+/// See lcec_el1xxx.c for an example of use.
+///
+/// This calls `lcec_din_register_channel_named()`, with a default name of `din-<ID>` provided.
+///
 /// @param pdo_entry_regs a pointer to the pdo_entry_regs passed into the device `_init` function.
 /// @param slave the slave, from `_init`.
 /// @param id  the pin ID.  Used for naming.  Should generally start at 0 and increment once per digital in pin.
 /// @param idx the PDO index for the digital input.
 /// @param sindx the PDO sub-index for the digital input.
 ///
-/// See lcec_el1xxx.c for an example of use.
 lcec_class_din_channel_t *lcec_din_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx) {
+  char name[32];
+
+  snprintf(name, 32, "din-%d", id);
+
+  return lcec_din_register_channel_named(pdo_entry_regs, slave, idx, sidx, name);
+}
+
+/// @brief registers a single digital-input channel and publishes it as a LinuxCNC HAL pin.
+///
+/// @param pdo_entry_regs a pointer to the pdo_entry_regs passed into the device `_init` function.
+/// @param slave the slave, from `_init`.
+/// @param id  the pin ID.  Used for naming.  Should generally start at 0 and increment once per digital in pin.
+/// @param idx the PDO index for the digital input.
+/// @param sindx the PDO sub-index for the digital input.
+/// @param name The base name to use for the channel, `din-<ID>` is common.
+lcec_class_din_channel_t *lcec_din_register_channel_named(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name) {
   lcec_class_din_channel_t *data;
   int err;
 
   data = hal_malloc(sizeof(lcec_class_din_channel_t));
   if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
     return NULL;
   }
   memset(data, 0, sizeof(lcec_class_din_channel_t));
 
   LCEC_PDO_INIT((*pdo_entry_regs), slave->index, slave->vid, slave->pid, idx, sidx, &data->pdo_os, &data->pdo_bp);
-  err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, id);
+  err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, name);
   if (err != 0) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
+    rtapi_print_msg(
+        RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
+    return NULL;
+  }
+
+  return data;
+}
+
+/// @brief registers a single digital-input channel and publishes it as a LinuxCNC HAL pin.
+///
+/// The `_packed` variant is for devices where several logical digital
+/// input channels are packed into a single PDO.  For instance, the
+/// RTelligent ECT60 has 6 digital input pins plus 3 synthetic ports,
+/// all packed into a single U32.  This function is intended to be
+/// called 9 times, with the same `idx` and `sdx` values, but varying
+/// `bit` and `name` values.
+///
+/// @param pdo_entry_regs a pointer to the pdo_entry_regs passed into the device `_init` function.
+/// @param slave the slave, from `_init`.
+/// @param os  The offset from `LCEC_PDO_INIT()`.
+/// @param bit  The bit offset for the digital in channel.
+/// @param name The base name to use for the channel, `din-<ID>` is common.
+lcec_class_din_channel_t *lcec_din_register_channel_packed(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, unsigned int os, int bit, char *name) {
+  lcec_class_din_channel_t *data;
+  int err;
+
+  data = hal_malloc(sizeof(lcec_class_din_channel_t));
+  if (data == NULL) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
+    return NULL;
+  }
+  memset(data, 0, sizeof(lcec_class_din_channel_t));
+
+  // Register the whole PDO, hopefully this does the sane thing if we register the same PDO repeatedly.
+  // LCEC_PDO_INIT((*pdo_entry_regs), slave->index, slave->vid, slave->pid, idx, sidx, &data->pdo_os, &data->pdo_bp);
+  data->pdo_os = os;
+  data->pdo_bp = bit;
+
+  // This is kind of a terrible hack, but it should mostly work, modulo possible issues with variable-sized PDOs and endianness problems.
+  data->pdo_bp = bit;
+
+  err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, name);
+  if (err != 0) {
+    rtapi_print_msg(
+        RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
     return NULL;
   }
 

--- a/src/devices/lcec_class_din.h
+++ b/src/devices/lcec_class_din.h
@@ -10,7 +10,7 @@
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-// 
+//
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
@@ -22,10 +22,12 @@
 #include "../lcec.h"
 
 typedef struct {
-  hal_bit_t *in;        ///< `hal_bit_t` pin for the `din-X` pin in LinuxCNC
-  hal_bit_t *in_not;    ///< `hal_bit_t` pin for the `din-X-not` pin in LinuxCNC
-  unsigned int pdo_os;  ///< This bit's offset in the master's PDO data structure.
-  unsigned int pdo_bp;  ///< This bit's bit position in the master's PDO data structure.
+  char *name;                  ///< The channel name/number, used for debugging messages.
+  hal_bit_t *in;               ///< `hal_bit_t` pin for the `din-X` pin in LinuxCNC.
+  hal_bit_t *in_not;           ///< `hal_bit_t` pin for the `din-X-not` pin in LinuxCNC.
+  unsigned int pdo_os;         ///< This bit's offset in the master's PDO data structure.
+  unsigned int pdo_bp;         ///< This bit's bit position in the master's PDO data structure.
+  unsigned int pdo_bp_packed;  ///< This bit's bit position in the master's PDO data structure, for packed din.
 } lcec_class_din_channel_t;
 
 typedef struct {
@@ -38,7 +40,8 @@ lcec_class_din_channel_t *lcec_din_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
 lcec_class_din_channel_t *lcec_din_register_channel_named(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name);
-lcec_class_din_channel_t *lcec_din_register_channel_packed(ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, unsigned int os, int bit, char *name);
+lcec_class_din_channel_t *lcec_din_register_channel_packed(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, char *name);
 
 void lcec_din_read(struct lcec_slave *slave, lcec_class_din_channel_t *data);
 void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_channels_t *channels);

--- a/src/devices/lcec_class_din.h
+++ b/src/devices/lcec_class_din.h
@@ -10,7 +10,7 @@
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//
+// 
 //    You should have received a copy of the GNU General Public License
 //    along with this program; if not, write to the Free Software
 //    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
@@ -22,19 +22,23 @@
 #include "../lcec.h"
 
 typedef struct {
-  hal_bit_t *in;  ///< `hal_bit_t` pin for the `din-X` pin in LinuxCNC
-  hal_bit_t *in_not; ///< `hal_bit_t` pin for the `din-X-not` pin in LinuxCNC
+  hal_bit_t *in;        ///< `hal_bit_t` pin for the `din-X` pin in LinuxCNC
+  hal_bit_t *in_not;    ///< `hal_bit_t` pin for the `din-X-not` pin in LinuxCNC
   unsigned int pdo_os;  ///< This bit's offset in the master's PDO data structure.
   unsigned int pdo_bp;  ///< This bit's bit position in the master's PDO data structure.
 } lcec_class_din_channel_t;
 
 typedef struct {
-  int count;  ///< The number of channels described by this structure.
+  int count;                            ///< The number of channels described by this structure.
   lcec_class_din_channel_t **channels;  ///< a dynamic array of `lcec_class_din_channel_t` channels.
 } lcec_class_din_channels_t;
 
 lcec_class_din_channels_t *lcec_din_allocate_channels(int count);
 lcec_class_din_channel_t *lcec_din_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
+lcec_class_din_channel_t *lcec_din_register_channel_named(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name);
+lcec_class_din_channel_t *lcec_din_register_channel_packed(ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, unsigned int os, int bit, char *name);
+
 void lcec_din_read(struct lcec_slave *slave, lcec_class_din_channel_t *data);
 void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_channels_t *channels);

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -97,17 +97,61 @@ lcec_class_dout_channel_t *lcec_dout_register_channel_named(
     return NULL;
   }
   memset(data, 0, sizeof(lcec_class_dout_channel_t));
+  data->name = name;
+  data->pdo_bp_packed = 0xffff;
 
   LCEC_PDO_INIT((*pdo_entry_regs), slave->index, slave->vid, slave->pid, idx, sidx, &data->pdo_os, &data->pdo_bp);
   err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, name);
   if (err != 0) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
+    rtapi_print_msg(
+        RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
     return NULL;
   }
   err = lcec_param_newf_list(data, slave_params, LCEC_MODULE_NAME, slave->master->name, slave->name, name);
   if (err != 0) {
     rtapi_print_msg(
         RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_params_newf_list for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
+    return NULL;
+  }
+
+  return data;
+}
+
+/// @brief registers a single digital-output channel and publishes it as a LinuxCNC HAL pin.
+///
+/// The `_packed` variant is for devices where several logical digital
+/// output channels are packed into a single PDO.  For instance, the
+/// RTelligent ECT60 has 2 digital outputs sharing a single U32.  For
+/// the ECT60, this function is intended to be called twice, with the
+/// same `idx` and `sdx` values, but varying `bit` and `name` values.
+///
+/// @param pdo_entry_regs a pointer to the pdo_entry_regs passed into the device `_init` function.
+/// @param slave the slave, from `_init`.
+/// @param os  The offset from `LCEC_PDO_INIT()`.
+/// @param bit  The bit offset for the digital out channel.
+/// @param name The base name to use for the channel, `dout-<ID>` is common.
+lcec_class_dout_channel_t *lcec_dout_register_channel_packed(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, char *name) {
+  lcec_class_dout_channel_t *data;
+  int err;
+
+  data = hal_malloc(sizeof(lcec_class_dout_channel_t));
+  if (data == NULL) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
+    return NULL;
+  }
+  memset(data, 0, sizeof(lcec_class_dout_channel_t));
+
+  // Register the whole PDO, hopefully this does the sane thing if we register the same PDO repeatedly.
+  LCEC_PDO_INIT((*pdo_entry_regs), slave->index, slave->vid, slave->pid, idx, sidx, &data->pdo_os, &data->pdo_bp);
+
+  // This is kind of a terrible hack, but it should mostly work, modulo possible issues with variable-sized PDOs and endianness problems.
+  data->pdo_bp_packed = bit;
+
+  err = lcec_pin_newf_list(data, slave_pins, LCEC_MODULE_NAME, slave->master->name, slave->name, name);
+  if (err != 0) {
+    rtapi_print_msg(
+        RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_pin_newf_list for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
     return NULL;
   }
 
@@ -125,13 +169,23 @@ void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data) 
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   hal_bit_t s;
+  int os = data->pdo_os;
+  int bp = data->pdo_bp;
+
+  // If this is a packed input, then we need to use the packed bit
+  // offset, not the one that came back from LCEC_PDO_INIT().  We also
+  // need to adjust the offset to pick the correct byte.
+  if (data->pdo_bp_packed != 0xffff) {
+    bp = data->pdo_bp_packed & 7;
+    os += data->pdo_bp_packed >> 3;  // the data in pd[] is always little-endian.
+  }
 
   s = *(data->out);
   if (data->invert) {
     s = !s;
   }
 
-  EC_WRITE_BIT(&pd[data->pdo_os], data->pdo_bp, s);
+  EC_WRITE_BIT(&pd[os], bp, s);
 }
 
 /// @brief Write data to all digital out channels attached to this device.

--- a/src/devices/lcec_class_dout.h
+++ b/src/devices/lcec_class_dout.h
@@ -22,9 +22,12 @@
 #include "../lcec.h"
 
 typedef struct {
-  hal_bit_t *out;
-  hal_bit_t invert;
-  unsigned int pdo_os, pdo_bp;
+  char *name;                  ///< Used for debugging only
+  hal_bit_t *out;              ///< -dout-X pin in LinuxCNC
+  hal_bit_t invert;            ///< Is the value inverted?
+  unsigned int pdo_os;         ///< Byte offset in PDO data struct
+  unsigned int pdo_bp;         ///< Bit offset in PDO data byte
+  unsigned int pdo_bp_packed;  ///< Controls is this is a packed-bit port, where more than one channel is found in a single PDO entry.
 } lcec_class_dout_channel_t;
 
 typedef struct {
@@ -37,5 +40,7 @@ lcec_class_dout_channel_t *lcec_dout_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
 lcec_class_dout_channel_t *lcec_dout_register_channel_named(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name);
+lcec_class_dout_channel_t *lcec_dout_register_channel_packed(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, char *name);
 void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data);
 void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_channels_t *pins);

--- a/src/devices/lcec_class_dout.h
+++ b/src/devices/lcec_class_dout.h
@@ -35,5 +35,7 @@ typedef struct {
 lcec_class_dout_channels_t *lcec_dout_allocate_channels(int count);
 lcec_class_dout_channel_t *lcec_dout_register_channel(
     ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
+lcec_class_dout_channel_t *lcec_dout_register_channel_named(
+    ec_pdo_entry_reg_t **pdo_entry_regs, struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name);
 void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data);
 void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_channels_t *pins);


### PR DESCRIPTION
Add support for overriding the naming of `lcec_class_din` and `lcec_class_dout` pins.  By default, they're named `din-<ID>` and `dout-<ID>`, but a function is provided for providing the name directly.

Also support "packed" din/dout channels.  In this case, a packed channel is one where multiple channels share a single PDO entry on the slave, one per bit.  So, maybe bit 0 is `din-0`, bit 1 is `din-1`, and so forth.  They're registered using a new `_packed()` registration function, but otherwise work identically.

This builds and runs, but isn't fully tested yet.

This is a bit of a hack, but *should* work correctly.  I think.

Fixes #249 
