### PR TITLE
fix(lcec_configgen): Re-enable building lcec_configgen now that the build farm has been updated

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: linuxcnc-ethercat
 Section: unknown
 Priority: extra
 Maintainer: Bjarne von Horn <vh@igh.de>
-Build-Depends: debhelper (>= 8.0.0), libexpat1-dev, linuxcnc-dev | linuxcnc-sim-dev | linuxcnc-uspace-dev | machinekit-dev, etherlabmaster-dev | libethercat-dev
+Build-Depends: debhelper (>= 8.0.0), libexpat1-dev, linuxcnc-dev | linuxcnc-sim-dev | linuxcnc-uspace-dev | machinekit-dev, etherlabmaster-dev | libethercat-dev, golang-go | golang-any
 Standards-Version: 3.9.3
 
 Package: linuxcnc-ethercat

--- a/src/Makefile
+++ b/src/Makefile
@@ -80,7 +80,7 @@ install: install-user install-realtime
 	true  # override 'install' from $(MODINC)
 
 realtime: lcec.so
-user: lcec_conf lcec_devices # lcec_configgen
+user: lcec_conf lcec_devices lcec_configgen
 
 # Run all tests (auto-generated above from tests/test_*.c).
 test: $(all-tests)
@@ -89,7 +89,7 @@ test: $(all-tests)
 install-user: user
 	mkdir -p $(DESTDIR)$(EMC2_HOME)/bin
 	cp lcec_conf $(DESTDIR)$(EMC2_HOME)/bin/
-	#cp lcec_configgen $(DESTDIR)/usr/bin/
+	cp lcec_configgen $(DESTDIR)/usr/bin/
 
 install-realtime: realtime
 	mkdir -p $(DESTDIR)$(RTLIBDIR)/


### PR DESCRIPTION
Reverts linuxcnc-ethercat/linuxcnc-ethercat#332