### PR TITLE
feat(cia402): Move profile and homing settings from modParams to pins

### DIFF
--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -421,9 +421,15 @@ static int lcec_rtec_init(int comp_id, struct lcec_slave *slave) {
   options->enable_pv = 1;
   options->enable_pp = 1;
   options->enable_csp = 1;
+  options->enable_csv = 1;
+  options->enable_hm = 1;
   options->enable_actual_torque = 1;
   options->enable_digital_input = 1;
   options->enable_digital_output = 1;
+  options->enable_profile_velocity = 1;
+  options->enable_profile_accel = 1;
+  options->enable_profile_decel = 1;
+  options->enable_home_accel = 1;
 
   // Set up syncs.  This is needed because the ECT60 (at least)
   // doesn't map all of the PDOs that we need, so we need to set up

--- a/src/tests/test_cia402.c
+++ b/src/tests/test_cia402.c
@@ -28,12 +28,12 @@ TESTFUNC(test_modparm_len) {
   channelized_mps = lcec_cia402_channelized_modparams(per_channel_mps);
   TESTNOTNULL(channelized_mps);
 
-  TESTINT(lcec_modparam_desc_len(channelized_mps), 15);
+  TESTINT(lcec_modparam_desc_len(channelized_mps), 27);
 
   lcec_modparam_desc_t *all_mps = lcec_modparam_desc_concat(channelized_mps, device_mps);
   TESTNOTNULL(all_mps);
 
-  TESTINT(lcec_modparam_desc_len(all_mps), 16);
+  TESTINT(lcec_modparam_desc_len(all_mps), 28);
 
   TESTRESULTS;
 }

--- a/tests/scottlaird-lcectest1/haltest.sh
+++ b/tests/scottlaird-lcectest1/haltest.sh
@@ -163,7 +163,7 @@ test-slave-oper D21
 
 echo "... Testing initial config of D22 (ECT60)"
 test-slave-oper D22
-test-pin-count D22 53
+test-pin-count D22 60
 
 echo "... Testing initial config of D23 (EP2308)"
 test-slave-oper D23


### PR DESCRIPTION
These mostly make sense to modify on the fly, so they should be pins, not modparams.  This pulls in the hardware's current values at startup, so we should have sane defaults to work with.

This also renumbers modParams and changes things so that we can support 8 axes, not just 4.  I'm hoping to have a 6-axis test device on hand later this week.

Issue #180