### PR TITLE
fix(syncs): Add error checking on sync size

### DIFF
--- a/src/devices/lcec_ax5100.c
+++ b/src/devices/lcec_ax5100.c
@@ -87,7 +87,7 @@ static int lcec_ax5100_init(int comp_id, struct lcec_slave *slave) {
   }
 
   // initialize sync info
-  lcec_syncs_init(&hal_data->syncs);
+  lcec_syncs_init(slave, &hal_data->syncs);
   lcec_syncs_add_sync(&hal_data->syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);
   lcec_syncs_add_sync(&hal_data->syncs, EC_DIR_INPUT, EC_WD_DEFAULT);
 

--- a/src/devices/lcec_ax5200.c
+++ b/src/devices/lcec_ax5200.c
@@ -96,7 +96,7 @@ static int lcec_ax5200_init(int comp_id, struct lcec_slave *slave) {
   }
 
   // initialize sync info
-  lcec_syncs_init(&hal_data->syncs);
+  lcec_syncs_init(slave, &hal_data->syncs);
   lcec_syncs_add_sync(&hal_data->syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);
   lcec_syncs_add_sync(&hal_data->syncs, EC_DIR_INPUT, EC_WD_DEFAULT);
 

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -165,7 +165,7 @@ static int lcec_basic_cia402_init(int comp_id, struct lcec_slave *slave) {
   //
   // These need to be done in the correct order, as the `lcec_syncs*`
   // code only adds new entries at the end.
-  lcec_syncs_t *syncs = lcec_cia402_init_sync(options);
+  lcec_syncs_t *syncs = lcec_cia402_init_sync(slave, options);
   lcec_cia402_add_output_sync(syncs, options);
 
   // XXXX: ff this driver needed to set up device-specific output PDO

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -607,8 +607,9 @@ lcec_class_cia402_options_t *lcec_cia402_options_multi_axes(int axis) {
 
 /// @brief Allocates a `lcec_syncs_t` and fills in the CiA 402 portion of it using data from `options`.
 ///
+
 /// @param opt A `lcec_class_cia402_options_t` structure that describes the options in use.
-lcec_syncs_t *lcec_cia402_init_sync(lcec_class_cia402_options_t *options) {
+lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options) {
   lcec_syncs_t *syncs;
 
   syncs = hal_malloc(sizeof(lcec_syncs_t));
@@ -616,7 +617,7 @@ lcec_syncs_t *lcec_cia402_init_sync(lcec_class_cia402_options_t *options) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for lcec_cia402_init_sync failed\n");
     return NULL;
   }
-  lcec_syncs_init(syncs);
+  lcec_syncs_init(slave, syncs);
   lcec_syncs_add_sync(syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);
   lcec_syncs_add_sync(syncs, EC_DIR_INPUT, EC_WD_DEFAULT);
 

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -305,7 +305,7 @@ lcec_class_cia402_options_t *lcec_cia402_options_multi_axis(void);
 int lcec_cia402_handle_modparam(struct lcec_slave *slave, const lcec_slave_modparam_t *p, lcec_class_cia402_options_t *opt);
 lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t const *orig);
 lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_mps);
-lcec_syncs_t *lcec_cia402_init_sync(lcec_class_cia402_options_t *options);
+lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_output_sync(lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_input_sync(lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -442,7 +442,7 @@ static int lcec_rtec_init(int comp_id, struct lcec_slave *slave) {
   // Set up syncs.  This is needed because the ECT60 (at least)
   // doesn't map all of the PDOs that we need, so we need to set up
   // our own mappings.
-  lcec_syncs_t *syncs = lcec_cia402_init_sync(options);
+  lcec_syncs_t *syncs = lcec_cia402_init_sync(slave, options);
   lcec_cia402_add_output_sync(syncs, options);
   // No output PDOs right now.
 

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -78,9 +78,9 @@
 #define LCEC_FSOE_SIZE(ch_count, data_len) (LCEC_FSOE_CMD_LEN + ch_count * (data_len + LCEC_FSOE_CRC_LEN) + LCEC_FSOE_CONNID_LEN)
 
 #define LCEC_MAX_PDO_REG_COUNT   128  ///< The maximum number of calls to lcec_pdo_init() for a single driver.
-#define LCEC_MAX_PDO_ENTRY_COUNT 32   ///< The maximum number of PDO entries in a PDO in a sync.
-#define LCEC_MAX_PDO_INFO_COUNT  8    ///< The maximum number of PDOs in a sync.
-#define LCEC_MAX_SYNC_COUNT      4    ///< The maximum number of syncs.
+#define LCEC_MAX_PDO_ENTRY_COUNT 128   ///< The maximum number of PDO entries in a PDO in a sync.
+#define LCEC_MAX_PDO_INFO_COUNT  16    ///< The maximum number of PDOs in a sync.
+#define LCEC_MAX_SYNC_COUNT      8    ///< The maximum number of syncs.
 
 struct lcec_master;
 struct lcec_slave;
@@ -274,6 +274,7 @@ typedef struct {
 
 /// @brief Sync manager configuration.
 typedef struct {
+  lcec_slave_t *slave; ///< For debugging messages
   int sync_count;                                 ///< Number of syncs.
   ec_sync_info_t *curr_sync;                      ///< Current sync.
   ec_sync_info_t syncs[LCEC_MAX_SYNC_COUNT + 1];  ///< Sync definitions.
@@ -326,7 +327,7 @@ int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const c
 int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...);
 
 void copy_fsoe_data(struct lcec_slave *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
-void lcec_syncs_init(lcec_syncs_t *syncs) __attribute__((nonnull));
+void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) __attribute__((nonnull));
 void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode);
 void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
 void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -59,7 +59,10 @@ void copy_fsoe_data(struct lcec_slave *slave, unsigned int slave_offset, unsigne
 }
 
 /// @brief Initialize syncs to 0.
-void lcec_syncs_init(lcec_syncs_t *syncs) { memset(syncs, 0, sizeof(lcec_syncs_t)); }
+void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) {
+  memset(syncs, 0, sizeof(lcec_syncs_t));
+  syncs->slave = slave;
+}
 
 /// @brief Add a new EtherCAT sync manager configuration.
 void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode) {
@@ -69,7 +72,12 @@ void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mo
   syncs->curr_sync->dir = dir;
   syncs->curr_sync->watchdog_mode = watchdog_mode;
 
-  (syncs->sync_count)++;
+  if (syncs->sync_count >= LCEC_MAX_SYNC_COUNT) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_sync: WARNING: sync full for slave %s.%s, not adding more.  Expect failure.\n",
+		    syncs->slave->master->name, syncs->slave->name);
+  } else {
+      (syncs->sync_count)++;
+  }
   syncs->syncs[syncs->sync_count].index = 0xff;
 }
 
@@ -84,7 +92,12 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
 
   syncs->curr_pdo_info->index = index;
 
-  (syncs->pdo_info_count)++;
+  if (syncs->pdo_info_count >= LCEC_MAX_PDO_INFO_COUNT) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s, not adding more.  Expect failure.\n",
+		    syncs->slave->master->name, syncs->slave->name);
+  } else {
+      (syncs->pdo_info_count)++;
+  }
 }
 
 /// @brief Add a new PDO entry to an existing PDO.
@@ -100,7 +113,12 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
   syncs->curr_pdo_entry->subindex = subindex;
   syncs->curr_pdo_entry->bit_length = bit_length;
 
-  (syncs->pdo_entry_count)++;
+  if (syncs->pdo_entry_count >= LCEC_MAX_PDO_ENTRY_COUNT) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_pdo_entry: WARNING: pdo_entries full for slave %s.%s, not adding more.  Expect failure.\n",
+		    syncs->slave->master->name, syncs->slave->name);
+  } else {
+    (syncs->pdo_entry_count)++;
+  }
 }
 
 /// @brief Read an SDO configuration from a slave device.


### PR DESCRIPTION
On devices with lots of PDOs (especially multi-axis CiA 402 devices), it's easy to overfill the sync structures, and there was previously no error checking at all, leading to memory corruption and weird bugs.

Issue #327 

