### PR TITLE
refactor(cia402): Consolidate optional object handling

### DIFF
--- a/src/lcec.h
+++ b/src/lcec.h
@@ -303,14 +303,14 @@ lcec_slave_t *lcec_slave_by_index(struct lcec_master *master, int index) __attri
 
 int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size);
 int lcec_read_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *result);
-int lcec_read_sdo8_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
-int lcec_read_sdo8_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo8_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo8_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
 int lcec_read_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t *result);
-int lcec_read_sdo16_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
-int lcec_read_sdo16_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo16_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo16_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
 int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t *result);
-int lcec_read_sdo32_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
-int lcec_read_sdo32_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo32_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo32_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
 int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size);
 int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size);
 int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value);

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -174,7 +174,7 @@ int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, 
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo8_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+int lcec_read_sdo8_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
   uint8_t data;
   int err = lcec_read_sdo(slave, index, subindex, &data, 1);
   *result = data;
@@ -193,7 +193,7 @@ int lcec_read_sdo8_pin(struct lcec_slave *slave, uint16_t index, uint8_t subinde
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo8_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+int lcec_read_sdo8_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
   uint8_t data;
   int err = lcec_read_sdo(slave, index, subindex, &data, 1);
   *result = data;
@@ -212,7 +212,7 @@ int lcec_read_sdo8_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t 
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo16_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+int lcec_read_sdo16_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
   uint8_t data[2];
   int err = lcec_read_sdo(slave, index, subindex, data, 2);
   *result = EC_READ_U16(data);
@@ -231,7 +231,7 @@ int lcec_read_sdo16_pin(struct lcec_slave *slave, uint16_t index, uint8_t subind
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo16_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+int lcec_read_sdo16_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
   uint8_t data[2];
   int err = lcec_read_sdo(slave, index, subindex, data, 2);
   *result = EC_READ_U16(data);
@@ -250,7 +250,7 @@ int lcec_read_sdo16_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo32_pin(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+int lcec_read_sdo32_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
   uint8_t data[4];
   int err = lcec_read_sdo(slave, index, subindex, data, 4);
   *result = EC_READ_U32(data);
@@ -269,7 +269,7 @@ int lcec_read_sdo32_pin(struct lcec_slave *slave, uint16_t index, uint8_t subind
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo32_pin_signed(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+int lcec_read_sdo32_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
   uint8_t data[4];
   int err = lcec_read_sdo(slave, index, subindex, data, 4);
   *result = EC_READ_U32(data);


### PR DESCRIPTION
The goal of this is to make every optional object basically identical, or as close as identical as possible.  It pulls index and subindex definitions into a set of `#define`s at the top and then references those from inside of `MAP_OPTIONAL_PDO()` and friends.  This should make adding additional optional PDOs (for `csv`, `cst`, `tq`, and `vl` modes, at a minimum) much less complicated and more consistent.

There is one remaining irritation here:

- The `OPTIONAL_PIN_x()` macros take a `var_name` and a `pin_name` parameter.  In all cases, the two are identical, except `var_name` uses underscores and `pin_name` uses dashes.  We could probably just use `# var_name` and then swap `_` for `-` later.

I'm not sure if that is worth bothering with, frankly.

Issue #180