### PR TITLE
feat(lcec_configgen): Add a new tool that can auto-generate XML files based on installed EtherCAT hardware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
                   GITHUB_CONTEXT: ${{ toJson(github) }}
               run: echo "$GITHUB_CONTEXT"
 
+            - uses: actions/setup-go@v4
+
             - name: Checkout linuxcnc-ethercat
               uses: actions/checkout@v4
 
@@ -125,7 +127,7 @@ jobs:
                   sudo apt install yapps2
 
             - name: Restore LinuxCNC cache
-              uses: actions/cache/restore@v3
+              uses: actions/cache/restore@v4
               env:
                   cache-name: cache-linuxcnc
               with:
@@ -133,7 +135,7 @@ jobs:
                   path: linuxcnc/
 
             - name: Restore Ethercat Master cache
-              uses: actions/cache/restore@v3
+              uses: actions/cache/restore@v4
               env:
                   cache-name: cache-ethercatmaster2
               with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,10 @@
 config.mk
 src/lcec_conf
 src/lcec_devices
+src/lcec_configgen
 src/Module.symvers
+src/configgen/devicelist
+src/configgen/lcec_configgen
 
 # Test files
 src/tests/*.bin

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: linuxcnc-ethercat
 Section: unknown
 Priority: extra
 Maintainer: Bjarne von Horn <vh@igh.de>
-Build-Depends: debhelper (>= 8.0.0), libexpat1-dev, linuxcnc-dev | linuxcnc-sim-dev | linuxcnc-uspace-dev | machinekit-dev, etherlabmaster-dev | libethercat-dev
+Build-Depends: debhelper (>= 8.0.0), libexpat1-dev, linuxcnc-dev | linuxcnc-sim-dev | linuxcnc-uspace-dev | machinekit-dev, etherlabmaster-dev | libethercat-dev, golang
 Standards-Version: 3.9.3
 
 Package: linuxcnc-ethercat

--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ install: install-user install-realtime
 	true  # override 'install' from $(MODINC)
 
 realtime: lcec.so
-user: lcec_conf lcec_devices
+user: lcec_conf lcec_devices lcec_configgen
 
 # Run all tests (auto-generated above from tests/test_*.c).
 test: $(all-tests)
@@ -89,6 +89,7 @@ test: $(all-tests)
 install-user: user
 	mkdir -p $(DESTDIR)$(EMC2_HOME)/bin
 	cp lcec_conf $(DESTDIR)$(EMC2_HOME)/bin/
+	cp lcec_configgen $(DESTDIR)/usr/bin/
 
 install-realtime: realtime
 	mkdir -p $(DESTDIR)$(RTLIBDIR)/
@@ -108,6 +109,16 @@ lcec_conf: $(lcec-conf-objs) $(lcec-common-objs) liblcecdevices.a
 
 lcec_devices: lcec_devices.o $(lcec-common-objs) liblcecdevices.a
 	$(CC) -o $@ lcec_devices.o $(lcec-common-objs) -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal -lexpat -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -lethercat -lm
+
+lcec_configgen: configgen/*.go configgen/*/*.go
+	(cd configgen ; go build lcec_configgen.go)
+	cp configgen/lcec_configgen .
+
+configgen/devicelist: configgen/devicelist.go
+	(cd configgen ; go build devicelist.go)
+
+configgen/drivers/drivers.go: configgen/devicelist ../documentation/devices/*.yml
+	(cd configgen ; go generate)
 
 # Rule for compiling tests/*.bin files.  We're naming test excutables *.bin so we can use wildcards in .gitignore and `make clean` to match them.
 tests/%.bin: tests/%.o $(lcec-common-objs) liblcecdevices.a

--- a/src/configgen/devicelist.go
+++ b/src/configgen/devicelist.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"bytes"
+	"gopkg.in/yaml.v3"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type DeviceDefinition struct {
+	Device           string `yaml:"Device"`
+	VendorID         string `yaml:"VendorID"`
+	VendorName       string `yaml:"VendorName"`
+	PID              string `yaml:"PID"`
+	Description      string `yaml:"Description"`
+	DocumentationURL string `yaml:"DocumentationURL"`
+	DeviceType       string `yaml:"DeviceType"`
+	Channels         int    `yaml:"Channels"`
+	Notes            string `yaml:"Notes"`
+	SrcFile          string `yaml:"SrcFile"`
+	TestingStatus    string `yaml:"TestingStatus"`
+}
+
+var (
+	pathFlag = flag.String("path", "../../documentation/devices/", "Path to *.yml files for device documentation")
+	outputFile = flag.String("output", "configgen/drivers.go", "File to create")
+)
+
+func parsefile(filename string) (*DeviceDefinition, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read file: %v", filename)
+	}
+
+	entry := &DeviceDefinition{}
+
+	err = yaml.Unmarshal(data, entry)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode yaml: %v", err)
+	}
+
+	return entry, nil
+}
+
+func main() {
+	flag.Parse()
+
+	entries := []*DeviceDefinition{}
+	otherfiles := 0
+
+	files, err := os.ReadDir(*pathFlag)
+	if err != nil {
+		log.Fatalf("Unable to read directory %q: %v", *pathFlag, err)
+	}
+
+	filenames := []string{}
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".yml") {
+			filenames = append(filenames, file.Name())
+		}
+	}
+
+	sort.Strings(filenames)
+	for _, name := range filenames {
+		if name[0] != '.' && strings.Contains(name, ".yml") {
+			entry, err := parsefile(filepath.Join(*pathFlag, name))
+			if err != nil {
+				log.Fatalf("Unable to parse file %q: %v", name, err)
+			}
+			if strings.TrimSpace(entry.Description) != "UNKNOWN" {
+				entries = append(entries, entry)
+			} else {
+				otherfiles++
+			}
+		}
+	}
+
+	var sb bytes.Buffer
+	
+	sb.WriteString("// Code generated  DO NOT EDIT.\n")
+	sb.WriteString("package configgen\n")
+	sb.WriteString("type EthercatDriver struct {\n")
+	sb.WriteString("	VendorID string\n")
+	sb.WriteString("    ProductID string\n")
+	sb.WriteString("    Type string\n")
+	sb.WriteString("}\n");
+
+	sb.WriteString("var Drivers=map[string]EthercatDriver{\n")
+	for _, e := range entries {
+		sb.WriteString(fmt.Sprintf("  %q: EthercatDriver{\n", e.Device))
+		sb.WriteString(fmt.Sprintf("    VendorID: %q,\n", e.VendorID))
+		sb.WriteString(fmt.Sprintf("    ProductID: %q,\n", e.PID))
+		sb.WriteString(fmt.Sprintf("    Type: %q,\n", e.Device))
+		sb.WriteString("  },\n")
+	}
+	sb.WriteString("}\n")
+
+	err = os.WriteFile(*outputFile, sb.Bytes(), 0644)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/src/configgen/drivers/drivers.go
+++ b/src/configgen/drivers/drivers.go
@@ -1,0 +1,1234 @@
+// Code generated  DO NOT EDIT.
+package configgen
+type EthercatDriver struct {
+	VendorID string
+    ProductID string
+    Type string
+}
+var Drivers=map[string]EthercatDriver{
+  "AX5101": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13ed6012",
+    Type: "AX5101",
+  },
+  "AX5103": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13ef6012",
+    Type: "AX5103",
+  },
+  "AX5106": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13f26012",
+    Type: "AX5106",
+  },
+  "AX5112": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13f86012",
+    Type: "AX5112",
+  },
+  "AX5118": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13fe6012",
+    Type: "AX5118",
+  },
+  "AX5203": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x14536012",
+    Type: "AX5203",
+  },
+  "AX5206": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x14566012",
+    Type: "AX5206",
+  },
+  "AX5805": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x16ad6012",
+    Type: "AX5805",
+  },
+  "DEMS300": EthercatDriver{
+    VendorID: "0x000001dd",
+    ProductID: "0x10400200",
+    Type: "DEMS300",
+  },
+  "DEASDA": EthercatDriver{
+    VendorID: "0x000001dd",
+    ProductID: "0x10305070",
+    Type: "DEASDA",
+  },
+  "DEASDA3": EthercatDriver{
+    VendorID: "0x000001dd",
+    ProductID: "0x00006010",
+    Type: "DEASDA3",
+  },
+  "DeASDB3": EthercatDriver{
+    VendorID: "0x000001dd",
+    ProductID: "0x00006080",
+    Type: "DeASDB3",
+  },
+  "ECR60": EthercatDriver{
+    VendorID: "0x00000a88",
+    ProductID: "0x0a880001",
+    Type: "ECR60",
+  },
+  "ECR60x2": EthercatDriver{
+    VendorID: "0x00000a88",
+    ProductID: "0x0a880005",
+    Type: "ECR60x2",
+  },
+  "ECR86": EthercatDriver{
+    VendorID: "0x00000a88",
+    ProductID: "0x0a880003",
+    Type: "ECR86",
+  },
+  "ECT60": EthercatDriver{
+    VendorID: "0x00000a88",
+    ProductID: "0x0a880002",
+    Type: "ECT60",
+  },
+  "ECT60x2": EthercatDriver{
+    VendorID: "0x00000a88",
+    ProductID: "0x0a880006",
+    Type: "ECT60x2",
+  },
+  "ECT86": EthercatDriver{
+    VendorID: "0x00000a88",
+    ProductID: "0x0a880004",
+    Type: "ECT86",
+  },
+  "EJ1859": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07432852",
+    Type: "EJ1859",
+  },
+  "EJ3004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bbc2852",
+    Type: "EJ3004",
+  },
+  "EJ3202": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c822852",
+    Type: "EJ3202",
+  },
+  "EJ3214": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c8e2852",
+    Type: "EJ3214",
+  },
+  "EJ4002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa22852",
+    Type: "EJ4002",
+  },
+  "EJ4004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa42852",
+    Type: "EJ4004",
+  },
+  "EJ4008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa82852",
+    Type: "EJ4008",
+  },
+  "EJ4018": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fb22852",
+    Type: "EJ4018",
+  },
+  "EJ4024": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fb82852",
+    Type: "EJ4024",
+  },
+  "EJ4132": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10242852",
+    Type: "EJ4132",
+  },
+  "EJ4134": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10262852",
+    Type: "EJ4134",
+  },
+  "EJ5002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x138a2852",
+    Type: "EJ5002",
+  },
+  "EK1100": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x044c2c52",
+    Type: "EK1100",
+  },
+  "EK1101": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x044d2c52",
+    Type: "EK1101",
+  },
+  "EK1110": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04562c52",
+    Type: "EK1110",
+  },
+  "EK1122": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04622c52",
+    Type: "EK1122",
+  },
+  "EK1814": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07162c52",
+    Type: "EK1814",
+  },
+  "EK1818": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x071a2c52",
+    Type: "EK1818",
+  },
+  "EK1828-0010": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07242c52",
+    Type: "EK1828-0010",
+  },
+  "EK1828": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07242c52",
+    Type: "EK1828",
+  },
+  "EL1002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03ea3052",
+    Type: "EL1002",
+  },
+  "EL1004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03ec3052",
+    Type: "EL1004",
+  },
+  "EL1008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03f03052",
+    Type: "EL1008",
+  },
+  "EL1012": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03f43052",
+    Type: "EL1012",
+  },
+  "EL1014": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03f63052",
+    Type: "EL1014",
+  },
+  "EL1018": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03fa3052",
+    Type: "EL1018",
+  },
+  "EL1024": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04003052",
+    Type: "EL1024",
+  },
+  "EL1034": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x040a3052",
+    Type: "EL1034",
+  },
+  "EL1084": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x043c3052",
+    Type: "EL1084",
+  },
+  "EL1088": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04403052",
+    Type: "EL1088",
+  },
+  "EL1094": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04463052",
+    Type: "EL1094",
+  },
+  "EL1098": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x044a3052",
+    Type: "EL1098",
+  },
+  "EL1104": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04503052",
+    Type: "EL1104",
+  },
+  "EL1114": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x045a3052",
+    Type: "EL1114",
+  },
+  "EL1124": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04643052",
+    Type: "EL1124",
+  },
+  "EL1134": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x046e3052",
+    Type: "EL1134",
+  },
+  "EL1144": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04783052",
+    Type: "EL1144",
+  },
+  "EL1252": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04e43052",
+    Type: "EL1252",
+  },
+  "EL1804": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x070c3052",
+    Type: "EL1804",
+  },
+  "EL1808": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07103052",
+    Type: "EL1808",
+  },
+  "EL1809": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07113052",
+    Type: "EL1809",
+  },
+  "EL1819": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x071b3052",
+    Type: "EL1819",
+  },
+  "EL1852": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x073c3052",
+    Type: "EL1852",
+  },
+  "EL1859": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07433052",
+    Type: "EL1859",
+  },
+  "EL1904": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07703052",
+    Type: "EL1904",
+  },
+  "EL1918_LOGIC": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x077e3052",
+    Type: "EL1918_LOGIC",
+  },
+  "EL2002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07d23052",
+    Type: "EL2002",
+  },
+  "EL2004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07d43052",
+    Type: "EL2004",
+  },
+  "EL2008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07d83052",
+    Type: "EL2008",
+  },
+  "EL2022": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07e63052",
+    Type: "EL2022",
+  },
+  "EL2024": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07e83052",
+    Type: "EL2024",
+  },
+  "EL2032": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07f03052",
+    Type: "EL2032",
+  },
+  "EL2034": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07f23052",
+    Type: "EL2034",
+  },
+  "EL2042": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07fa3052",
+    Type: "EL2042",
+  },
+  "EL2084": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x08243052",
+    Type: "EL2084",
+  },
+  "EL2088": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x08283052",
+    Type: "EL2088",
+  },
+  "EL2124": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x084c3052",
+    Type: "EL2124",
+  },
+  "EL2202": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x089a3052",
+    Type: "EL2202",
+  },
+  "EL2521": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x09d93052",
+    Type: "EL2521",
+  },
+  "EL2612": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0a343052",
+    Type: "EL2612",
+  },
+  "EL2622": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0a3e3052",
+    Type: "EL2622",
+  },
+  "EL2634": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0a4a3052",
+    Type: "EL2634",
+  },
+  "EL2652": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0a5c3052",
+    Type: "EL2652",
+  },
+  "EL2798": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0aee3052",
+    Type: "EL2798",
+  },
+  "EL2808": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0af83052",
+    Type: "EL2808",
+  },
+  "EL2809": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0af93052",
+    Type: "EL2809",
+  },
+  "EL2904": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0b583052",
+    Type: "EL2904",
+  },
+  "EL3001": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bb93052",
+    Type: "EL3001",
+  },
+  "EL3002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bba3052",
+    Type: "EL3002",
+  },
+  "EL3004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bbc3052",
+    Type: "EL3004",
+  },
+  "EL3008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bc03052",
+    Type: "EL3008",
+  },
+  "EL3011": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bc33052",
+    Type: "EL3011",
+  },
+  "EL3012": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bc43052",
+    Type: "EL3012",
+  },
+  "EL3014": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bc63052",
+    Type: "EL3014",
+  },
+  "EL3021": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bcd3052",
+    Type: "EL3021",
+  },
+  "EL3022": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bce3052",
+    Type: "EL3022",
+  },
+  "EL3024": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bd03052",
+    Type: "EL3024",
+  },
+  "EL3041": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0be13052",
+    Type: "EL3041",
+  },
+  "EL3042": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0be23052",
+    Type: "EL3042",
+  },
+  "EL3044": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0be43052",
+    Type: "EL3044",
+  },
+  "EL3048": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0be83052",
+    Type: "EL3048",
+  },
+  "EL3051": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0beb3052",
+    Type: "EL3051",
+  },
+  "EL3052": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bec3052",
+    Type: "EL3052",
+  },
+  "EL3054": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bee3052",
+    Type: "EL3054",
+  },
+  "EL3058": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bf23052",
+    Type: "EL3058",
+  },
+  "EL3061": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bf53052",
+    Type: "EL3061",
+  },
+  "EL3062": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bf63052",
+    Type: "EL3062",
+  },
+  "EL3064": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bf83052",
+    Type: "EL3064",
+  },
+  "EL3068": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0bfc3052",
+    Type: "EL3068",
+  },
+  "EL3101": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c1d3052",
+    Type: "EL3101",
+  },
+  "EL3102": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c1e3052",
+    Type: "EL3102",
+  },
+  "EL3104": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c203052",
+    Type: "EL3104",
+  },
+  "EL3111": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c273052",
+    Type: "EL3111",
+  },
+  "EL3112": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c283052",
+    Type: "EL3112",
+  },
+  "EL3114": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c2a3052",
+    Type: "EL3114",
+  },
+  "EL3121": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c313052",
+    Type: "EL3121",
+  },
+  "EL3122": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c323052",
+    Type: "EL3122",
+  },
+  "EL3124": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c343052",
+    Type: "EL3124",
+  },
+  "EL3141": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c453052",
+    Type: "EL3141",
+  },
+  "EL3142": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c463052",
+    Type: "EL3142",
+  },
+  "EL3144": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c483052",
+    Type: "EL3144",
+  },
+  "EL3151": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c4f3052",
+    Type: "EL3151",
+  },
+  "EL3152": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c503052",
+    Type: "EL3152",
+  },
+  "EL3154": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c523052",
+    Type: "EL3154",
+  },
+  "EL3161": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c593052",
+    Type: "EL3161",
+  },
+  "EL3162": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c5a3052",
+    Type: "EL3162",
+  },
+  "EL3164": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c5c3052",
+    Type: "EL3164",
+  },
+  "EL3182": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c6e3052",
+    Type: "EL3182",
+  },
+  "EL3201": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c813052",
+    Type: "EL3201",
+  },
+  "EL3202": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c823052",
+    Type: "EL3202",
+  },
+  "EL3204": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c843052",
+    Type: "EL3204",
+  },
+  "EL3208": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c883052",
+    Type: "EL3208",
+  },
+  "EL3214": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c8e3052",
+    Type: "EL3214",
+  },
+  "EL3218": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c923052",
+    Type: "EL3218",
+  },
+  "EL3255": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0cb73052",
+    Type: "EL3255",
+  },
+  "EL3403": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0d4b3052",
+    Type: "EL3403",
+  },
+  "EL4001": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa13052",
+    Type: "EL4001",
+  },
+  "EL4002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa23052",
+    Type: "EL4002",
+  },
+  "EL4004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa43052",
+    Type: "EL4004",
+  },
+  "EL4008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fa83052",
+    Type: "EL4008",
+  },
+  "EL4011": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fab3052",
+    Type: "EL4011",
+  },
+  "EL4012": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fac3052",
+    Type: "EL4012",
+  },
+  "EL4014": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fae3052",
+    Type: "EL4014",
+  },
+  "EL4018": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fb23052",
+    Type: "EL4018",
+  },
+  "EL4021": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fb53052",
+    Type: "EL4021",
+  },
+  "EL4022": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fb63052",
+    Type: "EL4022",
+  },
+  "EL4024": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fb83052",
+    Type: "EL4024",
+  },
+  "EL4028": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fbc3052",
+    Type: "EL4028",
+  },
+  "EL4031": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fbf3052",
+    Type: "EL4031",
+  },
+  "EL4032": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fc03052",
+    Type: "EL4032",
+  },
+  "EL4034": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fc23052",
+    Type: "EL4034",
+  },
+  "EL4038": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0fc63052",
+    Type: "EL4038",
+  },
+  "EL4102": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10063052",
+    Type: "EL4102",
+  },
+  "EL4104": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10083052",
+    Type: "EL4104",
+  },
+  "EL4112": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10103052",
+    Type: "EL4112",
+  },
+  "EL4114": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10123052",
+    Type: "EL4114",
+  },
+  "EL4122": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x101a3052",
+    Type: "EL4122",
+  },
+  "EL4124": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x101c3052",
+    Type: "EL4124",
+  },
+  "EL4132": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10243052",
+    Type: "EL4132",
+  },
+  "EL4134": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x10263052",
+    Type: "EL4134",
+  },
+  "EL5002": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x138a3052",
+    Type: "EL5002",
+  },
+  "EL5032": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13a83052",
+    Type: "EL5032",
+  },
+  "EL5101": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13ed3052",
+    Type: "EL5101",
+  },
+  "EL5102": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x13ee3052",
+    Type: "EL5102",
+  },
+  "EL5151": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x141f3052",
+    Type: "EL5151",
+  },
+  "EL5152": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x14203052",
+    Type: "EL5152",
+  },
+  "EL6090": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x17ca3052",
+    Type: "EL6090",
+  },
+  "EL6900": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1af43052",
+    Type: "EL6900",
+  },
+  "EL7031": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b773052",
+    Type: "EL7031",
+  },
+  "EL7041-0052": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EL7041-0052",
+  },
+  "EL7041-1000": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EL7041-1000",
+  },
+  "EL7041": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EL7041",
+  },
+  "EL7201_9014": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1c213052",
+    Type: "EL7201_9014",
+  },
+  "EL7211": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1c2b3052",
+    Type: "EL7211",
+  },
+  "EL7221": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1c353052",
+    Type: "EL7221",
+  },
+  "EL7342": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1cae3052",
+    Type: "EL7342",
+  },
+  "EL7411": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1cf33052",
+    Type: "EL7411",
+  },
+  "EL9505": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x25213052",
+    Type: "EL9505",
+  },
+  "EL9508": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x25243052",
+    Type: "EL9508",
+  },
+  "EL9510": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x25263052",
+    Type: "EL9510",
+  },
+  "EL9512": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x25283052",
+    Type: "EL9512",
+  },
+  "EL9515": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x252b3052",
+    Type: "EL9515",
+  },
+  "EL9576": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x25683052",
+    Type: "EL9576",
+  },
+  "EM3701": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0e753452",
+    Type: "EM3701",
+  },
+  "EM3702": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0e763452",
+    Type: "EM3702",
+  },
+  "EM3712": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0e803452",
+    Type: "EM3712",
+  },
+  "EM7004": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b5c3452",
+    Type: "EM7004",
+  },
+  "EP1008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03f04052",
+    Type: "EP1008",
+  },
+  "EP1018": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x03fa4052",
+    Type: "EP1018",
+  },
+  "EP1122": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x04624052",
+    Type: "EP1122",
+  },
+  "EP1819": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x071b4052",
+    Type: "EP1819",
+  },
+  "EP2008": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07d84052",
+    Type: "EP2008",
+  },
+  "EP2028": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07ec4052",
+    Type: "EP2028",
+  },
+  "EP2308": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x09044052",
+    Type: "EP2308",
+  },
+  "EP2316": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x090c4052",
+    Type: "EP2316",
+  },
+  "EP2318": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x090e4052",
+    Type: "EP2318",
+  },
+  "EP2328": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x09184052",
+    Type: "EP2328",
+  },
+  "EP2338": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x09224052",
+    Type: "EP2338",
+  },
+  "EP2339": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x09234052",
+    Type: "EP2339",
+  },
+  "EP2349": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x092d4052",
+    Type: "EP2349",
+  },
+  "EP2809": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0af94052",
+    Type: "EP2809",
+  },
+  "EP3174": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c664052",
+    Type: "EP3174",
+  },
+  "EP3184": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c704052",
+    Type: "EP3184",
+  },
+  "EP3204": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c844052",
+    Type: "EP3204",
+  },
+  "EP4174": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x104e4052",
+    Type: "EP4174",
+  },
+  "EP7041": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EP7041",
+  },
+  "EPP2308": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x64765649",
+    Type: "EPP2308",
+  },
+  "EPP2316": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x090c4052",
+    Type: "EPP2316",
+  },
+  "EPP2318": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x647656e9",
+    Type: "EPP2318",
+  },
+  "EPP2328": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x64765789",
+    Type: "EPP2328",
+  },
+  "EPP2334": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x647657e9",
+    Type: "EPP2334",
+  },
+  "EPP2338": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x64765829",
+    Type: "EPP2338",
+  },
+  "EPP2339": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x64765839",
+    Type: "EPP2339",
+  },
+  "EPP2349": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x647658d9",
+    Type: "EPP2349",
+  },
+  "EPX3158": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x9809ab69",
+    Type: "EPX3158",
+  },
+  "EQ2339": EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x092d4052",
+    Type: "EQ2339",
+  },
+  "EX260-SEC1": EthercatDriver{
+    VendorID: "0x00000114",
+    ProductID: "0x01000001",
+    Type: "EX260-SEC1",
+  },
+  "EX260-SEC2": EthercatDriver{
+    VendorID: "0x00000114",
+    ProductID: "0x01000002",
+    Type: "EX260-SEC2",
+  },
+  "EX260-SEC3": EthercatDriver{
+    VendorID: "0x00000114",
+    ProductID: "0x01000003",
+    Type: "EX260-SEC3",
+  },
+  "EX260-SEC4": EthercatDriver{
+    VendorID: "0x00000114",
+    ProductID: "0x01000004",
+    Type: "EX260-SEC4",
+  },
+  "EasyIO": EthercatDriver{
+    VendorID: "0x0000079a",
+    ProductID: "0x0debacca",
+    Type: "EasyIO",
+  },
+  "EPOCAT": EthercatDriver{
+    VendorID: "0x0000079A",
+    ProductID: "0x00decade",
+    Type: "EPOCAT",
+  },
+  "OmrG5_KN01H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000005",
+    Type: "OmrG5_KN01H",
+  },
+  "OmrG5_KN01L": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000002",
+    Type: "OmrG5_KN01L",
+  },
+  "OmrG5_KN02H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000006",
+    Type: "OmrG5_KN02H",
+  },
+  "OmrG5_KN02L": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000003",
+    Type: "OmrG5_KN02L",
+  },
+  "OmrG5_KN04H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000007",
+    Type: "OmrG5_KN04H",
+  },
+  "OmrG5_KN04L": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000004",
+    Type: "OmrG5_KN04L",
+  },
+  "OmrG5_KN06F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000b",
+    Type: "OmrG5_KN06F",
+  },
+  "OmrG5_KN08H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000008",
+    Type: "OmrG5_KN08H",
+  },
+  "OmrG5_KN10F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000c",
+    Type: "OmrG5_KN10F",
+  },
+  "OmrG5_KN10H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000009",
+    Type: "OmrG5_KN10H",
+  },
+  "OmrG5_KN150F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005f",
+    Type: "OmrG5_KN150F",
+  },
+  "OmrG5_KN150H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005a",
+    Type: "OmrG5_KN150H",
+  },
+  "OmrG5_KN15F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000d",
+    Type: "OmrG5_KN15F",
+  },
+  "OmrG5_KN15H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000a",
+    Type: "OmrG5_KN15H",
+  },
+  "OmrG5_KN20F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005b",
+    Type: "OmrG5_KN20F",
+  },
+  "OmrG5_KN20H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000056",
+    Type: "OmrG5_KN20H",
+  },
+  "OmrG5_KN30F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005c",
+    Type: "OmrG5_KN30F",
+  },
+  "OmrG5_KN30H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000057",
+    Type: "OmrG5_KN30H",
+  },
+  "OmrG5_KN50F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005d",
+    Type: "OmrG5_KN50F",
+  },
+  "OmrG5_KN50H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000058",
+    Type: "OmrG5_KN50H",
+  },
+  "OmrG5_KN75F": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005e",
+    Type: "OmrG5_KN75F",
+  },
+  "OmrG5_KN75H": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000059",
+    Type: "OmrG5_KN75H",
+  },
+  "OmrG5_KNA5L": EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000001",
+    Type: "OmrG5_KNA5L",
+  },
+  "STMDS5K": EthercatDriver{
+    VendorID: "0x000000b9",
+    ProductID: "0x00001388",
+    Type: "STMDS5K",
+  },
+  "basic_cia402": EthercatDriver{
+    VendorID: "0xffffffff",
+    ProductID: "0xffffffff",
+    Type: "basic_cia402",
+  },
+}

--- a/src/configgen/go.mod
+++ b/src/configgen/go.mod
@@ -1,0 +1,5 @@
+module github.com/linuxcnc-ethercat/linuxcnc-ethercat/configgen
+
+go 1.16
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/src/configgen/go.sum
+++ b/src/configgen/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/configgen/lcec_configgen.go
+++ b/src/configgen/lcec_configgen.go
@@ -1,0 +1,533 @@
+package main
+
+// This is intended to create a LinuxCNC XML config file on stdout,
+// based on information from `ethercat slaves` and `ethercat sdos`.
+// It can recognize all EtherCAT devices that LinuxCNC currently has
+// drivers for, as well as recognizing otherwise-unknown CiA 402
+// devices.  Unknown CiA 402 devices will have their SDOs probed, as
+// well as the value of 0x6502:00, and a set of `<modParam>`s will be
+// generated that should enable all of the standard CiA 402 features
+// that the hardware supports.  This isn't as good as a
+// device-specific driver (there's no support for setting
+// device-specific options, for example), but it should be usable in
+// most cases.
+
+//go:generate ./devicelist --output drivers/drivers.go
+//
+// This tells Go to generate configgen/drivers.go using the
+// 'devicelist' tool in this directory.  This parses all of the YAML
+// files in `documentation/devices` to identify drivers, VIDs, and
+// PIDs.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"github.com/linuxcnc-ethercat/linuxcnc-ethercat/configgen/drivers"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type EthercatSlave struct {
+	Master     string
+	Slave      string
+	VendorID   string
+	ProductID  string
+	RevisionNo string
+	DeviceName string
+	SDOs       map[string]string
+}
+
+// This block of `Config*` types are intended to match the full set of
+// XML parameters that `lcec_conf` can parse, so we can use this for
+// editing configs.  For various reasons, that may never actually be
+// useful (it'd eat comments, for one), but it's probably worth having
+// a second implementation, anyway.
+type ConfigRoot struct {
+	XMLName xml.Name `xml:"masters"`
+	Masters []*ConfigMaster
+}
+
+type ConfigMaster struct {
+	XMLName           xml.Name `xml:"master"`
+	Idx               string   `xml:"idx,attr"`
+	AppTimePeriod     string   `xml:"appTimePeriod,attr,omitempty"`
+	RefClockSyncCyles string   `xml:"refClockSyncCycles,attr,omitempty"`
+	Slaves            []ConfigSlave
+}
+
+type ConfigSlave struct {
+	Comment      string   `xml:",comment"`
+	XMLName      xml.Name `xml:"slave"`
+	Idx          string   `xml:"idx,attr"`
+	Type         string   `xml:"type,attr"`
+	Vid          string   `xml:"vid,attr,omitempty"`
+	Pid          string   `xml:"pid,attr,omitempty"`
+	Name         string   `xml:"name,attr"`
+	ConfigPDOs   string   `xml:"configPdos,attr,omitempty"`
+	SyncManagers []*ConfigSyncManager
+	ModParams    []ConfigModParam
+}
+
+type ConfigModParam struct {
+	XMLName xml.Name `xml:"modParam"`
+	Name    string   `xml:"name,attr"`
+	Value   string   `xml:"value,attr"`
+}
+
+type ConfigSyncManager struct {
+	XMLName xml.Name `xml:"syncManager"`
+	Idx     string   `xml:"idx,attr"`
+	Dir     string   `xml:"dir,attr"`
+	PDOs    []*ConfigPDO
+}
+
+type ConfigPDO struct {
+	XMLName xml.Name `xml:"pdo"`
+	Idx     string   `xml:"idx,attr"`
+	Entries []*ConfigPDOEntry
+}
+
+type ConfigPDOEntry struct {
+	XMLName        xml.Name `xml:"pdoEntry"`
+	Idx            string   `xml:"idx,attr"`
+	SubIdx         string   `xml:"subIdx,attr"`
+	BitLen         string   `xml:"bitLen,attr"`
+	HalPin         string   `xml:"halPin,attr"`
+	HalType        string   `xml:"halType,attr"`
+	Scale          string   `xml:"scale,attr,omitempty"`
+	Offset         string   `xml:"offset,attr,omitempty"`
+	ComplexEntries []*ConfigComplexEntry
+	Comment        string `xml:",comment"`
+}
+
+type ConfigComplexEntry struct {
+	XMLName xml.Name `xml:"complexEntry"`
+	BitLen  string   `xml:"bitLen,attr"`
+	HalPin  string   `xml:"halPin,attr"`
+	HalType string   `xml:"halType,attr"`
+	Scale   string   `xml:"scale,attr"`
+	Offset  string   `xml:"offset,attr"`
+}
+
+type EnableSDO struct {
+	offset, subindex int
+	name             string
+}
+
+var (
+	EnableSDOs = []EnableSDO{
+		EnableSDO{name: "enableActualCurrent", offset: 0x78, subindex: 0},
+		EnableSDO{name: "enableActualFollowingError", offset: 0xf4, subindex: 0},
+		EnableSDO{name: "enableActualTorque", offset: 0x77, subindex: 0},
+		EnableSDO{name: "enableActualVelocitySensor", offset: 0x69, subindex: 0},
+		EnableSDO{name: "enableActualVoltage", offset: 0x79, subindex: 0},
+		EnableSDO{name: "enableFollowingErrorTimeout", offset: 0x66, subindex: 0},
+		EnableSDO{name: "enableFollowingErrorWindow", offset: 0x65, subindex: 0},
+		EnableSDO{name: "enableHomeAccel", offset: 0x9a, subindex: 0},
+		EnableSDO{name: "enableInterpolationTimePeriod", offset: 0xc2, subindex: 1},
+		EnableSDO{name: "enableMaximumAcceleration", offset: 0xc6, subindex: 0},
+		EnableSDO{name: "enableMaximumCurrent", offset: 0x73, subindex: 0},
+		EnableSDO{name: "enableMaximumDeceleration", offset: 0xc6, subindex: 0},
+		EnableSDO{name: "enableMaximumMotorRPM", offset: 0x80, subindex: 0},
+		EnableSDO{name: "enableMaximumTorque", offset: 0x72, subindex: 0},
+		EnableSDO{name: "enableMotorRatedCurrent", offset: 0x75, subindex: 0},
+		EnableSDO{name: "enableMotorRatedTorque", offset: 0x76, subindex: 0},
+		EnableSDO{name: "enablePolarity", offset: 0x73, subindex: 0},
+		EnableSDO{name: "enableProfileAccel", offset: 0x83, subindex: 0},
+		EnableSDO{name: "enableProfileDecel", offset: 0x84, subindex: 0},
+		EnableSDO{name: "enableProfileEndVelocity", offset: 0x82, subindex: 0},
+		EnableSDO{name: "enableProfileMaxVelocity", offset: 0x7f, subindex: 0},
+		EnableSDO{name: "enableProfileVelocity", offset: 0x81, subindex: 0},
+		EnableSDO{name: "enableTargetTorque", offset: 0x71, subindex: 0},
+		EnableSDO{name: "enableTorqueDemand", offset: 0x74, subindex: 0},
+		EnableSDO{name: "enableTorqueProfileType", offset: 0x88, subindex: 0},
+		EnableSDO{name: "enableTorqueSlope", offset: 0x87, subindex: 0},
+		EnableSDO{name: "enableVelocityDemand", offset: 0x6b, subindex: 0},
+		EnableSDO{name: "enableVelocityErrorTime", offset: 0x6e, subindex: 0},
+		EnableSDO{name: "enableVelocityErrorWindow", offset: 0x6d, subindex: 0},
+		EnableSDO{name: "enableVelocitySensorSelector", offset: 0x61, subindex: 0},
+		EnableSDO{name: "enableVelocityThresholdTime", offset: 0x70, subindex: 0},
+		EnableSDO{name: "enableVelocityThresholdWindow", offset: 0x6f, subindex: 0},
+	}
+
+	// Regexes for 'ethercat slaves'
+	slaveMasterRE     = regexp.MustCompile("^=== Master ([0-9]+), Slave ([0-9]+) ===$")
+	slaveVendorRE     = regexp.MustCompile("^  Vendor Id: +(0x[0-9a-fA-F]+)")
+	slaveProductRE    = regexp.MustCompile("^  Product code: +(0x[0-9a-fA-F]+)")
+	slaveRevisionRE   = regexp.MustCompile("^  Revision number: +(0x[0-9a-fA-F]+)")
+	slaveDeviceNameRE = regexp.MustCompile("^  Device name: (.*)")
+
+	// Regex for 'ethercat sdos'
+	sdoRE = regexp.MustCompile("^  (0x[0-9a-fA-F]{4}:[0-9a-fA-F]{2}), [rw-]+, ([^,]+),")
+
+	// Regexes for 'ethercat pdos'
+	pdoSMRE    = regexp.MustCompile("^SM([0-9]+): PhysAddr (0x[0-9a-f]+).*")
+	pdoPDORE   = regexp.MustCompile("^  ([RT]xPDO) (0x[0-9a-f]+) \"(.*)\"")
+	pdoEntryRE = regexp.MustCompile("^    PDO entry (0x[0-9a-f]+):([0-9a-f]+), +([0-9]+) bit, \"(.*)\"")
+
+	// Regex for pin names.  Anything that this matches will be replaced by a `-` in pin names.
+	pinRE = regexp.MustCompile("[^a-z0-9]+")
+
+	// Sequence number for device naming
+	deviceSequence int
+
+	typedbFlag      = flag.Bool("typedb", true, "Use the built-in list of supported EtherCAT device types?  If false, all devices will be 'generic' or 'basic_cia402'.")
+	extraciamodFlag = flag.Bool("extra_cia_modparams", false, "Add CiA 402 <modParam>s to all CiA 402 devices, not just 'basic_cia402'.")
+	genericPdoFlag  = flag.Bool("generic_pdos", true, "Attempt to build PDOs for generic devices.")
+)
+
+// readSlaves calls `ethercat -v slaves` and parses the output,
+// returning a slice of EthercatSlave objects.
+func readSlaves() ([]EthercatSlave, error) {
+	slaves := []EthercatSlave{}
+
+	out, err := exec.Command("ethercat", "-v", "slaves").Output()
+
+	if err != nil {
+		return nil, err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+
+	slave := EthercatSlave{}
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if slaveMasterRE.MatchString(line) {
+			results := slaveMasterRE.FindStringSubmatch(line)
+			slave.Master = string(results[1])
+			slave.Slave = string(results[2])
+		} else if slaveVendorRE.MatchString(line) {
+			results := slaveVendorRE.FindStringSubmatch(line)
+			slave.VendorID = string(results[1])
+		} else if slaveProductRE.MatchString(line) {
+			results := slaveProductRE.FindStringSubmatch(line)
+			slave.ProductID = string(results[1])
+		} else if slaveRevisionRE.MatchString(line) {
+			results := slaveRevisionRE.FindStringSubmatch(line)
+			slave.RevisionNo = string(results[1])
+		} else if slaveDeviceNameRE.MatchString(line) {
+			results := slaveDeviceNameRE.FindStringSubmatch(line)
+			slave.DeviceName = string(results[1])
+
+			slaves = append(slaves, slave)
+			slave = EthercatSlave{}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return slaves, nil
+}
+
+// readSDOs calls `ethercat sdos` for the current slave and extracts a
+// list of all of the SDOs reported.  These are then added to slave.SDOs.
+func (s *EthercatSlave) readSDOs() error {
+	sdos := make(map[string]string)
+
+	out, err := exec.Command("ethercat", "-m", s.Master, "sdos", "-p", s.Slave).Output()
+
+	if err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if sdoRE.MatchString(line) {
+			results := sdoRE.FindStringSubmatch(line)
+			sdos[results[1]] = results[2]
+		}
+	}
+
+	s.SDOs = sdos
+	return nil
+}
+
+// Returns true if the device is a CiA 402 device.  This probes all 3
+// of the SDOs that my copy of the spec says are required; if all are
+// present, then we'll assume that it's a CiA 402 device.
+func (s *EthercatSlave) isCiA402() bool {
+	if (s.SDOs["0x6040:00"] != "") && (s.SDOs["0x6041:00"] != "") && (s.SDOs["0x6502:00"] != "") {
+		return true
+	}
+	return false
+}
+
+// Identifies the number of channels (or axes) supported by the
+// device.  Unlike `isCiA402()`, this only looks for 0x6502.
+func (s *EthercatSlave) CiAChannels() int {
+	channels := 0
+	for _, sdo := range []string{"0x6502:00", "0x6d02:00", "0x7502:00", "0x7d02:00", "0x8502:00", "0x8d02:00", "0x9502:00", "0x9d02:00"} {
+		if s.SDOs[sdo] != "" {
+			channels++
+		} else {
+			return channels
+		}
+	}
+	return channels
+}
+
+// CiAEnableModParams looks at the SDOs gathered earlier as well as
+// the output of `ethercat upload 0x6502 0` and emits a set of
+// `<modParam>` settings that will tell the CiA 402 drivers which
+// features to enable for this slave.
+//
+// This should really only be needed for `basic_cia402`.
+func (s *EthercatSlave) CiAEnableModParams() []ConfigModParam {
+	mp := []ConfigModParam{}
+
+	// Just doing channel 1 for now.
+	// First, we need the value of 0x6502:00
+	out, err := exec.Command("ethercat", "-m", s.Master, "upload", "-p", s.Slave, "0x6502", "0").Output()
+
+	if err != nil {
+		panic(err)
+	}
+
+	split := strings.Split(string(out), " ")
+	abilities, err := strconv.ParseUint(split[0], 0, 32)
+
+	if err != nil {
+		panic(err)
+	}
+
+	if (abilities & (1 << 0)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enablePP", Value: "true"})
+	}
+	if (abilities & (1 << 1)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableVL", Value: "true"})
+	}
+	if (abilities & (1 << 2)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enablePV", Value: "true"})
+	}
+	if (abilities & (1 << 3)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableTQ", Value: "true"})
+	}
+	if (abilities & (1 << 5)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableHM", Value: "true"})
+	}
+	if (abilities & (1 << 6)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableIP", Value: "true"})
+	}
+	if (abilities & (1 << 7)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableCSP", Value: "true"})
+	}
+	if (abilities & (1 << 8)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableCSV", Value: "true"})
+	}
+	if (abilities & (1 << 9)) != 0 {
+		mp = append(mp, ConfigModParam{Name: "enableCST", Value: "true"})
+	}
+
+	for _, feature := range EnableSDOs {
+		sdo := fmt.Sprintf("0x%04x:%02x", feature.offset+0x6000, feature.subindex)
+		if s.SDOs[sdo] != "" {
+			mp = append(mp, ConfigModParam{Name: feature.name, Value: "true"})
+		}
+	}
+
+	return mp
+}
+
+// InferType determines the best 'type=""` value to use in the generated
+// XML file.  It looks at which VID:PID pairs current drivers support,
+// and if no matches are found it returns either `basic_cia402` or
+// `generic`.
+func (s *EthercatSlave) InferType() string {
+	if *typedbFlag {
+		for _, v := range configgen.Drivers {
+			if s.VendorID == v.VendorID && s.ProductID == v.ProductID {
+				return v.Type
+			}
+		}
+	}
+
+	if s.isCiA402() {
+		return "basic_cia402"
+	} else {
+		return "generic"
+	}
+}
+
+// InferName comes up with a plausible `name=""` value for use in the generated XML file.
+func (s *EthercatSlave) InferName() string {
+	deviceSequence++
+	return fmt.Sprintf("D%d", deviceSequence)
+}
+
+func xmlFormatHex(in string) string {
+	return strings.ReplaceAll(in, "0x", "")
+}
+
+func pinFormatComment(in string) string {
+	return pinRE.ReplaceAllString(strings.ToLower(in), "-")
+}
+
+func (s *EthercatSlave) BuildPDOs(c *ConfigSlave) error {
+	out, err := exec.Command("ethercat", "-m", s.Master, "pdos", "-p", s.Slave).Output()
+
+	var sm *ConfigSyncManager
+	var pdo *ConfigPDO
+
+	if err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if pdoSMRE.MatchString(line) {
+			results := pdoSMRE.FindStringSubmatch(line)
+			sm = &ConfigSyncManager{
+				Idx: xmlFormatHex(results[1]),
+			}
+
+			// Set up bogus defaults for in/out.  I can't
+			// figure out how to determine this from
+			// `ethercat pdos` in general.  When we have
+			// input or output PDOs, then it's easy, but
+			// for empty PDOs it's not.  I'm also unsure
+			// if we care.
+			if sm.Idx == "0" {
+				sm.Dir = "in"
+			} else if sm.Idx == "1" {
+				sm.Dir = "out"
+			}
+
+			c.SyncManagers = append(c.SyncManagers, sm)
+		} else if pdoPDORE.MatchString(line) {
+			results := pdoPDORE.FindStringSubmatch(line)
+			pdo = &ConfigPDO{
+				Idx: xmlFormatHex(results[2]),
+			}
+			sm.PDOs = append(sm.PDOs, pdo)
+			if results[1] == "RxPDO" {
+				sm.Dir = "out"
+			} else if results[1] == "TxPDO" {
+				sm.Dir = "in"
+			}
+		} else if pdoEntryRE.MatchString(line) {
+			results := pdoEntryRE.FindStringSubmatch(line)
+
+			entry := &ConfigPDOEntry{
+				Idx:     xmlFormatHex(results[1]),
+				SubIdx:  xmlFormatHex(results[2]),
+				BitLen:  results[3],
+				Comment: results[4],
+			}
+			entry.HalPin = fmt.Sprintf("pin-%s-%s", xmlFormatHex(entry.Idx), entry.SubIdx)
+			if entry.Comment != "" {
+				entry.HalPin = pinFormatComment(entry.Comment)
+				entry.Comment = ""
+			}
+
+			sdotype := s.SDOs[fmt.Sprintf("0x%s:%s", entry.Idx, entry.SubIdx)]
+			bits, _ := strconv.ParseUint(entry.BitLen, 0, 32)
+
+			if bits < 8 {
+				entry.HalType = "bit"
+			} else {
+				switch sdotype {
+				case "uint8", "uint16", "uint32":
+					entry.HalType = "u32"
+				case "int8", "int16", "int32":
+					entry.HalType = "s32"
+				case "bool":
+					entry.HalType = "bit"
+				case "uint64": // Some support in LinuxCNC, but not in LCEC today, so it'll throw an error.
+					entry.HalType = "u64"
+				case "int64": // Some support in LinuxCNC, but not in LCEC today, so it'll throw an error.
+					entry.HalType = "s64"
+				case "float", "double":
+					if bits == 32 {
+						entry.HalType = "float-ieee"
+					} else {
+						entry.HalType = "float-double-ieee"
+					}
+				default:
+					// Not sure what to do with this...
+					entry.HalType = "!!" + sdotype + "!!"
+				}
+			}
+			pdo.Entries = append(pdo.Entries, entry)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+
+	slaves, err := readSlaves()
+	if err != nil {
+		panic(err)
+	}
+
+	masters := map[string]*ConfigMaster{}
+	for _, slave := range slaves {
+		if masters[slave.Master] == nil {
+			masters[slave.Master] = &ConfigMaster{
+				Idx:    slave.Master,
+				Slaves: []ConfigSlave{},
+			}
+		}
+
+		err = slave.readSDOs()
+		if err != nil {
+			panic(err)
+		}
+		slaveconfig := ConfigSlave{
+			Idx:       slave.Slave,
+			Type:      slave.InferType(),
+			Name:      slave.InferName(),
+			ModParams: []ConfigModParam{},
+		}
+
+		if slaveconfig.Type == "basic_cia402" || (*extraciamodFlag && slave.isCiA402()) {
+			slaveconfig.ModParams = append(slaveconfig.ModParams, slave.CiAEnableModParams()...)
+		}
+
+		if slaveconfig.Type == "generic" || slaveconfig.Type == "basic_cia402" {
+			slaveconfig.Vid = slave.VendorID
+			slaveconfig.Pid = slave.ProductID
+			slaveconfig.Comment = slave.DeviceName
+		}
+
+		if slaveconfig.Type == "generic" && *genericPdoFlag {
+			slave.BuildPDOs(&slaveconfig)
+		}
+
+		masters[slave.Master].Slaves = append(masters[slave.Master].Slaves, slaveconfig)
+
+	}
+
+	r := ConfigRoot{
+		Masters: []*ConfigMaster{},
+	}
+
+	for _, v := range masters {
+		r.Masters = append(r.Masters, v)
+	}
+
+	b, err := xml.MarshalIndent(r, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+
+	// Hack to switch from <foo></foo> to <foo/> without breaking <!-- bar --></foo>
+	re := regexp.MustCompile("([^-])></[a-zA-Z]+>")
+	ns := re.ReplaceAllString(string(b), "$1/>")
+	fmt.Println(ns)
+}


### PR DESCRIPTION
This is still a WIP.  It creates `lcec_configgen`, which can produce a config XML file based on data from `ethercat slaves`, `ethercat sdos`, and the list of supported VID:PID devices for each driver.

This is particularly focused on CiA 402 devices for now, because they have so many modParams that can enable additional features, but it should be able to ID pretty much any hardware that we know about.  It's still a work in progress, but here's what I get running it on my test box:

```xml
<masters>
  <master idx="0">
    <slave idx="0" type="EK1100" name="D1"/>
    <slave idx="1" type="EL1018" name="D2"/>
    <slave idx="2" type="EL1018" name="D3"/>
    <slave idx="3" type="EL2008" name="D4"/>
    <slave idx="4" type="EL2008" name="D5"/>
    <slave idx="5" type="EL2084" name="D6"/>
    <slave idx="6" type="EL2022" name="D7"/>
    <slave idx="7" type="EL2022" name="D8"/>
    <slave idx="8" type="EL2034" name="D9"/>
    <slave idx="9" type="EL2798" name="D10"/>
    <slave idx="10" type="EL3068" name="D11"/>
    <slave idx="11" type="generic" vid="0x00000002" pid="0x17713052" name="D12">
      <!--EL6001 Schnittstelle (RS232)-->
      <syncManager idx="0" dir="in"/>
      <syncManager idx="1" dir="out"/>
      <syncManager idx="2" dir="out">
        <pdo idx="1602">
          <pdoEntry idx="3003" subIdx="01" bitLen="16" halPin="ctrl" halType="u32"/>
          <pdoEntry idx="3003" subIdx="02" bitLen="8" halPin="data-out-0" halType="u32"/>
          <pdoEntry idx="3003" subIdx="03" bitLen="8" halPin="data-out-1" halType="u32"/>
          <pdoEntry idx="3003" subIdx="04" bitLen="8" halPin="data-out-2" halType="u32"/>
          <pdoEntry idx="3003" subIdx="05" bitLen="8" halPin="data-out-3" halType="u32"/>
          <pdoEntry idx="3003" subIdx="06" bitLen="8" halPin="data-out-4" halType="u32"/>
          <pdoEntry idx="3003" subIdx="07" bitLen="8" halPin="data-out-5" halType="u32"/>
          <pdoEntry idx="3003" subIdx="08" bitLen="8" halPin="data-out-6" halType="u32"/>
          <pdoEntry idx="3003" subIdx="09" bitLen="8" halPin="data-out-7" halType="u32"/>
          <pdoEntry idx="3003" subIdx="0a" bitLen="8" halPin="data-out-8" halType="u32"/>
          <pdoEntry idx="3003" subIdx="0b" bitLen="8" halPin="data-out-9" halType="u32"/>
          <pdoEntry idx="3003" subIdx="0c" bitLen="8" halPin="data-out-10" halType="u32"/>
          <pdoEntry idx="3003" subIdx="0d" bitLen="8" halPin="data-out-11" halType="u32"/>
          <pdoEntry idx="3003" subIdx="0e" bitLen="8" halPin="data-out-12" halType="u32"/>
          <pdoEntry idx="3003" subIdx="0f" bitLen="8" halPin="data-out-13" halType="u32"/>
          <pdoEntry idx="3003" subIdx="10" bitLen="8" halPin="data-out-14" halType="u32"/>
          <pdoEntry idx="3003" subIdx="11" bitLen="8" halPin="data-out-15" halType="u32"/>
          <pdoEntry idx="3003" subIdx="12" bitLen="8" halPin="data-out-16" halType="u32"/>
          <pdoEntry idx="3003" subIdx="13" bitLen="8" halPin="data-out-17" halType="u32"/>
          <pdoEntry idx="3003" subIdx="14" bitLen="8" halPin="data-out-18" halType="u32"/>
          <pdoEntry idx="3003" subIdx="15" bitLen="8" halPin="data-out-19" halType="u32"/>
          <pdoEntry idx="3003" subIdx="16" bitLen="8" halPin="data-out-20" halType="u32"/>
          <pdoEntry idx="3003" subIdx="17" bitLen="8" halPin="data-out-21" halType="u32"/>
        </pdo>
      </syncManager>
      <syncManager idx="3" dir="in">
        <pdo idx="1a02">
          <pdoEntry idx="3103" subIdx="01" bitLen="16" halPin="status" halType="u32"/>
          <pdoEntry idx="3103" subIdx="02" bitLen="8" halPin="data-in-0" halType="u32"/>
          <pdoEntry idx="3103" subIdx="03" bitLen="8" halPin="data-in-1" halType="u32"/>
          <pdoEntry idx="3103" subIdx="04" bitLen="8" halPin="data-in-2" halType="u32"/>
          <pdoEntry idx="3103" subIdx="05" bitLen="8" halPin="data-in-3" halType="u32"/>
          <pdoEntry idx="3103" subIdx="06" bitLen="8" halPin="data-in-4" halType="u32"/>
          <pdoEntry idx="3103" subIdx="07" bitLen="8" halPin="data-in-5" halType="u32"/>
          <pdoEntry idx="3103" subIdx="08" bitLen="8" halPin="data-in-6" halType="u32"/>
          <pdoEntry idx="3103" subIdx="09" bitLen="8" halPin="data-in-7" halType="u32"/>
          <pdoEntry idx="3103" subIdx="0a" bitLen="8" halPin="data-in-8" halType="u32"/>
          <pdoEntry idx="3103" subIdx="0b" bitLen="8" halPin="data-in-9" halType="u32"/>
          <pdoEntry idx="3103" subIdx="0c" bitLen="8" halPin="data-in-10" halType="u32"/>
          <pdoEntry idx="3103" subIdx="0d" bitLen="8" halPin="data-in-11" halType="u32"/>
          <pdoEntry idx="3103" subIdx="0e" bitLen="8" halPin="data-in-12" halType="u32"/>
          <pdoEntry idx="3103" subIdx="0f" bitLen="8" halPin="data-in-13" halType="u32"/>
          <pdoEntry idx="3103" subIdx="10" bitLen="8" halPin="data-in-14" halType="u32"/>
          <pdoEntry idx="3103" subIdx="11" bitLen="8" halPin="data-in-15" halType="u32"/>
          <pdoEntry idx="3103" subIdx="12" bitLen="8" halPin="data-in-16" halType="u32"/>
          <pdoEntry idx="3103" subIdx="13" bitLen="8" halPin="data-in-17" halType="u32"/>
          <pdoEntry idx="3103" subIdx="14" bitLen="8" halPin="data-in-18" halType="u32"/>
          <pdoEntry idx="3103" subIdx="15" bitLen="8" halPin="data-in-19" halType="u32"/>
          <pdoEntry idx="3103" subIdx="16" bitLen="8" halPin="data-in-20" halType="u32"/>
          <pdoEntry idx="3103" subIdx="17" bitLen="8" halPin="data-in-21" halType="u32"/>
        </pdo>
      </syncManager>
    </slave>
    <slave idx="12" type="EL4004" name="D13"/>
    <slave idx="13" type="generic" vid="0x00000002" pid="0x0e613052" name="D14">
      <!--EL3681 Digital multimeter terminal-->
      <syncManager idx="0" dir="in"/>
      <syncManager idx="1" dir="out"/>
      <syncManager idx="2" dir="out">
        <pdo idx="1600">
          <pdoEntry idx="7000" subIdx="01" bitLen="1" halPin="disable-autorange" halType="bit"/>
          <pdoEntry idx="7000" subIdx="02" bitLen="1" halPin="start-calibration" halType="bit"/>
          <pdoEntry idx="0000" subIdx="00" bitLen="2" halPin="gap" halType="bit"/>
          <pdoEntry idx="7000" subIdx="05" bitLen="4" halPin="mode" halType="bit"/>
          <pdoEntry idx="7000" subIdx="09" bitLen="8" halPin="range" halType="s32"/>
        </pdo>
      </syncManager>
      <syncManager idx="3" dir="in">
        <pdo idx="1a00">
          <pdoEntry idx="6000" subIdx="01" bitLen="1" halPin="underrange" halType="bit"/>
          <pdoEntry idx="6000" subIdx="02" bitLen="1" halPin="overrange" halType="bit"/>
          <pdoEntry idx="6000" subIdx="03" bitLen="1" halPin="extended-range" halType="bit"/>
          <pdoEntry idx="6000" subIdx="04" bitLen="1" halPin="data-invalid" halType="bit"/>
          <pdoEntry idx="6000" subIdx="05" bitLen="1" halPin="range-invalid" halType="bit"/>
          <pdoEntry idx="6000" subIdx="06" bitLen="1" halPin="autorange-disabled" halType="bit"/>
          <pdoEntry idx="6000" subIdx="07" bitLen="1" halPin="error" halType="bit"/>
          <pdoEntry idx="6000" subIdx="08" bitLen="1" halPin="calibration-in-progress" halType="bit"/>
          <pdoEntry idx="0000" subIdx="00" bitLen="6" halPin="gap" halType="bit"/>
          <pdoEntry idx="6000" subIdx="0f" bitLen="1" halPin="txpdo-state" halType="bit"/>
          <pdoEntry idx="6000" subIdx="10" bitLen="1" halPin="txpdo-toggle" halType="bit"/>
          <pdoEntry idx="6000" subIdx="11" bitLen="32" halPin="value" halType="s32"/>
        </pdo>
        <pdo idx="1a01">
          <pdoEntry idx="0000" subIdx="00" bitLen="4" halPin="gap" halType="bit"/>
          <pdoEntry idx="6001" subIdx="05" bitLen="4" halPin="mode" halType="bit"/>
          <pdoEntry idx="6001" subIdx="09" bitLen="8" halPin="range" halType="s32"/>
        </pdo>
      </syncManager>
    </slave>
    <slave idx="14" type="EL3403" name="D15"/>
    <slave idx="15" type="EL3204" name="D16"/>
    <slave idx="16" type="generic" vid="0x00000002" pid="0x24c23052" name="D17">
      <!--EL9410 E-Bus Netzteilklemme (Diagnose)-->
      <syncManager idx="0" dir="in">
        <pdo idx="1a00">
          <pdoEntry idx="6000" subIdx="01" bitLen="1" halPin="undervoltage" halType="bit"/>
        </pdo>
        <pdo idx="1a01">
          <pdoEntry idx="6010" subIdx="01" bitLen="1" halPin="undervoltage" halType="bit"/>
        </pdo>
      </syncManager>
    </slave>
    <slave idx="17" type="EL1859" name="D18"/>
    <slave idx="18" type="EL4032" name="D19"/>
    <slave idx="19" type="EL7041" name="D20"/>
    <slave idx="20" type="EK1110" name="D21"/>
    <slave idx="21" type="ECT60" name="D22">
      <modParam name="enablePP" value="true"/>
      <modParam name="enablePV" value="true"/>
      <modParam name="enableTQ" value="true"/>
      <modParam name="enableHM" value="true"/>
      <modParam name="enableCSP" value="true"/>
      <modParam name="enableCSV" value="true"/>
      <modParam name="enableActualFollowingError" value="true"/>
      <modParam name="enableActualTorque" value="true"/>
      <modParam name="enableHomeAccel" value="true"/>
      <modParam name="enableInterpolationTimePeriod" value="true"/>
      <modParam name="enableProfileAccel" value="true"/>
      <modParam name="enableProfileDecel" value="true"/>
      <modParam name="enableProfileVelocity" value="true"/>
      <modParam name="enableVelocitySensorSelector" value="true"/>
    </slave>
    <slave idx="22" type="EP2308" name="D23"/>
    <slave idx="23" type="EPP2338" name="D24"/>
  </master>
</masters>
```

I'm not going to claim that it's perfect, or even necessarily *valid*, but it passes through `lcec_conf` without crashing.

- [x] Figure out how to produce sane names
- [x] Expand the list of XML tags supported, including DC, SDOs, and PDOs for generic devices.
- [ ] Clean up error checking.
- [x] Add Go to the CI pipeline so this actually builds correctly.
- [x] Figure out how to add sane comments in places.
- [ ] Add the ability to read the current XML config and modify it?
- [x] Emit PDOs for generics. 

Issue #180, although that's getting kind of crazy at this point.