### PR TITLE
fix(cia402): Move most non-performance critical write PDOs to SDOs

### DIFF
--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -178,120 +178,78 @@ typedef struct {
 } lcec_class_cia402_enabled_t;
 
 typedef struct {
+#define PDO_PIN(name, pin_type)				\
+  pin_type *name; \
+  unsigned int name##_os; \
+  unsigned int name##_bp;
+  
+#define SDO_PIN(name, pin_type) \
+  pin_type *name; \
+  pin_type name##_old; \
+  ec_sdo_request_t *name##_sdorequest;
+
   // Out
-  hal_u32_t *controlword;
-  hal_s32_t *opmode;
+  PDO_PIN(controlword, hal_u32_t);
+  PDO_PIN(home_method, hal_s32_t);
+  PDO_PIN(opmode, hal_s32_t);
+  PDO_PIN(target_position, hal_s32_t);
+  PDO_PIN(target_torque, hal_s32_t);
+  PDO_PIN(target_velocity, hal_s32_t);
+  PDO_PIN(target_vl, hal_s32_t);
+  PDO_PIN(interpolation_time_period, hal_u32_t);
+  PDO_PIN(profile_velocity, hal_u32_t);
 
-  hal_s32_t *home_method;
-  hal_s32_t *motion_profile;
-  hal_s32_t *target_position;
-  hal_s32_t *target_torque;
-  hal_s32_t *target_velocity;
-  hal_s32_t *target_vl;
-  hal_s32_t *torque_profile_type;
-  hal_s32_t *velocity_sensor_selector;
-  hal_s32_t *vl_maximum;
-  hal_s32_t *vl_minimum;
-  hal_u32_t *following_error_timeout;
-  hal_u32_t *following_error_window;
-  hal_u32_t *home_accel;
-  hal_u32_t *home_velocity_fast;
-  hal_u32_t *home_velocity_slow;
-  hal_u32_t *interpolation_time_period;
-  hal_u32_t *maximum_acceleration;
-  hal_u32_t *maximum_current;
-  hal_u32_t *maximum_deceleration;
-  hal_u32_t *maximum_motor_rpm;
-  hal_u32_t *maximum_torque;
-  hal_u32_t *motor_rated_current;
-  hal_u32_t *motor_rated_torque;
-  hal_u32_t *polarity;
-  hal_u32_t *profile_accel;
-  hal_u32_t *profile_decel;
-  hal_u32_t *profile_end_velocity;
-  hal_u32_t *profile_max_velocity;
-  hal_u32_t *profile_velocity;
-  hal_u32_t *torque_slope;
-  hal_u32_t *velocity_error_time;
-  hal_u32_t *velocity_error_window;
-  hal_u32_t *velocity_threshold_time;
-  hal_u32_t *velocity_threshold_window;
-  hal_u32_t *vl_accel;
-  hal_u32_t *vl_decel;
+  SDO_PIN(following_error_timeout, hal_u32_t);
+  SDO_PIN(following_error_window, hal_u32_t);
+  SDO_PIN(home_accel, hal_u32_t);  
+  SDO_PIN(home_velocity_fast, hal_u32_t); 
+  SDO_PIN(home_velocity_slow, hal_u32_t); 
+  SDO_PIN(maximum_acceleration, hal_u32_t);  
+  SDO_PIN(maximum_current, hal_u32_t); 
+  SDO_PIN(maximum_deceleration, hal_u32_t); 
+  SDO_PIN(maximum_motor_rpm, hal_u32_t); 
+  SDO_PIN(maximum_torque, hal_u32_t); 
+  SDO_PIN(motion_profile, hal_s32_t);
+  SDO_PIN(motor_rated_current, hal_u32_t); 
+  SDO_PIN(motor_rated_torque, hal_u32_t); 
+  SDO_PIN(polarity, hal_u32_t); 
+  SDO_PIN(profile_accel, hal_u32_t);  
+  SDO_PIN(profile_decel, hal_u32_t); 
+  SDO_PIN(profile_end_velocity, hal_u32_t); 
+  SDO_PIN(profile_max_velocity, hal_u32_t); 
+  SDO_PIN(torque_profile_type, hal_s32_t);
+  SDO_PIN(torque_slope, hal_u32_t);
+  SDO_PIN(velocity_error_time, hal_u32_t); 
+  SDO_PIN(velocity_error_window, hal_u32_t); 
+  SDO_PIN(velocity_sensor_selector, hal_s32_t);
+  SDO_PIN(velocity_threshold_time, hal_u32_t); 
+  SDO_PIN(velocity_threshold_window, hal_u32_t); 
+  SDO_PIN(vl_accel, hal_u32_t);
+  SDO_PIN(vl_decel, hal_u32_t);
+  SDO_PIN(vl_maximum, hal_s32_t);
+  SDO_PIN(vl_minimum, hal_s32_t);
 
-  // In
-  hal_u32_t *statusword;
-  hal_s32_t *opmode_display;
+  // In.
+  PDO_PIN(statusword, hal_u32_t);
+  PDO_PIN(opmode_display, hal_s32_t);
   hal_s32_t *supported_modes;
-
   hal_bit_t *supports_mode_pp, *supports_mode_vl, *supports_mode_pv, *supports_mode_tq, *supports_mode_hm, *supports_mode_ip,
       *supports_mode_csp, *supports_mode_csv, *supports_mode_cst;
 
-  hal_s32_t *actual_current;
-  hal_s32_t *actual_position;
-  hal_s32_t *actual_torque;
-  hal_s32_t *actual_velocity;
-  hal_s32_t *actual_velocity_sensor;
-  hal_s32_t *actual_vl;
-  hal_s32_t *demand_vl;
-  hal_s32_t *torque_demand;
-  hal_s32_t *velocity_demand;
-  hal_u32_t *actual_following_error;
-  hal_u32_t *actual_voltage;
+  PDO_PIN(actual_current, hal_s32_t);
+  PDO_PIN(actual_position, hal_s32_t);
+  PDO_PIN(actual_torque, hal_s32_t);
+  PDO_PIN(actual_velocity, hal_s32_t);
+  PDO_PIN(actual_velocity_sensor, hal_s32_t);
+  PDO_PIN(actual_vl, hal_s32_t);
+  PDO_PIN(demand_vl, hal_s32_t);
+  PDO_PIN(torque_demand, hal_s32_t);
+  PDO_PIN(velocity_demand, hal_s32_t);
 
-  unsigned int controlword_os;  ///< The controlword's offset in the master's PDO data structure.
-  unsigned int following_error_timeout_os;
-  unsigned int following_error_window_os;
-  unsigned int home_accel_os;          ///< The acceleration used while homing.
-  unsigned int home_method_os;         ///< The homing method used.  See manufacturer's docs.
-  unsigned int home_velocity_fast_os;  ///< The velocity used for the fast portion of the homing.
-  unsigned int home_velocity_slow_os;  ///< The velocity used for the slow portion of the homing.
-  unsigned int interpolation_time_period_os;
-  unsigned int maximum_acceleration_os;
-  unsigned int maximum_current_os;
-  unsigned int maximum_deceleration_os;
-  unsigned int maximum_motor_rpm_os;
-  unsigned int maximum_torque_os;
-  unsigned int motion_profile_os;
-  unsigned int motor_rated_current_os;
-  unsigned int motor_rated_torque_os;
-  unsigned int opmode_os;  ///< The opmode's offset in the master's PDO data structure.
-  unsigned int polarity_os;
-  unsigned int profile_accel_os;         ///< The target accleeration for the next move in `pp` mode.
-  unsigned int profile_decel_os;         ///< The target deceleration for the next move in `pp` mode.
-  unsigned int profile_end_velocity_os;  ///< The end velocity for the next move in `pp` mode.  Almost always 0.
-  unsigned int profile_max_velocity_os;  ///< The maximum velocity allowed in profile move modes.
-  unsigned int profile_velocity_os;      ///< The target velocity for the next move in `pp` mode.
-  unsigned int supported_modes_os;       ///< The supported modes offset in the master's PDO data structure.
-  unsigned int target_position_os;       ///< The target position's offset in the master's PDO data structure.
-  unsigned int target_torque_os;
-  unsigned int target_velocity_os;  ///< The target velocity's offset in the master's PDO data structure.
-  unsigned int target_vl_os;
-  unsigned int torque_profile_type_os;
-  unsigned int torque_slope_os;
-  unsigned int velocity_error_time_os;
-  unsigned int velocity_error_window_os;
-  unsigned int velocity_sensor_selector_os;
-  unsigned int velocity_threshold_time_os;
-  unsigned int velocity_threshold_window_os;
-  unsigned int vl_accel_os;
-  unsigned int vl_decel_os;
-  unsigned int vl_maximum_os;
-  unsigned int vl_minimum_os;
+  PDO_PIN(actual_following_error, hal_u32_t);
+  PDO_PIN(actual_voltage, hal_u32_t);
 
-  unsigned int actual_current_os;
-  unsigned int actual_following_error_os;
-  unsigned int actual_position_os;  ///< The actual position's offset in the master's PDO data structure.
-  unsigned int actual_torque_os;    ///< The actual torque's offset in the master's PDO data structure.
-  unsigned int actual_velocity_os;  ///< The actual velocity's offset in the master's PDO data structure.
-  unsigned int actual_velocity_sensor_os;
-  unsigned int actual_vl_os;
-  unsigned int actual_voltage_os;
-  unsigned int demand_vl_os;
-  unsigned int opmode_display_os;  ///< The opmode display's offset in the master's PDO data structure.
-  unsigned int statusword_os;      ///< The statusword's offset in the master's PDO data structure.
-  unsigned int torque_demand_os;
-  unsigned int velocity_demand_os;
+  unsigned int base_idx; ///< The PDO/SDO offset for this channel
 
   lcec_class_cia402_channel_options_t *options;  ///< The options used to create this device.
   lcec_class_cia402_enabled_t *enabled;

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -80,7 +80,7 @@
 #define LCEC_MAX_PDO_REG_COUNT   128  ///< The maximum number of calls to lcec_pdo_init() for a single driver.
 #define LCEC_MAX_PDO_ENTRY_COUNT 128   ///< The maximum number of PDO entries in a PDO in a sync.
 #define LCEC_MAX_PDO_INFO_COUNT  16    ///< The maximum number of PDOs in a sync.
-#define LCEC_MAX_SYNC_COUNT      8    ///< The maximum number of syncs.
+#define LCEC_MAX_SYNC_COUNT      4    ///< The maximum number of syncs.
 
 struct lcec_master;
 struct lcec_slave;
@@ -281,11 +281,11 @@ typedef struct {
 
   int pdo_info_count;                                ///< Number of PDO infos.
   ec_pdo_info_t *curr_pdo_info;                      ///< Current PDO info.
-  ec_pdo_info_t pdo_infos[LCEC_MAX_PDO_INFO_COUNT];  ///< PDO info definitions.
+  ec_pdo_info_t pdo_infos[LCEC_MAX_PDO_INFO_COUNT+1];  ///< PDO info definitions.
 
   int pdo_entry_count;                                        ///< Number of PDO entries.
   ec_pdo_entry_info_t *curr_pdo_entry;                        ///< Current PDO entry.
-  ec_pdo_entry_info_t pdo_entries[LCEC_MAX_PDO_ENTRY_COUNT];  ///< PDO entry definitions.
+  ec_pdo_entry_info_t pdo_entries[LCEC_MAX_PDO_ENTRY_COUNT+1];  ///< PDO entry definitions.
 } lcec_syncs_t;
 
 /// @brief Lookup table mapping string to int

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -72,7 +72,7 @@ void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mo
   syncs->curr_sync->dir = dir;
   syncs->curr_sync->watchdog_mode = watchdog_mode;
 
-  if (syncs->sync_count >= LCEC_MAX_SYNC_COUNT) {
+  if (syncs->sync_count > LCEC_MAX_SYNC_COUNT) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_sync: WARNING: sync full for slave %s.%s, not adding more.  Expect failure.\n",
 		    syncs->slave->master->name, syncs->slave->name);
   } else {
@@ -92,7 +92,7 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
 
   syncs->curr_pdo_info->index = index;
 
-  if (syncs->pdo_info_count >= LCEC_MAX_PDO_INFO_COUNT) {
+  if (syncs->pdo_info_count > LCEC_MAX_PDO_INFO_COUNT) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s, not adding more.  Expect failure.\n",
 		    syncs->slave->master->name, syncs->slave->name);
   } else {
@@ -113,7 +113,7 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
   syncs->curr_pdo_entry->subindex = subindex;
   syncs->curr_pdo_entry->bit_length = bit_length;
 
-  if (syncs->pdo_entry_count >= LCEC_MAX_PDO_ENTRY_COUNT) {
+  if (syncs->pdo_entry_count > LCEC_MAX_PDO_ENTRY_COUNT) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_pdo_entry: WARNING: pdo_entries full for slave %s.%s, not adding more.  Expect failure.\n",
 		    syncs->slave->master->name, syncs->slave->name);
   } else {

--- a/tests/scottlaird-lcectest1/fulltest.hal
+++ b/tests/scottlaird-lcectest1/fulltest.hal
@@ -1,6 +1,6 @@
 loadusr -W lcec_conf fulltest.xml
 loadrt lcec
-loadrt cia402 count=1
+loadrt cia402 count=2
 
 loadrt threads name1=servo-thread period1=1000000
 addf lcec.read-all servo-thread
@@ -11,17 +11,17 @@ addf cia402.0.write-all servo-thread
 
 show
 
-net rtec-statusword lcec.0.D22.srv-cia-statusword => cia402.0.statusword
-net rtec-opmode-display lcec.0.D22.srv-opmode-display => cia402.0.opmode-display
-net rtec-drv-act-pos lcec.0.D22.srv-actual-position => cia402.0.drv-actual-position
-net rtec-drv-act-velo lcec.0.D22.srv-actual-velocity => cia402.0.drv-actual-velocity
+net rtec-statusword lcec.0.D22.srv-1-cia-statusword => cia402.0.statusword
+net rtec-opmode-display lcec.0.D22.srv-1-opmode-display => cia402.0.opmode-display
+net rtec-drv-act-pos lcec.0.D22.srv-1-actual-position => cia402.0.drv-actual-position
+net rtec-drv-act-velo lcec.0.D22.srv-1-actual-velocity => cia402.0.drv-actual-velocity
 
-net rtec-controlword cia402.0.controlword => lcec.0.D22.srv-cia-controlword
-net rtec-modes-of-operation cia402.0.opmode => lcec.0.D22.srv-opmode
-net rtec-drv-target-pos cia402.0.drv-target-position => lcec.0.D22.srv-target-position
-net rtec-drv-target-velo cia402.0.drv-target-velocity => lcec.0.D22.srv-target-velocity
+net rtec-controlword cia402.0.controlword => lcec.0.D22.srv-1-cia-controlword
+net rtec-modes-of-operation cia402.0.opmode => lcec.0.D22.srv-1-opmode
+net rtec-drv-target-pos cia402.0.drv-target-position => lcec.0.D22.srv-1-target-position
+net rtec-drv-target-velo cia402.0.drv-target-velocity => lcec.0.D22.srv-1-target-velocity
 
-setp cia402.0.csp-mode 0  # velocity mode, for testing.
+setp cia402.0.csp-mode 1  # velocity mode, for testing.
 
 start
 

--- a/tests/scottlaird-lcectest1/fulltest.xml
+++ b/tests/scottlaird-lcectest1/fulltest.xml
@@ -110,17 +110,14 @@
       <modParam name="ciaChannels" value="2"/>
       <modParam name="ch1enablePP" value="true"/>
       <modParam name="ch1enablePV" value="true"/>
+      <modParam name="ch1enableCSP" value="true"/>
       <modParam name="ch1enableHM" value="true"/>
       <modParam name="ch1enableCSP" value="true"/>
-      <modParam name="ch1enableActualCurrent" value="true"/>
-      <modParam name="ch1enableActualFollowingError" value="true"/>
-      <modParam name="ch1enableActualTorque" value="true"/>
-      <modParam name="ch1enableActualVelocitySensor" value="true"/>
-      <modParam name="ch1enableActualVoltage" value="true"/>
+      <modParam name="ch1enableActualCurrent" value="true"/> 
+      <modParam name="ch1enableActualVoltage" value="true"/> 
       <modParam name="ch1enableFollowingErrorTimeout" value="true"/>
       <modParam name="ch1enableFollowingErrorWindow" value="true"/>
       <modParam name="ch1enableHomeAccel" value="true"/>
-      <modParam name="ch1enableInterpolationTimePeriod" value="true"/>
       <modParam name="ch1enableMaximumAcceleration" value="true"/>
       <modParam name="ch1enableMaximumCurrent" value="true"/>
       <modParam name="ch1enableMaximumDeceleration" value="true"/>
@@ -134,20 +131,17 @@
       <modParam name="ch1enableProfileEndVelocity" value="true"/>
       <modParam name="ch1enableProfileMaxVelocity" value="true"/>
       <modParam name="ch1enableProfileVelocity" value="true"/>
-      <modParam name="ch1enableTargetTorque" value="true"/>
-      <modParam name="ch1enableTorqueDemand" value="true"/>
-      <modParam name="ch1enableTorqueProfileType" value="true"/>
-      <modParam name="ch1enableTorqueSlope" value="true"/>
-      <modParam name="ch1enableVelocityDemand" value="true"/>
       <modParam name="ch1enableVelocityErrorTime" value="true"/>
       <modParam name="ch1enableVelocityErrorWindow" value="true"/>
       <modParam name="ch1enableVelocitySensorSelector" value="true"/>
       <modParam name="ch1enableVelocityThresholdTime" value="true"/>
       <modParam name="ch1enableVelocityThresholdWindow" value="true"/>
-      <modParam name="ch2enablePP" value="true"/>
+      <modParam name="ch2enablePP" value="true"/> 
+      <modParam name="ch2enablePV" value="true"/>
+      <modParam name="ch2enableCSP" value="true"/>
       <modParam name="ch2enablePV" value="true"/>
       <modParam name="ch2enableHM" value="true"/>
-      <modParam name="ch2enableCSP" value="true"/>
+      <modParam name="ch2enableCSP" value="true"/> -->
       <modParam name="ch2enableActualCurrent" value="true"/>
       <modParam name="ch2enableActualFollowingError" value="true"/>
       <modParam name="ch2enableActualTorque" value="true"/>
@@ -179,7 +173,7 @@
       <modParam name="ch2enableVelocityErrorWindow" value="true"/>
       <modParam name="ch2enableVelocitySensorSelector" value="true"/>
       <modParam name="ch2enableVelocityThresholdTime" value="true"/>
-      <modParam name="ch2enableVelocityThresholdWindow" value="true"/> 
+      <modParam name="ch2enableVelocityThresholdWindow" value="true"/>
     </slave>
 <!--    <slave idx="22" type="basic_cia402" vid="0x00000227" pid="0x00000005" name="D23">
       <modParam name="ciaChannels" value="6"/>


### PR DESCRIPTION
The CiA 402 library creates an *enormous* number of PDOs, especially on multi-axis devices, and the bulk of these aren't really things that need to be frequently changed.  This include details like `motor-rated-torque` and `home-method`, which *could* be `<modParam>`s that are unlikely to change at runtime, along with a few other settings that could reasonably be changed from time to time, but will never be updated on a millisecond-by-millisecond basis.

IMO, the UX for HAL pins is better than the UX for `<modParam>`s, as HAL pins are trivially discoverable, while `<modParam>`s just lurk in the documentation.  Plus, during setup and tuning, it's nice to be able to adjust peak RPM, motor current, etc on the fly.

The problem is that we can easily create more PDOs from pins than some devices are able to support.  Specifically, Leadshine's EtherCAT drives have an apparently hard limit of 8 PDO entries per PDO, and 4 Rx PDOs per device.  For dual-axis devices, that means that we can't have more than 16 PDO entries per axis, and that includes whatever device-specific settings we end up mapping (encoder resolution, etc).

My first attempt at using the Leadshine 2CS3E-D507 (dual axis closed-loop stepper drive) failed horribly; I think I was trying to cram 30+ PDO entries into an 8-entry PDO.  It kind of gets worse from there:

1.  I'm not convinced that there's a portable way to determine how many PDO entries a device supports at runtime.  There are a few things that'd probably work (read 0x1600:00, read 0x1600:01, :02, etc until an error occurs), but I can think of cases where any of those might fail.
2. Etherlab's code will let us add more PDO entries than the hardware supports, and will end up logging an error that looks a lot like it saying that a specific PDO isn't supported, when it's actually griping about the PDO being full.

After griping about this a bit, I realized that we had 2 main choices:

1.  Only map ~5 PDO entries per axis (plus the 2 or 3 entries that CiA 402 requires) by vigorously paring down features via `<modParam>`.
2. Stop using PDOs for writing to things that don't need to change at high speed.

So, we're going with option 2 for now.  I've divided up the objects that we write to into two lists: things that need to be updated constantly (`target_position`, etc), and things that we'd like to be able to change from time to time, but don't need high performance.  The items from the first list remained as mapped PDOs.  The items on the second list are no longer mapped, and are written as SDOs under the hood.  There are going to be some performance issues around that, but I suspect that it won't really matter as long as we don't try doing high-speed writes to an SDO-backed pin.

This is kind of weird, but I think it's the right way to go.  Assuming it works about as I expect it to, it's probably worth wrapping some code around this and making it a semi-standard pattern in LCEC, because it seems to be a perfectly reasonable pattern for mapping config objects to pins.

Issues #327 #180 
