### PR TITLE
style: always use lcec_slave_t instead of struct lcec_slave

### DIFF
--- a/src/devices/lcec_ax5100.c
+++ b/src/devices/lcec_ax5100.c
@@ -22,7 +22,7 @@
 
 #include "../lcec.h"
 
-static int lcec_ax5100_init(int comp_id, struct lcec_slave *slave);
+static int lcec_ax5100_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_ax5100_modparams[] = {
   {"enableFB2", LCEC_AX5_PARAM_ENABLE_FB2, MODPARAM_TYPE_BIT}, {"enableDiag", LCEC_AX5_PARAM_ENABLE_DIAG, MODPARAM_TYPE_BIT}, {NULL},};
@@ -49,10 +49,10 @@ static const LCEC_CONF_FSOE_T fsoe_conf = {
     .data_channels = 1,
 };
 
-static void lcec_ax5100_read(struct lcec_slave *slave, long period);
-static void lcec_ax5100_write(struct lcec_slave *slave, long period);
+static void lcec_ax5100_read(lcec_slave_t *slave, long period);
+static void lcec_ax5100_write(lcec_slave_t *slave, long period);
 
-/*static*/ int lcec_ax5100_preinit(struct lcec_slave *slave) {
+/*static*/ int lcec_ax5100_preinit(lcec_slave_t *slave) {
   // check if already initialized
   if (slave->fsoeConf != NULL) {
     return 0;
@@ -64,7 +64,7 @@ static void lcec_ax5100_write(struct lcec_slave *slave, long period);
   return 0;
 }
 
-static int lcec_ax5100_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_ax5100_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_ax5100_data_t *hal_data;
   int err;
@@ -113,14 +113,14 @@ static int lcec_ax5100_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_ax5100_read(struct lcec_slave *slave, long period) {
+static void lcec_ax5100_read(lcec_slave_t *slave, long period) {
   lcec_ax5100_data_t *hal_data = (lcec_ax5100_data_t *)slave->hal_data;
 
   // check inputs
   lcec_class_ax5_read(slave, &hal_data->chan);
 }
 
-static void lcec_ax5100_write(struct lcec_slave *slave, long period) {
+static void lcec_ax5100_write(lcec_slave_t *slave, long period) {
   lcec_ax5100_data_t *hal_data = (lcec_ax5100_data_t *)slave->hal_data;
 
   // write outputs

--- a/src/devices/lcec_ax5200.c
+++ b/src/devices/lcec_ax5200.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_ax5200_init(int comp_id, struct lcec_slave *slave);
+static int lcec_ax5200_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_ax5200_modparams[] = {
     {"enableFB2", LCEC_AX5_PARAM_ENABLE_FB2, MODPARAM_TYPE_BIT},
@@ -49,10 +49,10 @@ static const LCEC_CONF_FSOE_T fsoe_conf = {
     .data_channels = 2,
 };
 
-static void lcec_ax5200_read(struct lcec_slave *slave, long period);
-static void lcec_ax5200_write(struct lcec_slave *slave, long period);
+static void lcec_ax5200_read(lcec_slave_t *slave, long period);
+static void lcec_ax5200_write(lcec_slave_t *slave, long period);
 
-/*static*/ int lcec_ax5200_preinit(struct lcec_slave *slave) {
+/*static*/ int lcec_ax5200_preinit(lcec_slave_t *slave) {
   // check if already initialized
   if (slave->fsoeConf != NULL) {
     return 0;
@@ -64,7 +64,7 @@ static void lcec_ax5200_write(struct lcec_slave *slave, long period);
   return 0;
 }
 
-static int lcec_ax5200_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_ax5200_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_ax5200_data_t *hal_data;
   int i;
@@ -138,7 +138,7 @@ static int lcec_ax5200_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_ax5200_read(struct lcec_slave *slave, long period) {
+static void lcec_ax5200_read(lcec_slave_t *slave, long period) {
   lcec_ax5200_data_t *hal_data = (lcec_ax5200_data_t *)slave->hal_data;
   int i;
   lcec_class_ax5_chan_t *chan;
@@ -150,7 +150,7 @@ static void lcec_ax5200_read(struct lcec_slave *slave, long period) {
   }
 }
 
-static void lcec_ax5200_write(struct lcec_slave *slave, long period) {
+static void lcec_ax5200_write(lcec_slave_t *slave, long period) {
   lcec_ax5200_data_t *hal_data = (lcec_ax5200_data_t *)slave->hal_data;
   int i;
   lcec_class_ax5_chan_t *chan;

--- a/src/devices/lcec_ax5805.c
+++ b/src/devices/lcec_ax5805.c
@@ -25,9 +25,9 @@
 #include "lcec_ax5100.h"
 #include "lcec_ax5200.h"
 
-static void lcec_ax5805_read(struct lcec_slave *slave, long period);
-static int lcec_ax5805_preinit(struct lcec_slave *slave);
-static int lcec_ax5805_init(int comp_id, struct lcec_slave *slave);
+static void lcec_ax5805_read(lcec_slave_t *slave, long period);
+static int lcec_ax5805_preinit(lcec_slave_t *slave);
+static int lcec_ax5805_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"AX5805", LCEC_BECKHOFF_VID, 0x16AD6012, 0, lcec_ax5805_preinit, lcec_ax5805_init},
@@ -91,9 +91,9 @@ static const lcec_pindesc_t slave_pins_2ch[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int lcec_ax5805_preinit(struct lcec_slave *slave) {
+static int lcec_ax5805_preinit(lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
-  struct lcec_slave *ax5n_slave;
+  lcec_slave_t *ax5n_slave;
 
   // try to find corresponding ax5n
   ax5n_slave = lcec_slave_by_index(master, slave->index - 1);
@@ -124,7 +124,7 @@ static int lcec_ax5805_preinit(struct lcec_slave *slave) {
   return 0;
 }
 
-static int lcec_ax5805_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_ax5805_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_ax5805_data_t *hal_data;
   int err;
@@ -169,7 +169,7 @@ static int lcec_ax5805_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_ax5805_read(struct lcec_slave *slave, long period) {
+static void lcec_ax5805_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_ax5805_data_t *hal_data = (lcec_ax5805_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -45,7 +45,7 @@ static const lcec_modparam_desc_t modparams_lcec_basic_cia402[] = {
     {NULL},
 };
 
-static int lcec_basic_cia402_init(int comp_id, struct lcec_slave *slave);
+static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave);
 
 // When extending this, you will need to modify the number of PDOs
 // registered (the `8` here).  For now, the easiest way to do this is
@@ -66,8 +66,8 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_lcec_basic_cia402)
 
-static void lcec_basic_cia402_read(struct lcec_slave *slave, long period);
-static void lcec_basic_cia402_write(struct lcec_slave *slave, long period);
+static void lcec_basic_cia402_read(lcec_slave_t *slave, long period);
+static void lcec_basic_cia402_write(lcec_slave_t *slave, long period);
 
 typedef struct {
   lcec_class_cia402_channels_t *cia402;
@@ -81,7 +81,7 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int handle_modparams(struct lcec_slave *slave, lcec_class_cia402_options_t *options) {
+static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *options) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   int v;
@@ -113,7 +113,7 @@ static int handle_modparams(struct lcec_slave *slave, lcec_class_cia402_options_
   return 0;
 }
 
-static int lcec_basic_cia402_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_basic_cia402_data_t *hal_data;
   int err;
@@ -251,7 +251,7 @@ static int lcec_basic_cia402_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_basic_cia402_read(struct lcec_slave *slave, long period) {
+static void lcec_basic_cia402_read(lcec_slave_t *slave, long period) {
   lcec_basic_cia402_data_t *hal_data = (lcec_basic_cia402_data_t *)slave->hal_data;
 
   // wait for slave to be operational
@@ -269,7 +269,7 @@ static void lcec_basic_cia402_read(struct lcec_slave *slave, long period) {
   //  lcec_din_read_all(slave, hal_data->din);
 }
 
-static void lcec_basic_cia402_write(struct lcec_slave *slave, long period) {
+static void lcec_basic_cia402_write(lcec_slave_t *slave, long period) {
   lcec_basic_cia402_data_t *hal_data = (lcec_basic_cia402_data_t *)slave->hal_data;
 
   // wait for slave to be operational

--- a/src/devices/lcec_class_ain.c
+++ b/src/devices/lcec_class_ain.c
@@ -112,7 +112,7 @@ lcec_class_ain_options_t *lcec_ain_options(void) {
 /// @return A `lcec_class_ain_channel_t` that contains all per-channel data and can be used with `lcec_ain_read()`.
 ///
 /// See lcec_el3xxx.c for an example of use.
-lcec_class_ain_channel_t *lcec_ain_register_channel(struct lcec_slave *slave, int id, uint16_t idx, lcec_class_ain_options_t *opt) {
+lcec_class_ain_channel_t *lcec_ain_register_channel(lcec_slave_t *slave, int id, uint16_t idx, lcec_class_ain_options_t *opt) {
   lcec_class_ain_channel_t *data;
   int err;
 
@@ -250,7 +250,7 @@ lcec_class_ain_channel_t *lcec_ain_register_channel(struct lcec_slave *slave, in
 ///
 /// Call this once per channel registered, from inside of your device's
 /// read function.  Use `lcec_ain_read_all` to read all pins.
-void lcec_ain_read(struct lcec_slave *slave, lcec_class_ain_channel_t *data) {
+void lcec_ain_read(lcec_slave_t *slave, lcec_class_ain_channel_t *data) {
   uint8_t *pd = slave->master->process_data;
   int value;  // Needs to be large enough to hold either a uint16_t or an sint16_t without loss.
   int max_value = data->options->max_value;
@@ -291,7 +291,7 @@ void lcec_ain_read(struct lcec_slave *slave, lcec_class_ain_channel_t *data) {
 ///
 /// @param slave The `slave`, passed from the per-device `_read`.
 /// @param channels An `lcec_class_ain_channel_t *`, as returned by lcec_ain_register_channel.
-void lcec_ain_read_all(struct lcec_slave *slave, lcec_class_ain_channels_t *channels) {
+void lcec_ain_read_all(lcec_slave_t *slave, lcec_class_ain_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
     lcec_class_ain_channel_t *channel = channels->channels[i];
 

--- a/src/devices/lcec_class_aout.c
+++ b/src/devices/lcec_class_aout.c
@@ -89,7 +89,7 @@ lcec_class_aout_options_t *lcec_aout_options(void) {
 /// @return A `lcec_class_aout_channel_t` that contains all per-channel data and can be used with `lcec_aout_write()`.
 ///
 /// See lcec_el3xxx.c for an example of use.
-lcec_class_aout_channel_t *lcec_aout_register_channel(struct lcec_slave *slave, int id, uint16_t idx, lcec_class_aout_options_t *opt) {
+lcec_class_aout_channel_t *lcec_aout_register_channel(lcec_slave_t *slave, int id, uint16_t idx, lcec_class_aout_options_t *opt) {
   lcec_class_aout_channel_t *data;
   int err;
 
@@ -161,7 +161,7 @@ lcec_class_aout_channel_t *lcec_aout_register_channel(struct lcec_slave *slave, 
 ///
 /// Call this once per channel registered, from inside of your device's
 /// read function.  Use `lcec_aout_write_all` to read all pins.
-void lcec_aout_write(struct lcec_slave *slave, lcec_class_aout_channel_t *data) {
+void lcec_aout_write(lcec_slave_t *slave, lcec_class_aout_channel_t *data) {
   uint8_t *pd = slave->master->process_data;
   int max_value = data->options->max_value;
   double tmpval, tmpdc, raw_val;
@@ -237,7 +237,7 @@ void lcec_aout_write(struct lcec_slave *slave, lcec_class_aout_channel_t *data) 
 ///
 /// @param slave The `slave`, passed from the per-device `_read`.
 /// @param channels An `lcec_class_aout_channel_t *`, as returned by lcec_aout_register_channel.
-void lcec_aout_write_all(struct lcec_slave *slave, lcec_class_aout_channels_t *channels) {
+void lcec_aout_write_all(lcec_slave_t *slave, lcec_class_aout_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
     lcec_class_aout_channel_t *channel = channels->channels[i];
 

--- a/src/devices/lcec_class_ax5.c
+++ b/src/devices/lcec_class_ax5.c
@@ -54,7 +54,7 @@ static const lcec_pindesc_t slave_fb2_params[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int get_param_flag(struct lcec_slave *slave, int id) {
+static int get_param_flag(lcec_slave_t *slave, int id) {
   LCEC_CONF_MODPARAM_VAL_T *pval;
 
   pval = lcec_modparam_get(slave, id);
@@ -65,7 +65,7 @@ static int get_param_flag(struct lcec_slave *slave, int id) {
   return pval->bit;
 }
 
-int lcec_class_ax5_pdos(struct lcec_slave *slave) {
+int lcec_class_ax5_pdos(lcec_slave_t *slave) {
   int pdo_count = 5;
 
   if (get_param_flag(slave, LCEC_AX5_PARAM_ENABLE_FB2)) {
@@ -79,7 +79,7 @@ int lcec_class_ax5_pdos(struct lcec_slave *slave) {
   return pdo_count;
 }
 
-int lcec_class_ax5_init(struct lcec_slave *slave, lcec_class_ax5_chan_t *chan, int index, const char *pfx) {
+int lcec_class_ax5_init(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan, int index, const char *pfx) {
   lcec_master_t *master = slave->master;
   int err;
   uint8_t idn_buf[4];
@@ -190,7 +190,7 @@ void lcec_class_ax5_check_scales(lcec_class_ax5_chan_t *chan) {
   }
 }
 
-void lcec_class_ax5_read(struct lcec_slave *slave, lcec_class_ax5_chan_t *chan) {
+void lcec_class_ax5_read(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   uint32_t pos_cnt;
@@ -241,7 +241,7 @@ void lcec_class_ax5_read(struct lcec_slave *slave, lcec_class_ax5_chan_t *chan) 
   *(chan->torque_fb_pct) = ((double)EC_READ_S16(&pd[chan->torque_fb_pdo_os])) * 0.1;
 }
 
-void lcec_class_ax5_write(struct lcec_slave *slave, lcec_class_ax5_chan_t *chan) {
+void lcec_class_ax5_write(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   uint16_t ctrl;

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -721,7 +721,7 @@ int lcec_cia402_add_input_sync(lcec_syncs_t *syncs, lcec_class_cia402_options_t 
 ///   `lcec_class_cia402_channel_options_t` from
 ///   `lcec_cia402_channel_options()`.
 lcec_class_cia402_channel_t *lcec_cia402_register_channel(
-    struct lcec_slave *slave, uint16_t base_idx, lcec_class_cia402_channel_options_t *opt) {
+    lcec_slave_t *slave, uint16_t base_idx, lcec_class_cia402_channel_options_t *opt) {
   lcec_class_cia402_channel_t *data;
   int err;
   lcec_class_cia402_enabled_t *enabled;
@@ -970,7 +970,7 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
 ///
 /// Call this once per channel registered, from inside of your device's
 /// read function.  Use `lcec_cia402_read_all` to read all channels.
-void lcec_cia402_read(struct lcec_slave *slave, lcec_class_cia402_channel_t *data) {
+void lcec_cia402_read(lcec_slave_t *slave, lcec_class_cia402_channel_t *data) {
   uint8_t *pd = slave->master->process_data;
 
 #define READ_OPT(pin_name)              \
@@ -996,7 +996,7 @@ void lcec_cia402_read(struct lcec_slave *slave, lcec_class_cia402_channel_t *dat
 ///
 /// @param slave The `slave`, passed from the per-device `_read`.
 /// @param channels An `lcec_class_cia402_channel_t *`, as returned by lcec_cia402_register_channel.
-void lcec_cia402_read_all(struct lcec_slave *slave, lcec_class_cia402_channels_t *channels) {
+void lcec_cia402_read_all(lcec_slave_t *slave, lcec_class_cia402_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
     lcec_cia402_read(slave, channels->channels[i]);
   }
@@ -1034,7 +1034,7 @@ void lcec_cia402_read_all(struct lcec_slave *slave, lcec_class_cia402_channels_t
     } \
   } while(0)
 
-void lcec_cia402_write(struct lcec_slave *slave, lcec_class_cia402_channel_t *data) {
+void lcec_cia402_write(lcec_slave_t *slave, lcec_class_cia402_channel_t *data) {
   uint8_t *pd = slave->master->process_data;
 
   EC_WRITE_U16(&pd[data->controlword_os], (uint16_t)(*(data->controlword)));
@@ -1085,7 +1085,7 @@ void lcec_cia402_write(struct lcec_slave *slave, lcec_class_cia402_channel_t *da
 ///
 /// @param slave The `slave`, passed from the per-device `_read`.
 /// @param channels An `lcec_class_cia402_channel_t *`, as returned by lcec_cia402_register_channel.
-void lcec_cia402_write_all(struct lcec_slave *slave, lcec_class_cia402_channels_t *channels) {
+void lcec_cia402_write_all(lcec_slave_t *slave, lcec_class_cia402_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
     lcec_class_cia402_channel_t *channel = channels->channels[i];
 
@@ -1246,7 +1246,7 @@ lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_m
 /// @param p The current modparam being processed.
 ///
 /// @return 0 if the modparam was handled, 1 if it was not handled, and <0 if an error occurred.
-int lcec_cia402_handle_modparam(struct lcec_slave *slave, const lcec_slave_modparam_t *p, lcec_class_cia402_options_t *opt) {
+int lcec_cia402_handle_modparam(lcec_slave_t *slave, const lcec_slave_modparam_t *p, lcec_class_cia402_options_t *opt) {
   if (p->id < CIA402_MP_BASE) {
     return 0;
   }

--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -65,7 +65,7 @@ lcec_class_din_channels_t *lcec_din_allocate_channels(int count) {
 /// @param idx the PDO index for the digital input.
 /// @param sindx the PDO sub-index for the digital input.
 ///
-lcec_class_din_channel_t *lcec_din_register_channel(struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx) {
+lcec_class_din_channel_t *lcec_din_register_channel(lcec_slave_t *slave, int id, uint16_t idx, uint16_t sidx) {
   char name[32];
 
   snprintf(name, 32, "din-%d", id);
@@ -80,7 +80,7 @@ lcec_class_din_channel_t *lcec_din_register_channel(struct lcec_slave *slave, in
 /// @param idx the PDO index for the digital input.
 /// @param sindx the PDO sub-index for the digital input.
 /// @param name The base name to use for the channel, `din-<ID>` is common.
-lcec_class_din_channel_t *lcec_din_register_channel_named(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name) {
+lcec_class_din_channel_t *lcec_din_register_channel_named(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, char *name) {
   lcec_class_din_channel_t *data;
   int err;
 
@@ -117,7 +117,7 @@ lcec_class_din_channel_t *lcec_din_register_channel_named(struct lcec_slave *sla
 /// @param os  The offset from `LCEC_PDO_INIT()`.
 /// @param bit  The bit offset for the digital in channel.
 /// @param name The base name to use for the channel, `din-<ID>` is common.
-lcec_class_din_channel_t *lcec_din_register_channel_packed(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, char *name) {
+lcec_class_din_channel_t *lcec_din_register_channel_packed(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, int bit, char *name) {
   lcec_class_din_channel_t *data;
   int err;
 
@@ -152,7 +152,7 @@ lcec_class_din_channel_t *lcec_din_register_channel_packed(struct lcec_slave *sl
 ///
 /// Call this once per pin registered, from inside of your device's
 /// read function.  See `lcec_din_read_all` for an alternative approach.
-void lcec_din_read(struct lcec_slave *slave, lcec_class_din_channel_t *data) {
+void lcec_din_read(lcec_slave_t *slave, lcec_class_din_channel_t *data) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   hal_bit_t s;
@@ -178,7 +178,7 @@ void lcec_din_read(struct lcec_slave *slave, lcec_class_din_channel_t *data) {
 ///
 /// @param slave The slave, passed from the per-device `_read`.
 /// @param channels An `lcec_class_din_channels_t *`, as returned by `lcec_din_allocate_channels()`.
-void lcec_din_read_all(struct lcec_slave *slave, lcec_class_din_channels_t *channels) {
+void lcec_din_read_all(lcec_slave_t *slave, lcec_class_din_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
     lcec_class_din_channel_t *channel = channels->channels[i];
 

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -66,7 +66,7 @@ lcec_class_dout_channels_t *lcec_dout_allocate_channels(int count) {
 /// @param sindx The PDO sub-index for the digital output.
 ///
 /// See lcec_el2xxx.c for an example of use.
-lcec_class_dout_channel_t *lcec_dout_register_channel(struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx) {
+lcec_class_dout_channel_t *lcec_dout_register_channel(lcec_slave_t *slave, int id, uint16_t idx, uint16_t sidx) {
   char name[32];
 
   snprintf(name, 32, "dout-%d", id);
@@ -83,7 +83,7 @@ lcec_class_dout_channel_t *lcec_dout_register_channel(struct lcec_slave *slave, 
 /// @param name The base pin name to use, usually `dout-<ID>`.
 ///
 /// See lcec_el2xxx.c for an example of use.
-lcec_class_dout_channel_t *lcec_dout_register_channel_named(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name) {
+lcec_class_dout_channel_t *lcec_dout_register_channel_named(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, char *name) {
   lcec_class_dout_channel_t *data;
   int err;
 
@@ -125,7 +125,7 @@ lcec_class_dout_channel_t *lcec_dout_register_channel_named(struct lcec_slave *s
 /// @param os  The offset from `LCEC_PDO_INIT()`.
 /// @param bit  The bit offset for the digital out channel.
 /// @param name The base name to use for the channel, `dout-<ID>` is common.
-lcec_class_dout_channel_t *lcec_dout_register_channel_packed(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, char *name) {
+lcec_class_dout_channel_t *lcec_dout_register_channel_packed(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, int bit, char *name) {
   lcec_class_dout_channel_t *data;
   int err;
 
@@ -159,7 +159,7 @@ lcec_class_dout_channel_t *lcec_dout_register_channel_packed(struct lcec_slave *
 ///
 /// @param slave The slave, passed from the per-device `_write`.
 /// @param data A lcec_class_dout_channel_t *, as returned by lcec_dout_register_channel.
-void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data) {
+void lcec_dout_write(lcec_slave_t *slave, lcec_class_dout_channel_t *data) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   hal_bit_t s;
@@ -187,7 +187,7 @@ void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data) 
 /// @param slave The slave, passed from the per-device `_write`.
 /// @param channels A `lcec_class_dout_channels_t *`, as returned by
 /// `lcec_dout_register_channel`.
-void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_channels_t *channels) {
+void lcec_dout_write_all(lcec_slave_t *slave, lcec_class_dout_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
     lcec_class_dout_channel_t *channel = channels->channels[i];
 

--- a/src/devices/lcec_class_enc.c
+++ b/src/devices/lcec_class_enc.c
@@ -50,7 +50,7 @@ static int32_t raw_diff(int shift, uint32_t raw_a, uint32_t raw_b);
 static void set_ref(lcec_class_enc_data_t *hal_data, long long ref);
 static long long signed_mod_64(long long val, unsigned long div);
 
-int class_enc_init(struct lcec_slave *slave, lcec_class_enc_data_t *hal_data, int raw_bits, const char *pfx) {
+int class_enc_init(lcec_slave_t *slave, lcec_class_enc_data_t *hal_data, int raw_bits, const char *pfx) {
   lcec_master_t *master = slave->master;
   int err;
 

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -43,7 +43,7 @@
 #define DEASDA_OPMODE_CSP 8
 #define DEASDA_OPMODE_CSV 9
 
-static int lcec_deasda_init(int comp_id, struct lcec_slave *slave);
+static int lcec_deasda_init(int comp_id, lcec_slave_t *slave);
 
 static const lcec_modparam_desc_t lcec_deasda_modparams[] = {
     {"opmode", LCEC_DESDA_MODPARAM_OPERATIONMODE, MODPARAM_TYPE_STRING},
@@ -250,13 +250,13 @@ static ec_sync_info_t lcec_deasda_syncs_csp[] = {
 
 static void lcec_deasda_check_scales(lcec_deasda_data_t *hal_data);
 
-static void lcec_deasda_read(struct lcec_slave *slave, long period);
-static void lcec_deasda_write_csv(struct lcec_slave *slave, long period);
-static void lcec_deasda_write_csp(struct lcec_slave *slave, long period);
+static void lcec_deasda_read(lcec_slave_t *slave, long period);
+static void lcec_deasda_write_csv(lcec_slave_t *slave, long period);
+static void lcec_deasda_write_csp(lcec_slave_t *slave, long period);
 
 static const drive_operationmodes_t *drive_opmode(char *drivemode);
 
-static int lcec_deasda_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_deasda_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_deasda_data_t *hal_data;
   int err;
@@ -420,7 +420,7 @@ void lcec_deasda_check_scales(lcec_deasda_data_t *hal_data) {
   }
 }
 
-static void lcec_deasda_read(struct lcec_slave *slave, long period) {
+static void lcec_deasda_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_deasda_data_t *hal_data = (lcec_deasda_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -516,7 +516,7 @@ static void lcec_deasda_read(struct lcec_slave *slave, long period) {
   *(hal_data->di_7) = (status_di >> 22) & 0x01;
 }
 
-static void lcec_deasda_write_csv(struct lcec_slave *slave, long period) {
+static void lcec_deasda_write_csv(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_deasda_data_t *hal_data = (lcec_deasda_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -566,7 +566,7 @@ static void lcec_deasda_write_csv(struct lcec_slave *slave, long period) {
   EC_WRITE_S32(&pd[hal_data->cmdvalue_pdo_os], (int32_t)speed_raw);
 }
 
-static void lcec_deasda_write_csp(struct lcec_slave *slave, long period) {
+static void lcec_deasda_write_csp(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_deasda_data_t *hal_data = (lcec_deasda_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_dems300.c
+++ b/src/devices/lcec_dems300.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_dems300_init(int comp_id, struct lcec_slave *slave);
+static int lcec_dems300_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"DeMS300", LCEC_DELTA_VID, 0x10400200, 0, NULL, lcec_dems300_init},
@@ -171,10 +171,10 @@ static ec_sync_info_t lcec_dems300_syncs[] = {
 
 static void lcec_dems300_check_scales(lcec_dems300_data_t *hal_data);
 
-static void lcec_dems300_read(struct lcec_slave *slave, long period);
-static void lcec_dems300_write(struct lcec_slave *slave, long period);
+static void lcec_dems300_read(lcec_slave_t *slave, long period);
+static void lcec_dems300_write(lcec_slave_t *slave, long period);
 
-static int lcec_dems300_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_dems300_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_dems300_data_t *hal_data;
   int err;
@@ -244,7 +244,7 @@ static void lcec_dems300_check_scales(lcec_dems300_data_t *hal_data) {
   }
 }
 
-static void lcec_dems300_read(struct lcec_slave *slave, long period) {
+static void lcec_dems300_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_dems300_data_t *hal_data = (lcec_dems300_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -318,7 +318,7 @@ static void lcec_dems300_read(struct lcec_slave *slave, long period) {
   *(hal_data->vel_fb_rpm_abs) = fabs(rpm);
 }
 
-static void lcec_dems300_write(struct lcec_slave *slave, long period) {
+static void lcec_dems300_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_dems300_data_t *hal_data = (lcec_dems300_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_digitalcombo.c
+++ b/src/devices/lcec_digitalcombo.c
@@ -63,7 +63,7 @@
 #include "lcec_class_din.h"
 #include "lcec_class_dout.h"
 
-static int lcec_digitalcombo_init(int comp_id, struct lcec_slave *slave);
+static int lcec_digitalcombo_init(int comp_id, lcec_slave_t *slave);
 
 #define F_IN(x)     (x)       // Input channels
 #define F_OUT(x)    (x * 32)  // Output channels
@@ -113,10 +113,10 @@ typedef struct {
   lcec_class_dout_channels_t *channels_out;
 } lcec_digitalcombo_data_t;
 
-static void lcec_digitalcombo_read(struct lcec_slave *slave, long period);
-static void lcec_digitalcombo_write(struct lcec_slave *slave, long period);
+static void lcec_digitalcombo_read(lcec_slave_t *slave, long period);
+static void lcec_digitalcombo_write(lcec_slave_t *slave, long period);
 
-static int lcec_digitalcombo_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_digitalcombo_init(int comp_id, lcec_slave_t *slave) {
   lcec_digitalcombo_data_t *hal_data;
   int i;
   int in_channels = INPORTS(slave->flags);
@@ -174,7 +174,7 @@ static int lcec_digitalcombo_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_digitalcombo_read(struct lcec_slave *slave, long period) {
+static void lcec_digitalcombo_read(lcec_slave_t *slave, long period) {
   lcec_digitalcombo_data_t *hal_data = (lcec_digitalcombo_data_t *)slave->hal_data;
 
   // wait for slave to be operational
@@ -185,7 +185,7 @@ static void lcec_digitalcombo_read(struct lcec_slave *slave, long period) {
   if (hal_data->channels_in != NULL) lcec_din_read_all(slave, hal_data->channels_in);
 }
 
-static void lcec_digitalcombo_write(struct lcec_slave *slave, long period) {
+static void lcec_digitalcombo_write(lcec_slave_t *slave, long period) {
   lcec_digitalcombo_data_t *hal_data = (lcec_digitalcombo_data_t *)slave->hal_data;
 
   // wait for slave to be operational

--- a/src/devices/lcec_easyio.c
+++ b/src/devices/lcec_easyio.c
@@ -35,7 +35,7 @@ typedef struct {
   lcec_class_aout_channels_t *analog_out;
 } lcec_easyio_data_t;
 
-static int lcec_easyio_init(int comp_id, struct lcec_slave *slave);
+static int lcec_easyio_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EasyIO", LCEC_ABET_VID, 0x0debacca, 0, NULL, lcec_easyio_init},
@@ -43,10 +43,10 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES(types)
 
-static void lcec_easyio_write(struct lcec_slave *slave, long period);
-static void lcec_easyio_read(struct lcec_slave *slave, long period);
+static void lcec_easyio_write(lcec_slave_t *slave, long period);
+static void lcec_easyio_read(lcec_slave_t *slave, long period);
 
-static int lcec_easyio_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_easyio_init(int comp_id, lcec_slave_t *slave) {
   lcec_easyio_data_t *hal_data;
   int i;
 
@@ -100,7 +100,7 @@ static int lcec_easyio_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_easyio_write(struct lcec_slave *slave, long period) {
+static void lcec_easyio_write(lcec_slave_t *slave, long period) {
   lcec_easyio_data_t *hal_data = (lcec_easyio_data_t *)slave->hal_data;
 
   if (!slave->state.operational) {
@@ -110,7 +110,7 @@ static void lcec_easyio_write(struct lcec_slave *slave, long period) {
   lcec_aout_write_all(slave, hal_data->analog_out);
 }
 
-static void lcec_easyio_read(struct lcec_slave *slave, long period) {
+static void lcec_easyio_read(lcec_slave_t *slave, long period) {
   lcec_easyio_data_t *hal_data = (lcec_easyio_data_t *)slave->hal_data;
 
   if (!slave->state.operational) {

--- a/src/devices/lcec_el1904.c
+++ b/src/devices/lcec_el1904.c
@@ -23,9 +23,9 @@
 
 #include "../lcec.h"
 
-static void lcec_el1904_read(struct lcec_slave *slave, long period);
-static int lcec_el1904_preinit(struct lcec_slave *slave);
-static int lcec_el1904_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el1904_read(lcec_slave_t *slave, long period);
+static int lcec_el1904_preinit(lcec_slave_t *slave);
+static int lcec_el1904_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL1904", LCEC_BECKHOFF_VID, 0x07703052, 0, lcec_el1904_preinit, lcec_el1904_init},
@@ -84,14 +84,14 @@ static const LCEC_CONF_FSOE_T fsoe_conf = {
     .data_channels = 1,
 };
 
-static int lcec_el1904_preinit(struct lcec_slave *slave) {
+static int lcec_el1904_preinit(lcec_slave_t *slave) {
   // set fsoe config
   slave->fsoeConf = &fsoe_conf;
 
   return 0;
 }
 
-static int lcec_el1904_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el1904_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el1904_data_t *hal_data;
   int i, err;
@@ -132,7 +132,7 @@ static int lcec_el1904_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el1904_read(struct lcec_slave *slave, long period) {
+static void lcec_el1904_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el1904_data_t *hal_data = (lcec_el1904_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el1918_logic.c
+++ b/src/devices/lcec_el1918_logic.c
@@ -23,10 +23,10 @@
 
 #include "../lcec.h"
 
-static void lcec_el1918_logic_read(struct lcec_slave *slave, long period);
-static void lcec_el1918_logic_write(struct lcec_slave *slave, long period);
-static int lcec_el1918_logic_preinit(struct lcec_slave *slave);
-static int lcec_el1918_logic_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el1918_logic_read(lcec_slave_t *slave, long period);
+static void lcec_el1918_logic_write(lcec_slave_t *slave, long period);
+static int lcec_el1918_logic_preinit(lcec_slave_t *slave);
+static int lcec_el1918_logic_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_el1918_logic_modparams[] = {
     {"fsoeSlaveIdx", LCEC_EL1918_LOGIC_PARAM_SLAVEID, MODPARAM_TYPE_U32},
@@ -49,7 +49,7 @@ typedef struct {
 } lcec_el1918_logic_fsoe_crc_t;
 
 typedef struct {
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
 
   hal_u32_t *fsoe_master_cmd;
   hal_u32_t *fsoe_master_connid;
@@ -107,7 +107,7 @@ static const lcec_pindesc_t fsoe_crc_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int export_std_pins(struct lcec_slave *slave, int pid, hal_bit_t **pin, hal_pin_dir_t dir) {
+static int export_std_pins(lcec_slave_t *slave, int pid, hal_bit_t **pin, hal_pin_dir_t dir) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   int count, err;
@@ -131,11 +131,11 @@ static int export_std_pins(struct lcec_slave *slave, int pid, hal_bit_t **pin, h
   return count;
 }
 
-static int lcec_el1918_logic_preinit(struct lcec_slave *slave) {
+static int lcec_el1918_logic_preinit(lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   int index, stdin_count, stdout_count;
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
   stdin_count = 0;
@@ -182,14 +182,14 @@ static int lcec_el1918_logic_preinit(struct lcec_slave *slave) {
   return 0;
 }
 
-int lcec_el1918_logic_init(int comp_id, struct lcec_slave *slave) {
+int lcec_el1918_logic_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el1918_logic_data_t *hal_data;
   lcec_el1918_logic_fsoe_t *fsoe_data;
   lcec_slave_modparam_t *p;
   int fsoe_idx, index, err;
   lcec_el1918_logic_fsoe_crc_t *crc;
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
   // initialize callbacks
@@ -284,7 +284,7 @@ int lcec_el1918_logic_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-void lcec_el1918_logic_read(struct lcec_slave *slave, long period) {
+void lcec_el1918_logic_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el1918_logic_data_t *hal_data = (lcec_el1918_logic_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -292,7 +292,7 @@ void lcec_el1918_logic_read(struct lcec_slave *slave, long period) {
   int i, crc_idx;
   uint8_t std_out;
   lcec_el1918_logic_fsoe_crc_t *crc;
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
   *(hal_data->state) = EC_READ_U8(&pd[hal_data->state_os]);
@@ -319,7 +319,7 @@ void lcec_el1918_logic_read(struct lcec_slave *slave, long period) {
   }
 }
 
-void lcec_el1918_logic_write(struct lcec_slave *slave, long period) {
+void lcec_el1918_logic_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el1918_logic_data_t *hal_data = (lcec_el1918_logic_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el1xxx.c
+++ b/src/devices/lcec_el1xxx.c
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 #include "lcec_class_din.h"
 
-static int lcec_el1xxx_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el1xxx_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL1002", LCEC_BECKHOFF_VID, 0x03EA3052, 0, NULL, lcec_el1xxx_init, NULL, 2},
@@ -54,9 +54,9 @@ static lcec_typelist_t types[] = {
 
 ADD_TYPES(types)
 
-static void lcec_el1xxx_read(struct lcec_slave *slave, long period);
+static void lcec_el1xxx_read(lcec_slave_t *slave, long period);
 
-static int lcec_el1xxx_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el1xxx_init(int comp_id, lcec_slave_t *slave) {
   lcec_class_din_channels_t *hal_data;
   int i;
 
@@ -81,7 +81,7 @@ static int lcec_el1xxx_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el1xxx_read(struct lcec_slave *slave, long period) {
+static void lcec_el1xxx_read(lcec_slave_t *slave, long period) {
   lcec_class_din_channels_t *hal_data = (lcec_class_din_channels_t *)slave->hal_data;
 
   // wait for slave to be operational

--- a/src/devices/lcec_el2202.c
+++ b/src/devices/lcec_el2202.c
@@ -28,7 +28,7 @@
 #include "../lcec.h"
 #define LCEC_EL2202_CHANS 2
 
-static int lcec_el2202_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el2202_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL2202", LCEC_BECKHOFF_VID, 0x089A3052, 0, NULL, lcec_el2202_init},  // 2 fast channels with tristate
@@ -87,9 +87,9 @@ static const lcec_pindesc_t slave_pins[] = {
 };
 
 /** \brief callback for periodic IO data access*/
-static void lcec_el2202_write(struct lcec_slave *slave, long period);
+static void lcec_el2202_write(lcec_slave_t *slave, long period);
 
-static int lcec_el2202_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el2202_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
 
   lcec_el2202_data_t *hal_data;
@@ -129,7 +129,7 @@ static int lcec_el2202_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el2202_write(struct lcec_slave *slave, long period) {
+static void lcec_el2202_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
 

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -30,7 +30,7 @@
 // - travel distance control active (8000:0A) must be FALSE (0x00, default)
 // ****************************************************************************
 
-static int lcec_el2521_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el2521_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL2521", LCEC_BECKHOFF_VID, 0x09d93052, 0, NULL, lcec_el2521_init},
@@ -131,10 +131,10 @@ static ec_sync_info_t lcec_el2521_syncs[] = {
 };
 
 static void lcec_el2521_check_scale(lcec_el2521_data_t *hal_data);
-static void lcec_el2521_read(struct lcec_slave *slave, long period);
-static void lcec_el2521_write(struct lcec_slave *slave, long period);
+static void lcec_el2521_read(lcec_slave_t *slave, long period);
+static void lcec_el2521_write(lcec_slave_t *slave, long period);
 
-static int lcec_el2521_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el2521_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el2521_data_t *hal_data;
   int err;
@@ -244,7 +244,7 @@ static void lcec_el2521_check_scale(lcec_el2521_data_t *hal_data) {
   }
 }
 
-static void lcec_el2521_read(struct lcec_slave *slave, long period) {
+static void lcec_el2521_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el2521_data_t *hal_data = (lcec_el2521_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -293,7 +293,7 @@ static void lcec_el2521_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_el2521_write(struct lcec_slave *slave, long period) {
+static void lcec_el2521_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el2521_data_t *hal_data = (lcec_el2521_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el2904.c
+++ b/src/devices/lcec_el2904.c
@@ -21,10 +21,10 @@
 
 #include "../lcec.h"
 
-static void lcec_el2904_read(struct lcec_slave *slave, long period);
-static void lcec_el2904_write(struct lcec_slave *slave, long period);
-static int lcec_el2904_preinit(struct lcec_slave *slave);
-static int lcec_el2904_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el2904_read(lcec_slave_t *slave, long period);
+static void lcec_el2904_write(lcec_slave_t *slave, long period);
+static int lcec_el2904_preinit(lcec_slave_t *slave);
+static int lcec_el2904_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL2904", LCEC_BECKHOFF_VID, 0x0B583052, 0, lcec_el2904_preinit, lcec_el2904_init},
@@ -96,14 +96,14 @@ static const lcec_pindesc_t slave_pins[] = {{HAL_U32, HAL_OUT, offsetof(lcec_el2
 
 static const LCEC_CONF_FSOE_T fsoe_conf = {.slave_data_len = 1, .master_data_len = 1, .data_channels = 1};
 
-static int lcec_el2904_preinit(struct lcec_slave *slave) {
+static int lcec_el2904_preinit(lcec_slave_t *slave) {
   // set fsoe config
   slave->fsoeConf = &fsoe_conf;
 
   return 0;
 }
 
-static int lcec_el2904_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el2904_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el2904_data_t *hal_data;
   int err;
@@ -144,7 +144,7 @@ static int lcec_el2904_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el2904_read(struct lcec_slave *slave, long period) {
+static void lcec_el2904_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el2904_data_t *hal_data = (lcec_el2904_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -165,7 +165,7 @@ static void lcec_el2904_read(struct lcec_slave *slave, long period) {
   *(hal_data->fsoe_out_3) = EC_READ_BIT(&pd[hal_data->fsoe_out_3_os], hal_data->fsoe_out_3_bp);
 }
 
-static void lcec_el2904_write(struct lcec_slave *slave, long period) {
+static void lcec_el2904_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el2904_data_t *hal_data = (lcec_el2904_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el2xxx.c
+++ b/src/devices/lcec_el2xxx.c
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 #include "lcec_class_dout.h"
 
-static int lcec_el2xxx_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el2xxx_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL2002", LCEC_BECKHOFF_VID, 0x07D23052, 0, NULL, lcec_el2xxx_init, NULL, 2},
@@ -50,9 +50,9 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES(types);
 
-static void lcec_el2xxx_write(struct lcec_slave *slave, long period);
+static void lcec_el2xxx_write(lcec_slave_t *slave, long period);
 
-static int lcec_el2xxx_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el2xxx_init(int comp_id, lcec_slave_t *slave) {
   lcec_class_dout_channels_t *hal_data;
   int i;
 
@@ -73,7 +73,7 @@ static int lcec_el2xxx_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el2xxx_write(struct lcec_slave *slave, long period) {
+static void lcec_el2xxx_write(lcec_slave_t *slave, long period) {
   lcec_class_dout_channels_t *hal_data = (lcec_class_dout_channels_t *)slave->hal_data;
 
   if (!slave->state.operational) {

--- a/src/devices/lcec_el31x2.c
+++ b/src/devices/lcec_el31x2.c
@@ -23,7 +23,7 @@
 
 #define LCEC_EL31x2_CHANS 2
 
-static int lcec_el31x2_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el31x2_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL3102", LCEC_BECKHOFF_VID, 0x0C1E3052, 0, NULL, lcec_el31x2_init},
@@ -86,9 +86,9 @@ static ec_sync_info_t lcec_el31x2_syncs[] = {
     {0xff},
 };
 
-static void lcec_el31x2_read(struct lcec_slave *slave, long period);
+static void lcec_el31x2_read(lcec_slave_t *slave, long period);
 
-static int lcec_el31x2_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el31x2_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el31x2_data_t *hal_data;
   lcec_el31x2_chan_t *chan;
@@ -129,7 +129,7 @@ static int lcec_el31x2_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el31x2_read(struct lcec_slave *slave, long period) {
+static void lcec_el31x2_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el31x2_data_t *hal_data = (lcec_el31x2_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el3255.c
+++ b/src/devices/lcec_el3255.c
@@ -23,7 +23,7 @@
 
 #define LCEC_EL3255_CHANS 5
 
-static int lcec_el3255_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el3255_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL3255", LCEC_BECKHOFF_VID, 0x0CB73052, 0, NULL, lcec_el3255_init},
@@ -143,9 +143,9 @@ static ec_pdo_info_t lcec_el3255_pdos_in[] = {{0x1A00, 11, lcec_el3255_channel1}
 static ec_sync_info_t lcec_el3255_syncs[] = {{0, EC_DIR_OUTPUT, 0, NULL}, {1, EC_DIR_INPUT, 0, NULL}, {2, EC_DIR_OUTPUT, 0, NULL},
     {3, EC_DIR_INPUT, 5, lcec_el3255_pdos_in}, {0xff}};
 
-static void lcec_el3255_read(struct lcec_slave *slave, long period);
+static void lcec_el3255_read(lcec_slave_t *slave, long period);
 
-static int lcec_el3255_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el3255_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el3255_data_t *hal_data;
   lcec_el3255_chan_t *chan;
@@ -189,7 +189,7 @@ static int lcec_el3255_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el3255_read(struct lcec_slave *slave, long period) {
+static void lcec_el3255_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el3255_data_t *hal_data = (lcec_el3255_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el3403.c
+++ b/src/devices/lcec_el3403.c
@@ -24,7 +24,7 @@
 
 #define LCEC_EL3403_CHANS 3
 
-static int lcec_el3403_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el3403_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     // analog in, 3ch, 16 bits
@@ -193,9 +193,9 @@ ec_sync_info_t lcec_el3403_syncs[] = {
     {0xff},
 };
 
-static void lcec_el3403_read(struct lcec_slave *slave, long period);
+static void lcec_el3403_read(lcec_slave_t *slave, long period);
 
-static int lcec_el3403_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el3403_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el3403_data_t *hal_data;
   lcec_el3403_chan_t *chan;
@@ -268,7 +268,7 @@ static int lcec_el3403_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el3403_read(struct lcec_slave *slave, long period) {
+static void lcec_el3403_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el3403_data_t *hal_data = (lcec_el3403_data_t *)slave->hal_data;
   lcec_el3403_chan_t *chan;

--- a/src/devices/lcec_el3xxx.c
+++ b/src/devices/lcec_el3xxx.c
@@ -38,7 +38,7 @@
 
 #define LCEC_EL3XXX_MAXCHANS 8  // for sizing arrays
 
-static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el3xxx_init(int comp_id, lcec_slave_t *slave);
 
 /// @brief Modparams settings available via XML.
 static const lcec_modparam_desc_t modparams_temperature[] = {
@@ -213,13 +213,13 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES(types)
 
-static void lcec_el3xxx_read(struct lcec_slave *slave, long period);
+static void lcec_el3xxx_read(lcec_slave_t *slave, long period);
 static int set_sensor_type(lcec_slave_t *slave, char *sensortype, lcec_class_ain_channel_t *chan, int idx, int sidx);
 static int set_resolution(lcec_slave_t *slave, char *resolution_name, lcec_class_ain_channel_t *chan, int idx, int sidx);
 static int set_wires(lcec_slave_t *slave, char *wires_name, lcec_class_ain_channel_t *chan, int idx, int sidx);
 
 /// @brief Initialize an EL3xxx device.
-static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el3xxx_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_class_ain_channels_t *hal_data;
   uint64_t flags;
@@ -284,7 +284,7 @@ static int lcec_el3xxx_init(int comp_id, struct lcec_slave *slave) {
 }
 
 /// @brief Read values from the device.
-static void lcec_el3xxx_read(struct lcec_slave *slave, long period) {
+static void lcec_el3xxx_read(lcec_slave_t *slave, long period) {
   lcec_class_ain_channels_t *hal_data = (lcec_class_ain_channels_t *)slave->hal_data;
 
   // wait for slave to be operational

--- a/src/devices/lcec_el4xxx.c
+++ b/src/devices/lcec_el4xxx.c
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 #include "lcec_class_aout.h"
 
-static int lcec_el4xxx_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el4xxx_init(int comp_id, lcec_slave_t *slave);
 
 /// Flags for describing devices
 #define F_S11         1 << 8  ///< Uses subindex 11 instead of sub-index 1 for ports.
@@ -78,9 +78,9 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES(types);
 
-static void lcec_el4xxx_write(struct lcec_slave *slave, long period);
+static void lcec_el4xxx_write(lcec_slave_t *slave, long period);
 
-static int lcec_el4xxx_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el4xxx_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_class_aout_channels_t *hal_data;
   int i;
@@ -107,7 +107,7 @@ static int lcec_el4xxx_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el4xxx_write(struct lcec_slave *slave, long period) {
+static void lcec_el4xxx_write(lcec_slave_t *slave, long period) {
   lcec_class_aout_channels_t *hal_data = (lcec_class_aout_channels_t *)slave->hal_data;
 
   // wait for slave to be operational

--- a/src/devices/lcec_el5002.c
+++ b/src/devices/lcec_el5002.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_el5002_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el5002_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_el5002_modparams[] = {
     {"ch0DisFrameErr", LCEC_EL5002_PARAM_CH_0 || LCEC_EL5002_PARAM_DIS_FRAME_ERR, MODPARAM_TYPE_BIT},
@@ -150,9 +150,9 @@ static ec_sync_info_t lcec_el5002_syncs[] = {
     {0xff},
 };
 
-static void lcec_el5002_read(struct lcec_slave *slave, long period);
+static void lcec_el5002_read(lcec_slave_t *slave, long period);
 
-static int lcec_el5002_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el5002_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   lcec_el5002_data_t *hal_data;
@@ -282,7 +282,7 @@ static int lcec_el5002_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el5002_read(struct lcec_slave *slave, long period) {
+static void lcec_el5002_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5002_data_t *hal_data = (lcec_el5002_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el5032.c
+++ b/src/devices/lcec_el5032.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_el5032_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el5032_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL5032", LCEC_BECKHOFF_VID, 0x13a83052, 0, NULL, lcec_el5032_init},
@@ -125,9 +125,9 @@ static ec_sync_info_t lcec_el5032_syncs[] = {
     {0xff},
 };
 
-static void lcec_el5032_read(struct lcec_slave *slave, long period);
+static void lcec_el5032_read(lcec_slave_t *slave, long period);
 
-static int lcec_el5032_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el5032_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el5032_data_t *hal_data;
   int i;
@@ -182,7 +182,7 @@ static int lcec_el5032_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el5032_read(struct lcec_slave *slave, long period) {
+static void lcec_el5032_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5032_data_t *hal_data = (lcec_el5032_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el5101.c
+++ b/src/devices/lcec_el5101.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_el5101_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el5101_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL5101", LCEC_BECKHOFF_VID, 0x13ed3052, 0, NULL, lcec_el5101_init},
@@ -142,10 +142,10 @@ static ec_sync_info_t lcec_el5101_syncs[] = {
     {0xff},
 };
 
-static void lcec_el5101_read(struct lcec_slave *slave, long period);
-static void lcec_el5101_write(struct lcec_slave *slave, long period);
+static void lcec_el5101_read(lcec_slave_t *slave, long period);
+static void lcec_el5101_write(lcec_slave_t *slave, long period);
 
-static int lcec_el5101_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el5101_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el5101_data_t *hal_data;
   int err;
@@ -195,7 +195,7 @@ static int lcec_el5101_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el5101_read(struct lcec_slave *slave, long period) {
+static void lcec_el5101_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5101_data_t *hal_data = (lcec_el5101_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -294,7 +294,7 @@ static void lcec_el5101_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_el5101_write(struct lcec_slave *slave, long period) {
+static void lcec_el5101_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5101_data_t *hal_data = (lcec_el5101_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el5102.c
+++ b/src/devices/lcec_el5102.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_el5102_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el5102_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL5102", LCEC_BECKHOFF_VID, 0x13ee3052, 0, NULL, lcec_el5102_init},
@@ -127,12 +127,12 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static void lcec_el5102_read(struct lcec_slave *slave, long period);
-static void lcec_el5102_read_channel(struct lcec_slave *slave, long period, int channel);
-static void lcec_el5102_write(struct lcec_slave *slave, long period);
-static void lcec_el5102_write_channel(struct lcec_slave *slave, long period, int channel);
+static void lcec_el5102_read(lcec_slave_t *slave, long period);
+static void lcec_el5102_read_channel(lcec_slave_t *slave, long period, int channel);
+static void lcec_el5102_write(lcec_slave_t *slave, long period);
+static void lcec_el5102_write_channel(lcec_slave_t *slave, long period, int channel);
 
-static int lcec_el5102_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el5102_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el5102_data_t *hal_data;
   int err;
@@ -210,12 +210,12 @@ static int lcec_el5102_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el5102_read(struct lcec_slave *slave, long period) {
+static void lcec_el5102_read(lcec_slave_t *slave, long period) {
   lcec_el5102_read_channel(slave, period, 0);
   lcec_el5102_read_channel(slave, period, 1);
 }
 
-static void lcec_el5102_read_channel(struct lcec_slave *slave, long period, int channel) {
+static void lcec_el5102_read_channel(lcec_slave_t *slave, long period, int channel) {
   lcec_master_t *master = slave->master;
   lcec_el5102_channel_data_t *data = &((lcec_el5102_data_t *)slave->hal_data)->channel[channel];
   uint8_t *pd = master->process_data;
@@ -312,12 +312,12 @@ static void lcec_el5102_read_channel(struct lcec_slave *slave, long period, int 
   data->last_operational = 1;
 }
 
-static void lcec_el5102_write(struct lcec_slave *slave, long period) {
+static void lcec_el5102_write(lcec_slave_t *slave, long period) {
   lcec_el5102_write_channel(slave, period, 0);
   lcec_el5102_write_channel(slave, period, 1);
 }
 
-static void lcec_el5102_write_channel(struct lcec_slave *slave, long period, int channel) {
+static void lcec_el5102_write_channel(lcec_slave_t *slave, long period, int channel) {
   lcec_master_t *master = slave->master;
   lcec_el5102_channel_data_t *data = &((lcec_el5102_data_t *)slave->hal_data)->channel[channel];
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el5151.c
+++ b/src/devices/lcec_el5151.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_el5151_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el5151_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL5151", LCEC_BECKHOFF_VID, 0x141f3052, 0, NULL, lcec_el5151_init},
@@ -171,10 +171,10 @@ static ec_sync_info_t lcec_el5151_syncs[] = {
     {0xff},
 };
 
-static void lcec_el5151_read(struct lcec_slave *slave, long period);
-static void lcec_el5151_write(struct lcec_slave *slave, long period);
+static void lcec_el5151_read(lcec_slave_t *slave, long period);
+static void lcec_el5151_write(lcec_slave_t *slave, long period);
 
-static int lcec_el5151_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el5151_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el5151_data_t *hal_data;
   int err;
@@ -234,7 +234,7 @@ static int lcec_el5151_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el5151_read(struct lcec_slave *slave, long period) {
+static void lcec_el5151_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5151_data_t *hal_data = (lcec_el5151_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -329,7 +329,7 @@ static void lcec_el5151_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_el5151_write(struct lcec_slave *slave, long period) {
+static void lcec_el5151_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5151_data_t *hal_data = (lcec_el5151_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el5152.c
+++ b/src/devices/lcec_el5152.c
@@ -23,7 +23,7 @@
 
 #include "../lcec.h"
 
-static int lcec_el5152_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el5152_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL5152", LCEC_BECKHOFF_VID, 0x14203052, 0, NULL, lcec_el5152_init},
@@ -159,10 +159,10 @@ static ec_pdo_info_t lcec_el5152_pdos_in[] = {{0x1A00, 11, lcec_el5152_channel1_
 static ec_sync_info_t lcec_el5152_syncs[] = {{0, EC_DIR_OUTPUT, 0, NULL}, {1, EC_DIR_INPUT, 0, NULL},
     {2, EC_DIR_OUTPUT, 2, lcec_el5152_pdos_out}, {3, EC_DIR_INPUT, 4, lcec_el5152_pdos_in}, {0xff}};
 
-static void lcec_el5152_read(struct lcec_slave *slave, long period);
-static void lcec_el5152_write(struct lcec_slave *slave, long period);
+static void lcec_el5152_read(lcec_slave_t *slave, long period);
+static void lcec_el5152_write(lcec_slave_t *slave, long period);
 
-static int lcec_el5152_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el5152_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el5152_data_t *hal_data;
   int i;
@@ -221,7 +221,7 @@ static int lcec_el5152_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el5152_read(struct lcec_slave *slave, long period) {
+static void lcec_el5152_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5152_data_t *hal_data = (lcec_el5152_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -319,7 +319,7 @@ static void lcec_el5152_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_el5152_write(struct lcec_slave *slave, long period) {
+static void lcec_el5152_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el5152_data_t *hal_data = (lcec_el5152_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el6090.c
+++ b/src/devices/lcec_el6090.c
@@ -24,9 +24,9 @@
 
 #include "../lcec.h"
 
-static void lcec_el6090_read(struct lcec_slave *slave, long period);
-static void lcec_el6090_write(struct lcec_slave *slave, long period);
-static int lcec_el6090_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el6090_read(lcec_slave_t *slave, long period);
+static void lcec_el6090_write(lcec_slave_t *slave, long period);
+static int lcec_el6090_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL6090", LCEC_BECKHOFF_VID, 0x17ca3052, 0, NULL, lcec_el6090_init},
@@ -249,7 +249,7 @@ static ec_sync_info_t lcec_el6090_syncs[] = {
     {0xff},
 };
 
-static int lcec_el6090_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el6090_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el6090_data_t *hal_data;
   lcec_el6090_chan_t *chan;
@@ -343,7 +343,7 @@ static int lcec_el6090_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el6090_read(struct lcec_slave *slave, long period) {
+static void lcec_el6090_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el6090_data_t *hal_data = (lcec_el6090_data_t *)slave->hal_data;
   lcec_el6090_chan_t *chan;
@@ -383,7 +383,7 @@ static void lcec_el6090_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_el6090_write(struct lcec_slave *slave, long period) {
+static void lcec_el6090_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el6090_data_t *hal_data = (lcec_el6090_data_t *)slave->hal_data;
   lcec_el6090_chan_t *chan;

--- a/src/devices/lcec_el6900.c
+++ b/src/devices/lcec_el6900.c
@@ -23,10 +23,10 @@
 
 #include "../lcec.h"
 
-static void lcec_el6900_read(struct lcec_slave *slave, long period);
-static void lcec_el6900_write(struct lcec_slave *slave, long period);
-static int lcec_el6900_preinit(struct lcec_slave *slave);
-static int lcec_el6900_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el6900_read(lcec_slave_t *slave, long period);
+static void lcec_el6900_write(lcec_slave_t *slave, long period);
+static int lcec_el6900_preinit(lcec_slave_t *slave);
+static int lcec_el6900_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_el6900_modparams[] = {
     {"fsoeSlaveIdx", LCEC_EL6900_PARAM_SLAVEID, MODPARAM_TYPE_U32},
@@ -57,7 +57,7 @@ typedef struct {
 } lcec_el6900_fsoe_crc_t;
 
 typedef struct {
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
 
   hal_u32_t *fsoe_master_cmd;
   hal_u32_t *fsoe_master_connid;
@@ -125,7 +125,7 @@ static const lcec_pindesc_t fsoe_crc_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int init_std_pdos(struct lcec_slave *slave, int pid, lcec_el6900_fsoe_io_t *io, int index, hal_pin_dir_t dir) {
+static int init_std_pdos(lcec_slave_t *slave, int pid, lcec_el6900_fsoe_io_t *io, int index, hal_pin_dir_t dir) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   int count, err;
@@ -153,11 +153,11 @@ static int init_std_pdos(struct lcec_slave *slave, int pid, lcec_el6900_fsoe_io_
   return count;
 }
 
-static int lcec_el6900_preinit(struct lcec_slave *slave) {
+static int lcec_el6900_preinit(lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   int index, stdin_count, stdout_count;
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
   stdin_count = 0;
@@ -204,14 +204,14 @@ static int lcec_el6900_preinit(struct lcec_slave *slave) {
   return 0;
 }
 
-static int lcec_el6900_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el6900_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el6900_data_t *hal_data;
   lcec_el6900_fsoe_t *fsoe_data;
   lcec_slave_modparam_t *p;
   int fsoe_idx, index, err;
   lcec_el6900_fsoe_crc_t *crc;
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
   // initialize callbacks
@@ -302,7 +302,7 @@ static int lcec_el6900_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-void lcec_el6900_read(struct lcec_slave *slave, long period) {
+void lcec_el6900_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el6900_data_t *hal_data = (lcec_el6900_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -310,7 +310,7 @@ void lcec_el6900_read(struct lcec_slave *slave, long period) {
   int i, crc_idx;
   lcec_el6900_fsoe_io_t *io;
   lcec_el6900_fsoe_crc_t *crc;
-  struct lcec_slave *fsoe_slave;
+  lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
   *(hal_data->state) = EC_READ_U8(&pd[hal_data->state_os]) & 0x03;
@@ -336,7 +336,7 @@ void lcec_el6900_read(struct lcec_slave *slave, long period) {
   }
 }
 
-void lcec_el6900_write(struct lcec_slave *slave, long period) {
+void lcec_el6900_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el6900_data_t *hal_data = (lcec_el6900_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el7041.c
+++ b/src/devices/lcec_el7041.c
@@ -22,9 +22,9 @@
 
 #include "../lcec.h"
 
-static int lcec_el7041_init(int comp_id, struct lcec_slave *s);
-static void lcec_el7041_read(struct lcec_slave *s, long period);
-static void lcec_el7041_write(struct lcec_slave *s, long period);
+static int lcec_el7041_init(int comp_id, lcec_slave_t *s);
+static void lcec_el7041_read(lcec_slave_t *s, long period);
+static void lcec_el7041_write(lcec_slave_t *s, long period);
 
 #define MODPARAM_MAX_CURRENT        1
 #define MODPARAM_REDUCED_CURRENT    2
@@ -346,7 +346,7 @@ static ec_sync_info_t lcec_el7041_syncs[] = {
     {0xff},
 };
 
-static int handle_modparams(struct lcec_slave *slave) {
+static int handle_modparams(lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
 
@@ -492,7 +492,7 @@ static int handle_modparams(struct lcec_slave *slave) {
   return 0;
 }
 
-static int lcec_el7041_init(int comp_id, struct lcec_slave *s) {
+static int lcec_el7041_init(int comp_id, lcec_slave_t *s) {
   lcec_master_t *m = s->master;
   lcec_el7041_data_t *hd;
   int err;
@@ -592,7 +592,7 @@ static int lcec_el7041_init(int comp_id, struct lcec_slave *s) {
   return 0;
 }
 
-static void lcec_el7041_read(struct lcec_slave *s, long period) {
+static void lcec_el7041_read(lcec_slave_t *s, long period) {
   lcec_master_t *m = s->master;
   lcec_el7041_data_t *hd = (lcec_el7041_data_t *)s->hal_data;
   uint8_t *pd = m->process_data;
@@ -714,7 +714,7 @@ static void lcec_el7041_read(struct lcec_slave *s, long period) {
   hd->last_operational = 1;
 }
 
-static void lcec_el7041_write(struct lcec_slave *s, long period) {
+static void lcec_el7041_write(lcec_slave_t *s, long period) {
   lcec_master_t *m = s->master;
   lcec_el7041_data_t *hd = (lcec_el7041_data_t *)s->hal_data;
   uint8_t *pd = m->process_data;

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -23,11 +23,11 @@
 
 #include "../lcec.h"
 
-static int lcec_el70x1_init(int comp_id, struct lcec_slave *slave);
-static int lcec_el7031_init(int comp_id, struct lcec_slave *slave);
-static int lcec_el7041_0052_init(int comp_id, struct lcec_slave *slave);
-static void lcec_el70x1_read(struct lcec_slave *slave, long period);
-static void lcec_el70x1_write(struct lcec_slave *slave, long period);
+static int lcec_el70x1_init(int comp_id, lcec_slave_t *slave);
+static int lcec_el7031_init(int comp_id, lcec_slave_t *slave);
+static int lcec_el7041_0052_init(int comp_id, lcec_slave_t *slave);
+static void lcec_el70x1_read(lcec_slave_t *slave, long period);
+static void lcec_el70x1_write(lcec_slave_t *slave, long period);
 
 static lcec_modparam_desc_t lcec_el70x1_modparams[] = {
     {"maxCurrent", LCEC_EL70x1_PARAM_MAX_CURR, MODPARAM_TYPE_U32},
@@ -253,21 +253,21 @@ static const lcec_pindesc_t slave_params[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int lcec_el7031_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el7031_init(int comp_id, lcec_slave_t *slave) {
   // initialize sync info
   slave->sync_info = lcec_el70x1_syncs;
 
   return lcec_el70x1_init(comp_id, slave);
 }
 
-static int lcec_el7041_0052_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el7041_0052_init(int comp_id, lcec_slave_t *slave) {
   // initialize sync info
   slave->sync_info = lcec_el7041_0052_syncs;
 
   return lcec_el70x1_init(comp_id, slave);
 }
 
-static int lcec_el70x1_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el70x1_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   lcec_el70x1_data_t *hal_data;
@@ -366,7 +366,7 @@ static int lcec_el70x1_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el70x1_read(struct lcec_slave *slave, long period) {
+static void lcec_el70x1_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el70x1_data_t *hal_data = (lcec_el70x1_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -384,7 +384,7 @@ static void lcec_el70x1_read(struct lcec_slave *slave, long period) {
   *(hal_data->stm_tx_toggle) = EC_READ_BIT(&pd[hal_data->stm_tx_toggle_pdo_os], hal_data->stm_tx_toggle_pdo_bp);
 }
 
-static void lcec_el70x1_write(struct lcec_slave *slave, long period) {
+static void lcec_el70x1_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el70x1_data_t *hal_data = (lcec_el70x1_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -27,8 +27,8 @@
 
 #define FAULT_RESET_PERIOD_NS 100000000
 
-/*static*/ int lcec_el7211_init(int comp_id, struct lcec_slave *slave);
-static int lcec_el7201_9014_init(int comp_id, struct lcec_slave *slave);
+/*static*/ int lcec_el7211_init(int comp_id, lcec_slave_t *slave);
+static int lcec_el7201_9014_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL7201_9014", LCEC_BECKHOFF_VID, 0x1C213052, 0, NULL, lcec_el7201_9014_init},
@@ -199,14 +199,14 @@ static ec_sync_info_t lcec_el7201_9014_syncs[] = {
     {0xff},
 };
 
-static lcec_el7211_data_t *lcec_el7211_alloc_hal(lcec_master_t *master, struct lcec_slave *slave);
-static int lcec_el7211_export_pins(lcec_master_t *master, struct lcec_slave *slave, lcec_el7211_data_t *hal_data);
+static lcec_el7211_data_t *lcec_el7211_alloc_hal(lcec_master_t *master, lcec_slave_t *slave);
+static int lcec_el7211_export_pins(lcec_master_t *master, lcec_slave_t *slave, lcec_el7211_data_t *hal_data);
 static void lcec_el7211_check_scales(lcec_el7211_data_t *hal_data);
-static void lcec_el7211_read(struct lcec_slave *slave, long period);
-static void lcec_el7201_9014_read(struct lcec_slave *slave, long period);
-static void lcec_el7211_write(struct lcec_slave *slave, long period);
+static void lcec_el7211_read(lcec_slave_t *slave, long period);
+static void lcec_el7201_9014_read(lcec_slave_t *slave, long period);
+static void lcec_el7211_write(lcec_slave_t *slave, long period);
 
-static lcec_el7211_data_t *lcec_el7211_alloc_hal(lcec_master_t *master, struct lcec_slave *slave) {
+static lcec_el7211_data_t *lcec_el7211_alloc_hal(lcec_master_t *master, lcec_slave_t *slave) {
   lcec_el7211_data_t *hal_data;
 
   // alloc hal memory
@@ -219,7 +219,7 @@ static lcec_el7211_data_t *lcec_el7211_alloc_hal(lcec_master_t *master, struct l
   return hal_data;
 }
 
-static int lcec_el7211_export_pins(lcec_master_t *master, struct lcec_slave *slave, lcec_el7211_data_t *hal_data) {
+static int lcec_el7211_export_pins(lcec_master_t *master, lcec_slave_t *slave, lcec_el7211_data_t *hal_data) {
   int err;
   uint8_t sdo_buf[4];
   uint32_t sdo_vel_resolution;
@@ -275,7 +275,7 @@ static int lcec_el7211_export_pins(lcec_master_t *master, struct lcec_slave *sla
 }
 
 // TODO: lcec_el7411_init calls this.  Fix?
-/*static*/ int lcec_el7211_init(int comp_id, struct lcec_slave *slave) {
+/*static*/ int lcec_el7211_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el7211_data_t *hal_data;
   int err;
@@ -307,7 +307,7 @@ static int lcec_el7211_export_pins(lcec_master_t *master, struct lcec_slave *sla
   return 0;
 }
 
-static int lcec_el7201_9014_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el7201_9014_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el7211_data_t *hal_data;
   int err;
@@ -373,7 +373,7 @@ static void lcec_el7211_check_scales(lcec_el7211_data_t *hal_data) {
   }
 }
 
-static void lcec_el7211_read(struct lcec_slave *slave, long period) {
+static void lcec_el7211_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el7211_data_t *hal_data = (lcec_el7211_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -438,7 +438,7 @@ static void lcec_el7211_read(struct lcec_slave *slave, long period) {
   class_enc_update(&hal_data->enc, hal_data->pos_resolution, hal_data->scale_rcpt, pos_cnt, 0, 0);
 }
 
-static void lcec_el7201_9014_read(struct lcec_slave *slave, long period) {
+static void lcec_el7201_9014_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el7211_data_t *hal_data = (lcec_el7211_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -461,7 +461,7 @@ static inline double clamp(double v, double sub, double sup) {
   return v;
 }
 
-static void lcec_el7211_write(struct lcec_slave *slave, long period) {
+static void lcec_el7211_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el7211_data_t *hal_data = (lcec_el7211_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el7342.c
+++ b/src/devices/lcec_el7342.c
@@ -37,9 +37,9 @@
 #define INFO_SEL_DCM_SWORD     150
 #define INFO_SEL_DCM_STATE     151
 
-static void lcec_el7342_read(struct lcec_slave *slave, long period);
-static void lcec_el7342_write(struct lcec_slave *slave, long period);
-static int lcec_el7342_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el7342_read(lcec_slave_t *slave, long period);
+static void lcec_el7342_write(lcec_slave_t *slave, long period);
+static int lcec_el7342_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EL7342", LCEC_BECKHOFF_VID, 0x1cae3052, 0, NULL, lcec_el7342_init},
@@ -382,7 +382,7 @@ static ec_sync_info_t lcec_el7342_syncs[] = {
 
 static void lcec_el7342_set_info(lcec_el7342_chan_t *chan, hal_s32_t *raw_info, hal_u32_t *sel_info);
 
-static int lcec_el7342_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el7342_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el7342_data_t *hal_data;
   int i;
@@ -497,7 +497,7 @@ static int lcec_el7342_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el7342_read(struct lcec_slave *slave, long period) {
+static void lcec_el7342_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el7342_data_t *hal_data = (lcec_el7342_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -607,7 +607,7 @@ static void lcec_el7342_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_el7342_write(struct lcec_slave *slave, long period) {
+static void lcec_el7342_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el7342_data_t *hal_data = (lcec_el7342_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_el7411.c
+++ b/src/devices/lcec_el7411.c
@@ -24,7 +24,7 @@
 #include "../lcec.h"
 #include "hal.h"
 
-static int lcec_el7411_init(int comp_id, struct lcec_slave *slave);
+static int lcec_el7411_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_el7411_modparams[] = {
     {"dcLinkNominal", LCEC_EL7411_PARAM_DCLINK_NOM, MODPARAM_TYPE_U32},
@@ -53,7 +53,7 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES(types);
 
-static int lcec_el7411_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el7411_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
 

--- a/src/devices/lcec_el95xx.c
+++ b/src/devices/lcec_el95xx.c
@@ -21,8 +21,8 @@
 
 #include "../lcec.h"
 
-static void lcec_el95xx_read(struct lcec_slave *slave, long period);
-static int lcec_el95xx_init(int comp_id, struct lcec_slave *slave);
+static void lcec_el95xx_read(lcec_slave_t *slave, long period);
+static int lcec_el95xx_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     // power supply
@@ -51,7 +51,7 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int lcec_el95xx_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_el95xx_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el95xx_data_t *hal_data;
   int err;
@@ -79,7 +79,7 @@ static int lcec_el95xx_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_el95xx_read(struct lcec_slave *slave, long period) {
+static void lcec_el95xx_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_el95xx_data_t *hal_data = (lcec_el95xx_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_em7004.c
+++ b/src/devices/lcec_em7004.c
@@ -23,9 +23,9 @@
 
 #include "../lcec.h"
 
-static void lcec_em7004_read(struct lcec_slave *slave, long period);
-static void lcec_em7004_write(struct lcec_slave *slave, long period);
-static int lcec_em7004_init(int comp_id, struct lcec_slave *slave);
+static void lcec_em7004_read(lcec_slave_t *slave, long period);
+static void lcec_em7004_write(lcec_slave_t *slave, long period);
+static int lcec_em7004_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EM7004", LCEC_BECKHOFF_VID, 0x1B5C3452, 0, NULL, lcec_em7004_init},
@@ -167,7 +167,7 @@ static const lcec_pindesc_t slave_enc_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int lcec_em7004_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_em7004_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_em7004_data_t *hal_data;
   lcec_em7004_din_t *din;
@@ -271,7 +271,7 @@ static int lcec_em7004_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_em7004_read(struct lcec_slave *slave, long period) {
+static void lcec_em7004_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_em7004_data_t *hal_data = (lcec_em7004_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -363,7 +363,7 @@ static void lcec_em7004_read(struct lcec_slave *slave, long period) {
   hal_data->last_operational = 1;
 }
 
-static void lcec_em7004_write(struct lcec_slave *slave, long period) {
+static void lcec_em7004_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_em7004_data_t *hal_data = (lcec_em7004_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -21,7 +21,7 @@
 
 #include "../lcec.h"
 
-static int lcec_fr4000_init(int comp_id, struct lcec_slave *slave);
+static int lcec_fr4000_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EpoCAT", LCEC_ABET_VID, 0x04decade, 0, NULL, lcec_fr4000_init},
@@ -364,10 +364,10 @@ static ec_sync_info_t lcec_fr4000_syncs[] = {
 static uint16_t raw_counts_old[5];
 static int32_t counts[5];
 
-void lcec_fr4000_read(struct lcec_slave *slave, long period);
-void lcec_fr4000_write(struct lcec_slave *slave, long period);
+void lcec_fr4000_read(lcec_slave_t *slave, long period);
+void lcec_fr4000_write(lcec_slave_t *slave, long period);
 
-int lcec_fr4000_init(int comp_id, struct lcec_slave *slave) {
+int lcec_fr4000_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_fr4000_data_t *hal_data;
   int err;
@@ -454,7 +454,7 @@ int lcec_fr4000_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-void lcec_fr4000_read(struct lcec_slave *slave, long period) {
+void lcec_fr4000_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_fr4000_data_t *hal_data = (lcec_fr4000_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -597,7 +597,7 @@ double calculateFvalue(double dac_value, double enc_scale, double dac_scale) {
   return value;
 }
 
-void lcec_fr4000_write(struct lcec_slave *slave, long period) {
+void lcec_fr4000_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_fr4000_data_t *hal_data = (lcec_fr4000_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_ex260.c
+++ b/src/devices/lcec_ex260.c
@@ -7,7 +7,7 @@
 
 #include "lcec.h"
 
-static int lcec_ex260_init(int comp_id, struct lcec_slave *slave);
+static int lcec_ex260_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"EX260-SEC1", LCEC_SMC_VID, 0x01000001, 0, NULL, lcec_ex260_init, NULL, 4},
@@ -44,9 +44,9 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static void lcec_ex260_write(struct lcec_slave *slave, long period);
+static void lcec_ex260_write(lcec_slave_t *slave, long period);
 
-static int lcec_ex260_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_ex260_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_ex260_pin_t *hal_data;
   lcec_ex260_pin_t *pin;
@@ -77,7 +77,7 @@ static int lcec_ex260_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_ex260_write(struct lcec_slave *slave, long period) {
+static void lcec_ex260_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_ex260_pin_t *hal_data = (lcec_ex260_pin_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_generic.c
+++ b/src/devices/lcec_generic.c
@@ -29,8 +29,8 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES(types)
 
-void lcec_generic_read(struct lcec_slave *slave, long period);
-void lcec_generic_write(struct lcec_slave *slave, long period);
+void lcec_generic_read(lcec_slave_t *slave, long period);
+void lcec_generic_write(lcec_slave_t *slave, long period);
 
 hal_s32_t lcec_generic_read_s32(uint8_t *pd, lcec_generic_pin_t *hal_data);
 hal_u32_t lcec_generic_read_u32(uint8_t *pd, lcec_generic_pin_t *hal_data);
@@ -41,7 +41,7 @@ void lcec_generic_write_u32(uint8_t *pd, lcec_generic_pin_t *hal_data, hal_u32_t
 ///
 /// Not static because it's called directly from `lcec_main`, unlike
 /// "normal" devices.
-int lcec_generic_init(int comp_id, struct lcec_slave *slave) {
+int lcec_generic_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_generic_pin_t *hal_data = (lcec_generic_pin_t *)slave->hal_data;
   int i, j;
@@ -119,7 +119,7 @@ int lcec_generic_init(int comp_id, struct lcec_slave *slave) {
 }
 
 /// @brief Read from a generic device.
-void lcec_generic_read(struct lcec_slave *slave, long period) {
+void lcec_generic_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_generic_pin_t *hal_data = (lcec_generic_pin_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -172,7 +172,7 @@ void lcec_generic_read(struct lcec_slave *slave, long period) {
 }
 
 /// @brief Write to a generic device.
-void lcec_generic_write(struct lcec_slave *slave, long period) {
+void lcec_generic_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_generic_pin_t *hal_data = (lcec_generic_pin_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -24,7 +24,7 @@
 #define OMRG5_PULSES_PER_REV_DEFLT     (1 << 20)
 #define OMRG5_FAULT_AUTORESET_DELAY_NS 100000000LL
 
-static int lcec_omrg5_init(int comp_id, struct lcec_slave *slave);
+static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"OmrG5_KNA5L", LCEC_OMRON_VID, 0x00000001, 0, NULL, lcec_omrg5_init},
@@ -204,10 +204,10 @@ static ec_sync_info_t lcec_omrg5_syncs[] = {
 
 static void lcec_omrg5_check_scales(lcec_omrg5_data_t *hal_data);
 
-static void lcec_omrg5_read(struct lcec_slave *slave, long period);
-static void lcec_omrg5_write(struct lcec_slave *slave, long period);
+static void lcec_omrg5_read(lcec_slave_t *slave, long period);
+static void lcec_omrg5_write(lcec_slave_t *slave, long period);
 
-static int lcec_omrg5_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_omrg5_data_t *hal_data;
   int err;
@@ -283,7 +283,7 @@ static void lcec_omrg5_check_scales(lcec_omrg5_data_t *hal_data) {
   }
 }
 
-static void lcec_omrg5_read(struct lcec_slave *slave, long period) {
+static void lcec_omrg5_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_omrg5_data_t *hal_data = (lcec_omrg5_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -348,7 +348,7 @@ static void lcec_omrg5_read(struct lcec_slave *slave, long period) {
   }
 }
 
-static void lcec_omrg5_write(struct lcec_slave *slave, long period) {
+static void lcec_omrg5_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_omrg5_data_t *hal_data = (lcec_omrg5_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -24,7 +24,7 @@
 #define LCEC_PH3LM2RM_RM_COUNT 2
 #define LCEC_PH3LM2RM_LM_COUNT 3
 
-static int lcec_ph3lm2rm_init(int comp_id, struct lcec_slave *slave);
+static int lcec_ph3lm2rm_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"Ph3LM2RM", LCEC_MODUSOFT_VID, 0x10000001, 0, NULL, lcec_ph3lm2rm_init},
@@ -124,17 +124,17 @@ static const lcec_pindesc_t slave_pins[] = {{HAL_BIT, HAL_IN, offsetof(lcec_ph3l
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_data_t, sync_locked), "%s.%s.%s.sync-locked"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
 
-static int lcec_ph3lm2rm_enc_init(struct lcec_slave *slave, lcec_ph3lm2rm_enc_data_t *hal_data, const char *pfx, double scale);
-static int lcec_ph3lm2rm_lm_init(struct lcec_slave *slave, int idx, lcec_ph3lm2rm_lm_data_t *hal_data, const char *pfx);
-static int lcec_ph3lm2rm_rm_init(struct lcec_slave *slave, int idx, lcec_ph3lm2rm_rm_data_t *hal_data, const char *pfx);
+static int lcec_ph3lm2rm_enc_init(lcec_slave_t *slave, lcec_ph3lm2rm_enc_data_t *hal_data, const char *pfx, double scale);
+static int lcec_ph3lm2rm_lm_init(lcec_slave_t *slave, int idx, lcec_ph3lm2rm_lm_data_t *hal_data, const char *pfx);
+static int lcec_ph3lm2rm_rm_init(lcec_slave_t *slave, int idx, lcec_ph3lm2rm_rm_data_t *hal_data, const char *pfx);
 
-static void lcec_ph3lm2rm_read(struct lcec_slave *slave, long period);
-static void lcec_ph3lm2rm_write(struct lcec_slave *slave, long period);
+static void lcec_ph3lm2rm_read(lcec_slave_t *slave, long period);
+static void lcec_ph3lm2rm_write(lcec_slave_t *slave, long period);
 
 static void lcec_ph3lm2rm_enc_read(uint8_t *pd, lcec_ph3lm2rm_enc_data_t *ch);
 static void lcec_ph3lm2rm_enc_write(uint8_t *pd, lcec_ph3lm2rm_enc_data_t *ch);
 
-static int lcec_ph3lm2rm_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_ph3lm2rm_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_ph3lm2rm_data_t *hal_data;
   char pfx[HAL_NAME_LEN];
@@ -181,7 +181,7 @@ static int lcec_ph3lm2rm_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static int lcec_ph3lm2rm_enc_init(struct lcec_slave *slave, lcec_ph3lm2rm_enc_data_t *hal_data, const char *pfx, double scale) {
+static int lcec_ph3lm2rm_enc_init(lcec_slave_t *slave, lcec_ph3lm2rm_enc_data_t *hal_data, const char *pfx, double scale) {
   lcec_master_t *master = slave->master;
   int err;
 
@@ -206,7 +206,7 @@ static int lcec_ph3lm2rm_enc_init(struct lcec_slave *slave, lcec_ph3lm2rm_enc_da
   return 0;
 }
 
-int lcec_ph3lm2rm_lm_init(struct lcec_slave *slave, int ios, lcec_ph3lm2rm_lm_data_t *hal_data, const char *pfx) {
+int lcec_ph3lm2rm_lm_init(lcec_slave_t *slave, int ios, lcec_ph3lm2rm_lm_data_t *hal_data, const char *pfx) {
   lcec_master_t *master = slave->master;
   int err;
 
@@ -238,7 +238,7 @@ int lcec_ph3lm2rm_lm_init(struct lcec_slave *slave, int ios, lcec_ph3lm2rm_lm_da
   return 0;
 }
 
-static int lcec_ph3lm2rm_rm_init(struct lcec_slave *slave, int ios, lcec_ph3lm2rm_rm_data_t *hal_data, const char *pfx) {
+static int lcec_ph3lm2rm_rm_init(lcec_slave_t *slave, int ios, lcec_ph3lm2rm_rm_data_t *hal_data, const char *pfx) {
   lcec_master_t *master = slave->master;
   int err;
 
@@ -265,7 +265,7 @@ static int lcec_ph3lm2rm_rm_init(struct lcec_slave *slave, int ios, lcec_ph3lm2r
   return 0;
 }
 
-static void lcec_ph3lm2rm_read(struct lcec_slave *slave, long period) {
+static void lcec_ph3lm2rm_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_ph3lm2rm_data_t *hal_data = (lcec_ph3lm2rm_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -310,7 +310,7 @@ static void lcec_ph3lm2rm_enc_read(uint8_t *pd, lcec_ph3lm2rm_enc_data_t *ch) {
   }
 }
 
-static void lcec_ph3lm2rm_write(struct lcec_slave *slave, long period) {
+static void lcec_ph3lm2rm_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_ph3lm2rm_data_t *hal_data = (lcec_ph3lm2rm_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -90,7 +90,7 @@ static const lcec_modparam_desc_t modparams_rtec[] = {
     {NULL},
 };
 
-static int lcec_rtec_init(int comp_id, struct lcec_slave *slave);
+static int lcec_rtec_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_typelist_t types[] = {
     {"ECR60", LCEC_RTELLIGENT_VID, 0x0a880001, 0, NULL, lcec_rtec_init, /* modparams_rtec */},
@@ -105,8 +105,8 @@ static lcec_typelist_t types[] = {
 };
 ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_rtec)
 
-static void lcec_rtec_read(struct lcec_slave *slave, long period);
-static void lcec_rtec_write(struct lcec_slave *slave, long period);
+static void lcec_rtec_read(lcec_slave_t *slave, long period);
+static void lcec_rtec_write(lcec_slave_t *slave, long period);
 
 static const lcec_lookuptable_int_t rtec_outputfunc[] = {
     {"custom", 0},
@@ -180,7 +180,7 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static int handle_modparams(struct lcec_slave *slave, lcec_class_cia402_options_t *opt) {
+static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *opt) {
   lcec_master_t *master = slave->master;
   lcec_slave_modparam_t *p;
   uint16_t input_polarity = 0, input_polarity_set = 0;
@@ -401,7 +401,7 @@ static int handle_modparams(struct lcec_slave *slave, lcec_class_cia402_options_
   return 0;
 }
 
-static int lcec_rtec_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_rtec_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_rtec_data_t *hal_data;
   int err;
@@ -508,7 +508,7 @@ static int lcec_rtec_init(int comp_id, struct lcec_slave *slave) {
   return 0;
 }
 
-static void lcec_rtec_read(struct lcec_slave *slave, long period) {
+static void lcec_rtec_read(lcec_slave_t *slave, long period) {
   lcec_rtec_data_t *hal_data = (lcec_rtec_data_t *)slave->hal_data;
   uint8_t *pd = slave->master->process_data;
 
@@ -526,7 +526,7 @@ static void lcec_rtec_read(struct lcec_slave *slave, long period) {
   lcec_din_read_all(slave, hal_data->din);
 }
 
-static void lcec_rtec_write(struct lcec_slave *slave, long period) {
+static void lcec_rtec_write(lcec_slave_t *slave, long period) {
   lcec_rtec_data_t *hal_data = (lcec_rtec_data_t *)slave->hal_data;
 
   // wait for slave to be operational

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -25,8 +25,8 @@
 #define LCEC_STMDS5K_PARAM_MULTITURN 1
 #define LCEC_STMDS5K_PARAM_EXTENC    2
 
-static int lcec_stmds5k_preinit(struct lcec_slave *slave);
-static int lcec_stmds5k_init(int comp_id, struct lcec_slave *slave);
+static int lcec_stmds5k_preinit(lcec_slave_t *slave);
+static int lcec_stmds5k_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_stmds5k_modparams[] = {
     {"isMultiturn", LCEC_STMDS5K_PARAM_MULTITURN, MODPARAM_TYPE_BIT}, {"extEnc", LCEC_STMDS5K_PARAM_EXTENC, MODPARAM_TYPE_U32}, {NULL}};
@@ -226,10 +226,10 @@ static const lcec_stmds5k_extenc_conf_t lcec_stmds5k_extenc_conf[] = {
 static const lcec_stmds5k_extenc_conf_t *lcec_stmds5k_get_extenc_conf(uint32_t type);
 static void lcec_stmds5k_check_scales(lcec_stmds5k_data_t *hal_data);
 
-static void lcec_stmds5k_read(struct lcec_slave *slave, long period);
-static void lcec_stmds5k_write(struct lcec_slave *slave, long period);
+static void lcec_stmds5k_read(lcec_slave_t *slave, long period);
+static void lcec_stmds5k_write(lcec_slave_t *slave, long period);
 
-static int lcec_stmds5k_preinit(struct lcec_slave *slave) {
+static int lcec_stmds5k_preinit(lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   LCEC_CONF_MODPARAM_VAL_T *pval;
 
@@ -245,7 +245,7 @@ static int lcec_stmds5k_preinit(struct lcec_slave *slave) {
   return 0;
 }
 
-static int lcec_stmds5k_init(int comp_id, struct lcec_slave *slave) {
+static int lcec_stmds5k_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_stmds5k_data_t *hal_data;
   int err;
@@ -414,7 +414,7 @@ static void lcec_stmds5k_check_scales(lcec_stmds5k_data_t *hal_data) {
   }
 }
 
-static void lcec_stmds5k_read(struct lcec_slave *slave, long period) {
+static void lcec_stmds5k_read(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_stmds5k_data_t *hal_data = (lcec_stmds5k_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
@@ -478,7 +478,7 @@ static void lcec_stmds5k_read(struct lcec_slave *slave, long period) {
   }
 }
 
-static void lcec_stmds5k_write(struct lcec_slave *slave, long period) {
+static void lcec_stmds5k_write(lcec_slave_t *slave, long period) {
   lcec_master_t *master = slave->master;
   lcec_stmds5k_data_t *hal_data = (lcec_stmds5k_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -82,13 +82,13 @@
 #define LCEC_MAX_PDO_INFO_COUNT  16    ///< The maximum number of PDOs in a sync.
 #define LCEC_MAX_SYNC_COUNT      4    ///< The maximum number of syncs.
 
-struct lcec_master;
-struct lcec_slave;
+typedef struct lcec_master lcec_master_t;
+typedef struct lcec_slave lcec_slave_t;
 
-typedef int (*lcec_slave_preinit_t)(struct lcec_slave *slave);
-typedef int (*lcec_slave_init_t)(int comp_id, struct lcec_slave *slave);
-typedef void (*lcec_slave_cleanup_t)(struct lcec_slave *slave);
-typedef void (*lcec_slave_rw_t)(struct lcec_slave *slave, long period);
+typedef int (*lcec_slave_preinit_t)(lcec_slave_t *slave);
+typedef int (*lcec_slave_init_t)(int comp_id, lcec_slave_t *slave);
+typedef void (*lcec_slave_cleanup_t)(lcec_slave_t *slave);
+typedef void (*lcec_slave_rw_t)(lcec_slave_t *slave, long period);
 
 typedef enum {
   MODPARAM_TYPE_BIT,    ///< Modparam value is a single bit.
@@ -156,8 +156,8 @@ typedef struct lcec_slave_state {
 } lcec_slave_state_t;
 
 typedef struct lcec_master {
-  struct lcec_master *prev;         ///< Next master.
-  struct lcec_master *next;         ///< Previous master.
+  lcec_master_t *prev;         ///< Next master.
+  lcec_master_t *next;         ///< Previous master.
   int index;                        ///< Index of this mater.
   char name[LCEC_CONF_STR_MAXLEN];  ///< Name of master.
   ec_master_t *master;              ///< EtherCAT master structure.
@@ -166,8 +166,8 @@ typedef struct lcec_master {
   ec_domain_t *domain;
   uint8_t *process_data;
   int process_data_len;
-  struct lcec_slave *first_slave;
-  struct lcec_slave *last_slave;
+  lcec_slave_t *first_slave;
+  lcec_slave_t *last_slave;
   lcec_master_data_t *hal_data;
   uint64_t app_time_base;
   uint32_t app_time_period;
@@ -230,9 +230,9 @@ typedef struct {
 
 /// @brief EtherCAT slave.
 typedef struct lcec_slave {
-  struct lcec_slave *prev;                   ///< Next slave
-  struct lcec_slave *next;                   ///< Previous slave
-  struct lcec_master *master;                ///< Master for this slave
+  lcec_slave_t *prev;                   ///< Next slave
+  lcec_slave_t *next;                   ///< Previous slave
+  lcec_master_t *master;                ///< Master for this slave
   int index;                                 ///< Index of this slave.
   char name[LCEC_CONF_STR_MAXLEN];           ///< Slave name.
   uint32_t vid;                              ///< Slave's vendor ID
@@ -300,33 +300,33 @@ typedef struct {
   const double value;
 } lcec_lookuptable_double_t;
 
-lcec_slave_t *lcec_slave_by_index(struct lcec_master *master, int index) __attribute__((nonnull));
+lcec_slave_t *lcec_slave_by_index(lcec_master_t *master, int index) __attribute__((nonnull));
 
-int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size);
-int lcec_read_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *result);
-int lcec_read_sdo8_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
-int lcec_read_sdo8_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
-int lcec_read_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t *result);
-int lcec_read_sdo16_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
-int lcec_read_sdo16_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
-int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t *result);
-int lcec_read_sdo32_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
-int lcec_read_sdo32_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
-int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size);
-int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size);
-int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value);
-int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value);
-int lcec_write_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t value);
-int lcec_write_sdo8_modparam(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value, const char *mpname);
-int lcec_write_sdo16_modparam(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value, const char *mpname);
-int lcec_write_sdo32_modparam(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t value, const char *mpname);
+int lcec_read_sdo(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size);
+int lcec_read_sdo8(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t *result);
+int lcec_read_sdo8_pin_U32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo8_pin_S32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo16(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint16_t *result);
+int lcec_read_sdo16_pin_U32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo16_pin_S32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_sdo32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint32_t *result);
+int lcec_read_sdo32_pin_U32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result);
+int lcec_read_sdo32_pin_S32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile int32_t *result);
+int lcec_read_idn(lcec_slave_t *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size);
+int lcec_write_sdo(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size);
+int lcec_write_sdo8(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t value);
+int lcec_write_sdo16(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint16_t value);
+int lcec_write_sdo32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint32_t value);
+int lcec_write_sdo8_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t value, const char *mpname);
+int lcec_write_sdo16_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint16_t value, const char *mpname);
+int lcec_write_sdo32_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint32_t value, const char *mpname);
 
 int lcec_pin_newf(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_addr, const char *fmt, ...);
 int lcec_pin_newf_list(void *base, const lcec_pindesc_t *list, ...);
 int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, ...);
 int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...);
 
-void copy_fsoe_data(struct lcec_slave *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
+void copy_fsoe_data(lcec_slave_t *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
 void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) __attribute__((nonnull));
 void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode);
 void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
@@ -341,12 +341,12 @@ int lcec_lookupint_i(const lcec_lookuptable_int_t *table, const char *key, int d
 double lcec_lookupdouble(const lcec_lookuptable_double_t *table, const char *key, double default_value) __attribute__((nonnull));
 double lcec_lookupdouble_i(const lcec_lookuptable_double_t *table, const char *key, double default_value) __attribute__((nonnull));
 
-LCEC_CONF_MODPARAM_VAL_T *lcec_modparam_get(struct lcec_slave *slave, int id) __attribute__((nonnull));
+LCEC_CONF_MODPARAM_VAL_T *lcec_modparam_get(lcec_slave_t *slave, int id) __attribute__((nonnull));
 int lcec_modparam_desc_len(const lcec_modparam_desc_t *mp) __attribute__((nonnull));
 lcec_modparam_desc_t *lcec_modparam_desc_concat(lcec_modparam_desc_t const *a, lcec_modparam_desc_t const *b) __attribute__((nonnull));
 
 lcec_pdo_entry_reg_t *lcec_allocate_pdo_entry_reg(int size);
-int lcec_pdo_init(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, unsigned int *os, unsigned int *bp);
+int lcec_pdo_init(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, unsigned int *os, unsigned int *bp);
 int lcec_pdo_entry_reg_len(lcec_pdo_entry_reg_t *reg);
 int lcec_append_pdo_entry_reg(lcec_pdo_entry_reg_t *dest, lcec_pdo_entry_reg_t *src);
 

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -27,7 +27,7 @@ static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list
 int lcec_comp_id = -1;
 
 /// @brief Find the slave with a specified index underneath a specific master.
-lcec_slave_t *lcec_slave_by_index(struct lcec_master *master, int index) {
+lcec_slave_t *lcec_slave_by_index(lcec_master_t *master, int index) {
   lcec_slave_t *slave;
 
   for (slave = master->first_slave; slave != NULL; slave = slave->next) {
@@ -40,7 +40,7 @@ lcec_slave_t *lcec_slave_by_index(struct lcec_master *master, int index) {
 }
 
 /// @brief Copy FSoE (Safety over EtherCAT / FailSafe over EtherCAT) data between slaves and masters.
-void copy_fsoe_data(struct lcec_slave *slave, unsigned int slave_offset, unsigned int master_offset) {
+void copy_fsoe_data(lcec_slave_t *slave, unsigned int slave_offset, unsigned int master_offset) {
   lcec_master_t *master = slave->master;
   uint8_t *pd = master->process_data;
   const LCEC_CONF_FSOE_T *fsoeConf = slave->fsoeConf;
@@ -122,7 +122,7 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
 }
 
 /// @brief Read an SDO configuration from a slave device.
-int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size) {
+int lcec_read_sdo(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t *target, size_t size) {
   lcec_master_t *master = slave->master;
   int err;
   size_t result_size;
@@ -144,22 +144,22 @@ int lcec_read_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, ui
 }
 
 /// @brief Read an 8-bit SDO from a slave device.
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint8_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *result) {
+int lcec_read_sdo8(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t *result) {
   return lcec_read_sdo(slave, index, subindex, result, 1);
 }
 
 /// @brief Read a 16-bit SDO from a slave device.
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint16_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t *result) {
+int lcec_read_sdo16(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint16_t *result) {
   uint8_t data[2];
   int err = lcec_read_sdo(slave, index, subindex, data, 2);
   *result = EC_READ_U16(data);
@@ -168,12 +168,12 @@ int lcec_read_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, 
 }
 
 /// @brief Read a 32-bit SDO from a slave device.
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t *result) {
+int lcec_read_sdo32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint32_t *result) {
   uint8_t data[4];
   int err = lcec_read_sdo(slave, index, subindex, data, 4);
   *result = EC_READ_U32(data);
@@ -187,12 +187,12 @@ int lcec_read_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, 
 /// paramater is a 32-bit integer, and it's declared `volatile` to
 /// reduce the number of warnings that GCC produces.
 ///
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo8_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+int lcec_read_sdo8_pin_U32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
   uint8_t data;
   int err = lcec_read_sdo(slave, index, subindex, &data, 1);
   *result = data;
@@ -206,12 +206,12 @@ int lcec_read_sdo8_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t sub
 /// paramater is a 32-bit integer, and it's declared `volatile` to
 /// reduce the number of warnings that GCC produces.
 ///
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo8_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+int lcec_read_sdo8_pin_S32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
   uint8_t data;
   int err = lcec_read_sdo(slave, index, subindex, &data, 1);
   *result = data;
@@ -225,12 +225,12 @@ int lcec_read_sdo8_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t sub
 /// paramater is a 32-bit integer, and it's declared `volatile` to
 /// reduce the number of warnings that GCC produces.
 ///
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo16_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+int lcec_read_sdo16_pin_U32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
   uint8_t data[2];
   int err = lcec_read_sdo(slave, index, subindex, data, 2);
   *result = EC_READ_U16(data);
@@ -244,12 +244,12 @@ int lcec_read_sdo16_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t su
 /// paramater is a 32-bit integer, and it's declared `volatile` to
 /// reduce the number of warnings that GCC produces.
 ///
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo16_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+int lcec_read_sdo16_pin_S32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
   uint8_t data[2];
   int err = lcec_read_sdo(slave, index, subindex, data, 2);
   *result = EC_READ_U16(data);
@@ -263,12 +263,12 @@ int lcec_read_sdo16_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t su
 /// paramater is a 32-bit integer, and it's declared `volatile` to
 /// reduce the number of warnings that GCC produces.
 ///
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo32_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
+int lcec_read_sdo32_pin_U32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile uint32_t *result) {
   uint8_t data[4];
   int err = lcec_read_sdo(slave, index, subindex, data, 4);
   *result = EC_READ_U32(data);
@@ -282,12 +282,12 @@ int lcec_read_sdo32_pin_U32(struct lcec_slave *slave, uint16_t index, uint8_t su
 /// paramater is a 32-bit integer, and it's declared `volatile` to
 /// reduce the number of warnings that GCC produces.
 ///
-/// @param slave The `struct lcec_slave` passed to `_init`, `_read`, etc.
+/// @param slave The `lcec_slave_t` passed to `_init`, `_read`, etc.
 /// @param index The CoE object index to read.  For `0x6010:02`, this would be `0x6010`.
 /// @param subindex The CoE object subindex to read.  For `0x6010:02`, this would be `0x02`.
 /// @param result A pointer to a `uint32_t` to write the result into.
 /// @return 0 for success, <0 for failure.
-int lcec_read_sdo32_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
+int lcec_read_sdo32_pin_S32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, volatile int32_t *result) {
   uint8_t data[4];
   int err = lcec_read_sdo(slave, index, subindex, data, 4);
   *result = EC_READ_U32(data);
@@ -318,7 +318,7 @@ int lcec_read_sdo32_pin_S32(struct lcec_slave *slave, uint16_t index, uint8_t su
 /// @param value A pointer to the value to be set.
 /// @param size The number of bytes to set.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size) {
+int lcec_write_sdo(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t *value, size_t size) {
   lcec_master_t *master = slave->master;
   int err;
   uint32_t abort_code;
@@ -348,7 +348,7 @@ int lcec_write_sdo(struct lcec_slave *slave, uint16_t index, uint8_t subindex, u
 /// @param subindex The SDO sub-index to be set.
 /// @param value An 8-bit value to set.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value) {
+int lcec_write_sdo8(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t value) {
   uint8_t data[1];
 
   EC_WRITE_U8(data, value);
@@ -364,7 +364,7 @@ int lcec_write_sdo8(struct lcec_slave *slave, uint16_t index, uint8_t subindex, 
 /// @param subindex The SDO sub-index to be set.
 /// @param value A 16-bit value to set.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value) {
+int lcec_write_sdo16(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint16_t value) {
   uint8_t data[2];
 
   EC_WRITE_U16(data, value);
@@ -380,7 +380,7 @@ int lcec_write_sdo16(struct lcec_slave *slave, uint16_t index, uint8_t subindex,
 /// @param subindex The SDO sub-index to be set.
 /// @param value A 32-bit value to set.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t value) {
+int lcec_write_sdo32(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint32_t value) {
   uint8_t data[4];
 
   EC_WRITE_U32(data, value);
@@ -397,7 +397,7 @@ int lcec_write_sdo32(struct lcec_slave *slave, uint16_t index, uint8_t subindex,
 /// @param value An 8-bit value to set.
 /// @param mpname The XML name of the modparam that triggered this.  Used for error messages.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo8_modparam(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint8_t value, const char *mpname) {
+int lcec_write_sdo8_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint8_t value, const char *mpname) {
   if (lcec_write_sdo8(slave, index, subindex, value) < 0) {
     rtapi_print_msg(RTAPI_MSG_ERR,
         LCEC_MSG_PFX "slave %s.%s: Failed to set SDO for <modParam name=\"%s\": sdo write of %04x:%02x = %d rejected by slave\n",
@@ -417,7 +417,7 @@ int lcec_write_sdo8_modparam(struct lcec_slave *slave, uint16_t index, uint8_t s
 /// @param value A 16-bit value to set.
 /// @param mpname The XML name of the modparam that triggered this.  Used for error messages.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo16_modparam(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint16_t value, const char *mpname) {
+int lcec_write_sdo16_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint16_t value, const char *mpname) {
   if (lcec_write_sdo16(slave, index, subindex, value) < 0) {
     rtapi_print_msg(RTAPI_MSG_ERR,
         LCEC_MSG_PFX "slave %s.%s: Failed to set SDO for <modParam name=\"%s\": sdo write of %04x:%02x = %d rejected by slave\n",
@@ -437,7 +437,7 @@ int lcec_write_sdo16_modparam(struct lcec_slave *slave, uint16_t index, uint8_t 
 /// @param value A 32-bit value to set.
 /// @param mpname The XML name of the modparam that triggered this.  Used for error messages.
 /// @return 0 for success or -1 for failure.
-int lcec_write_sdo32_modparam(struct lcec_slave *slave, uint16_t index, uint8_t subindex, uint32_t value, const char *mpname) {
+int lcec_write_sdo32_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subindex, uint32_t value, const char *mpname) {
   if (lcec_write_sdo32(slave, index, subindex, value) < 0) {
     rtapi_print_msg(RTAPI_MSG_ERR,
         LCEC_MSG_PFX "slave %s.%s: Failed to set SDO for <modParam name=\"%s\": sdo write of %04x:%02x = %d rejected by slave\n",
@@ -451,7 +451,7 @@ int lcec_write_sdo32_modparam(struct lcec_slave *slave, uint16_t index, uint8_t 
 ///
 /// IDNs ("Identification Number") are similar to SDOs, but for SoE
 /// (Servo over EtherCAT) devices, not CoE (CanOPEN over EtherCAT).
-int lcec_read_idn(struct lcec_slave *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size) {
+int lcec_read_idn(lcec_slave_t *slave, uint8_t drive_no, uint16_t idn, uint8_t *target, size_t size) {
   lcec_master_t *master = slave->master;
   int err;
   size_t result_size;
@@ -553,7 +553,7 @@ int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...) {
 }
 
 /// @brief Get an XML `<modParam>` value for a specified slave.
-LCEC_CONF_MODPARAM_VAL_T *lcec_modparam_get(struct lcec_slave *slave, int id) {
+LCEC_CONF_MODPARAM_VAL_T *lcec_modparam_get(lcec_slave_t *slave, int id) {
   lcec_slave_modparam_t *p;
 
   if (slave->modparams == NULL) {
@@ -591,7 +591,7 @@ lcec_pdo_entry_reg_t *lcec_allocate_pdo_entry_reg(int size) {
 /// checking and takes a *slave instead of pos/vid/pid, but fills the
 /// same function and should be relatively simple to swap in.
 ///
-/// @param slave The `struct lcec_slave` this is passed into `_init`.
+/// @param slave The `lcec_slave_t` this is passed into `_init`.
 /// @param idx The CoE object index that we want to register.  If we're trying to register `0x6010:12`, then the index should be `0x6010`.
 /// @param sidx The object subindex that we want to register.  In the previous example, this would be `0x12`.
 /// @param os The offset for this PDO entry.  This should point to an unsigned int in your `hal_data` structure, and it will be filled in
@@ -599,7 +599,7 @@ lcec_pdo_entry_reg_t *lcec_allocate_pdo_entry_reg(int size) {
 /// @param bp The bit offset for this PDO entry.  This should point to an unsigned int in your `hal_data` structure if this is a <8 bit
 /// type, or it may be NULL for 8-bit or larger types.  Attempting to use NULL with a boolean will trigger an error at runtime.
 /// @return 0 for succeess, <0 for failure.
-int lcec_pdo_init(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, unsigned int *os, unsigned int *bp) {
+int lcec_pdo_init(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, unsigned int *os, unsigned int *bp) {
   if (slave->regs->current >= slave->regs->max) {
     // We specifically want to log this, because most users don't
     // bother checking the return value, and this is an init bug.


### PR DESCRIPTION
This is dumb, but it's been bugging me.  We use a mixture of `struct lcec_slave` and `lcec_slave_t` through the code, when there's really no reason to at this point.  It's slightly easier to use `struct lcec_slave` when creating recursively defined types (linked lists, for example -- `struct lcec_slave` has a pointer to a `struct lcec_slave` in it), but modern C makes it easy enough to fix that.

This also does the same for `lcec_master_t`/`struct lcec_master`, but it's much less common.
