### PR TITLE
feat(cia402): Add supported modes pins

### DIFF
--- a/documentation/cia402.md
+++ b/documentation/cia402.md
@@ -363,9 +363,26 @@ TODO
 ### Pins
 
 The CiA 402 framework defines a number of HAL pins, depending on which optional features are enabled.
-
-TODO
-
+ 
+- `srv-cia-controlword` -- CiA 402 state machine control word, used by cia402 HAL component.
+- `srv-cia-statusword` -- CiA 402 state machine status word, used by cia402 HAL component.
+- `srv-opmode` -- CiA 402 opmode, used by cia402 HAL component.
+- `srv-opmode-display` -- CiA 402 current op mode, used by cia402 HAL component.
+- `srv-actual-position` -- actual position, in device-dependent units.
+- `srv-actual-velocity` -- actual velocity, in device-dependent units.
+- `srv-actual-torque` -- actual torque, in device-dependent units.
+- `srv-target-position` -- target position for `pp` and `csp` modes.
+- `srv-target-velocity` -- target velocity for `pv` and `csv` modes.
+- `srv-supported-modes`  -- Modes supported by this device, from 0x6502:00.
+- `srv-supports-mode-csp` -- True if this device supports `csp` mode.
+- `srv-supports-mode-cst` -- True if this device supports `cst` mode.
+- `srv-supports-mode-csv` -- True if this device supports `csv` mode.
+- `srv-supports-mode-hm` -- True if this device supports `hm` mode.
+- `srv-supports-mode-ip` -- True if this device supports `ip` mode.
+- `srv-supports-mode-pp` -- True if this device supports `pp` mode.
+- `srv-supports-mode-pv` -- True if this device supports `pv` mode.
+- `srv-supports-mode-tq` -- True if this device supports `pq` mode.
+- `srv-supports-mode-vl` -- True if this device supports `vl` mode.
 
 ## Supporting new devices
 
@@ -599,6 +616,6 @@ should all be called out.
 | 6405:00 | str  |                        | Motor catalog URL              |                            |                                                                                                     |
 | 6406:00 | time |                        | Motor calibration date         |                            |                                                                                                     |
 | 6407:00 | U32  |                        | Motor service period           |                            |                                                                                                     |
-| 6502:00 | U32  | yes                    | Supported opmodes              |                            |                                                                                                     |
+| 6502:00 | U32  | yes                    | Supported opmodes              | `srv-supported-modes`      | See also `srv-supports-mode-*`                                                                      |
 | 6503:00 | str  |                        | Drive catalog number           |                            |                                                                                                     |
 | 6505:00 | str  |                        | Drive catalog url              |                            |                                                                                                     |

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -31,6 +31,16 @@ static const lcec_pindesc_t pins_required[] = {
     // HAL_OUT is readable, HAL_IN is writable.
     {HAL_U32, HAL_IN, offsetof(lcec_class_cia402_channel_t, controlword), "%s.%s.%s.%s-cia-controlword"},
     {HAL_U32, HAL_OUT, offsetof(lcec_class_cia402_channel_t, statusword), "%s.%s.%s.%s-cia-statusword"},
+    {HAL_U32, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supported_modes), "%s.%s.%s.%s-supported-modes"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_pp), "%s.%s.%s.%s-supports-mode-pp"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_vl), "%s.%s.%s.%s-supports-mode-vl"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_pv), "%s.%s.%s.%s-supports-mode-pv"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_tq), "%s.%s.%s.%s-supports-mode-tq"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_hm), "%s.%s.%s.%s-supports-mode-hm"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_ip), "%s.%s.%s.%s-supports-mode-ip"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_csp), "%s.%s.%s.%s-supports-mode-csp"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_csv), "%s.%s.%s.%s-supports-mode-csv"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_class_cia402_channel_t, supports_mode_cst), "%s.%s.%s.%s-supports-mode-cst"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
@@ -351,6 +361,20 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(struct lcec_slave *sla
   HANDLE_OPTIONAL_PINS(actual_velocity);
   HANDLE_OPTIONAL_PINS(target_position);
   HANDLE_OPTIONAL_PINS(target_velocity);
+
+  uint32_t modes;
+  lcec_read_sdo32(slave, base_idx + 0x502, 0, &modes);
+
+  *(data->supported_modes) = modes;
+  *(data->supports_mode_pp) = modes & 1 << 0;
+  *(data->supports_mode_vl) = modes & 1 << 1;
+  *(data->supports_mode_pv) = modes & 1 << 2;
+  *(data->supports_mode_tq) = modes & 1 << 3;
+  *(data->supports_mode_hm) = modes & 1 << 5;
+  *(data->supports_mode_ip) = modes & 1 << 6;
+  *(data->supports_mode_csp) = modes & 1 << 7;
+  *(data->supports_mode_csv) = modes & 1 << 8;
+  *(data->supports_mode_cst) = modes & 1 << 9;
 
   return data;
 }

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -91,16 +91,20 @@ typedef struct {
   hal_s32_t *target_velocity;
 
   // In
+  hal_s32_t *actual_position;
+  hal_s32_t *actual_torque;
+  hal_s32_t *actual_velocity;
   hal_u32_t *statusword;
   hal_s32_t *opmode_display;
-  hal_s32_t *actual_position;
-  hal_s32_t *actual_velocity;
-  hal_s32_t *actual_torque;
+  hal_s32_t *supported_modes;
+  hal_bit_t *supports_mode_pp, *supports_mode_vl, *supports_mode_pv, *supports_mode_tq, *supports_mode_hm, *supports_mode_ip,
+      *supports_mode_csp, *supports_mode_csv, *supports_mode_cst;
 
-  unsigned int controlword_os;  ///< The controlword's offset in the master's PDO data structure.
-  unsigned int opmode_os;       ///< The opmode's offset in the master's PDO data structure.
-  unsigned int targetpos_os;    ///< The target position's offset in the master's PDO data structure.
-  unsigned int targetvel_os;    ///< The target velocity's offset in the master's PDO data structure.
+  unsigned int controlword_os;      ///< The controlword's offset in the master's PDO data structure.
+  unsigned int opmode_os;           ///< The opmode's offset in the master's PDO data structure.
+  unsigned int supported_modes_os;  ///< The supported modes offset in the master's PDO data structure.
+  unsigned int targetpos_os;        ///< The target position's offset in the master's PDO data structure.
+  unsigned int targetvel_os;        ///< The target velocity's offset in the master's PDO data structure.
 
   unsigned int statusword_os;   ///< The statusword's offset in the master's PDO data structure.
   unsigned int opmode_disp_os;  ///< The opmode display's offset in the master's PDO data structure.

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -189,8 +189,8 @@ static int handle_modparams(struct lcec_slave *slave) {
   int v;
 
   // Read current polarity values, so we don't overwrite them all.
-  lcec_read_sdo(slave, 0x2006, 0, (uint8_t *)&output_polarity, 2);
-  lcec_read_sdo(slave, 0x2008, 0, (uint8_t *)&input_polarity, 2);
+  lcec_read_sdo16(slave, 0x2006, 0, &output_polarity);
+  lcec_read_sdo16(slave, 0x2008, 0, &input_polarity);
 
   // We'll need to byte-swap here, for big-endian systems.
 

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -302,6 +302,15 @@ typedef struct {
 lcec_slave_t *lcec_slave_by_index(struct lcec_master *master, int index) __attribute__((nonnull));
 
 int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size);
+int lcec_read_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *result);
+int lcec_read_sdo8_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo8_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t *result);
+int lcec_read_sdo16_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo16_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t *result);
+int lcec_read_sdo32_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo32_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
 int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size);
 int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size);
 int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value);

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -125,6 +125,158 @@ int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, ui
   return 0;
 }
 
+/// @brief Read an 8-bit SDO from a slave device.
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint8_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *result) {
+  return lcec_read_sdo(slave, index, subindex, result, 1);
+}
+
+/// @brief Read a 16-bit SDO from a slave device.
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint16_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t *result) {
+  uint8_t data[2];
+  int err = lcec_read_sdo(slave, index, subindex, data, 2);
+  *result = EC_READ_U16(data);
+
+  return err;
+}
+
+/// @brief Read a 32-bit SDO from a slave device.
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t *result) {
+  uint8_t data[4];
+  int err = lcec_read_sdo(slave, index, subindex, data, 4);
+  *result = EC_READ_U32(data);
+
+  return err;
+}
+
+/// @brief Read an 8-bit SDO from a slave device into a U32 HAL pin.
+///
+/// This has two differences from `lcec_read_sdo8()`: the `result`
+/// paramater is a 32-bit integer, and it's declared `volatile` to
+/// reduce the number of warnings that GCC produces.
+///
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo8_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+  uint8_t data;
+  int err = lcec_read_sdo(slave, index, subindex, &data, 1);
+  *result = data;
+
+  return err;
+}
+
+/// @brief Read an 8-bit SDO from a slave device into a S32 HAL pin.
+///
+/// This has two differences from `lcec_read_sdo8()`: the `result`
+/// paramater is a 32-bit integer, and it's declared `volatile` to
+/// reduce the number of warnings that GCC produces.
+///
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo8_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+  uint8_t data;
+  int err = lcec_read_sdo(slave, index, subindex, &data, 1);
+  *result = data;
+
+  return err;
+}
+
+/// @brief Read a 16-bit SDO from a slave device into a U32 HAL pin.
+///
+/// This has two differences from `lcec_read_sdo16()`: the `result`
+/// paramater is a 32-bit integer, and it's declared `volatile` to
+/// reduce the number of warnings that GCC produces.
+///
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo16_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+  uint8_t data[2];
+  int err = lcec_read_sdo(slave, index, subindex, data, 2);
+  *result = EC_READ_U16(data);
+
+  return err;
+}
+
+/// @brief Read a 16-bit SDO from a slave device into a S32 HAL pin.
+///
+/// This has two differences from `lcec_read_sdo16()`: the `result`
+/// paramater is a 32-bit integer, and it's declared `volatile` to
+/// reduce the number of warnings that GCC produces.
+///
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo16_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+  uint8_t data[2];
+  int err = lcec_read_sdo(slave, index, subindex, data, 2);
+  *result = EC_READ_U16(data);
+
+  return err;
+}
+
+/// @brief Read a 32-bit SDO from a slave device into a U32 HAL pin.
+///
+/// This has two differences from `lcec_read_sdo32()`: the `result`
+/// paramater is a 32-bit integer, and it's declared `volatile` to
+/// reduce the number of warnings that GCC produces.
+///
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo32_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+  uint8_t data[4];
+  int err = lcec_read_sdo(slave, index, subindex, data, 4);
+  *result = EC_READ_U32(data);
+
+  return err;
+}
+
+/// @brief Read a 32-bit SDO from a slave device into a S32 HAL pin.
+///
+/// This has two differences from `lcec_read_sdo32()`: the `result`
+/// paramater is a 32-bit integer, and it's declared `volatile` to
+/// reduce the number of warnings that GCC produces.
+///
+/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
+/// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
+/// @param result A pointer to a `uint32_t` to write the result into.
+/// @return 0 for success, <0 for failure.
+int lcec_read_sdo32_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+  uint8_t data[4];
+  int err = lcec_read_sdo(slave, index, subindex, data, 4);
+  *result = EC_READ_U32(data);
+
+  return err;
+}
+
 /// @brief Write an SDO configuration to a slave device.
 ///
 /// This writes an SDO config to a specified slave device.  It can

--- a/tests/scottlaird-lcectest1/haltest.sh
+++ b/tests/scottlaird-lcectest1/haltest.sh
@@ -163,7 +163,7 @@ test-slave-oper D21
 
 echo "... Testing initial config of D22 (ECT60)"
 test-slave-oper D22
-test-pin-count D22 43
+test-pin-count D22 53
 
 echo "... Testing initial config of D23 (EP2308)"
 test-slave-oper D23


### PR DESCRIPTION
This exports object 0x6502 ("supported modes") as pin `srv-supported-modes` 

It also breaks out the standard modes into their own boolean pins, so higher-level code can check for feature support without doing bit math:

- `srv-supports-mode-csp`
- `srv-supports-mode-cst`
- `srv-supports-mode-csv`
- `srv-supports-mode-hm`
- `srv-supports-mode-ip`
- `srv-supports-mode-pp`
- `srv-supports-mode-pv`
- `srv-supports-mode-tq`
- `srv-supports-mode-vl`

Issue #180 