### PR TITLE
style(cia402): Get rid of the giant lists of pin/PDO/etc initialization and replace with more macros

### DIFF
--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -125,8 +125,6 @@ typedef struct {
 /// This is constructed from an options structure by
 /// `lcec_cia402_enabled()`.
 typedef struct {
-  int enable_hm;
-
   int enable_actual_current;
   int enable_actual_following_error;
   int enable_actual_position;
@@ -135,17 +133,22 @@ typedef struct {
   int enable_actual_velocity_sensor;
   int enable_actual_vl;
   int enable_actual_voltage;
+  int enable_csp;
+  int enable_cst;
+  int enable_csv;
   int enable_demand_vl;
   int enable_digital_input;
   int enable_digital_output;
   int enable_error_code;
   int enable_following_error_timeout;
   int enable_following_error_window;
+  int enable_hm;
   int enable_home_accel;
   int enable_home_method;
   int enable_home_velocity_fast;
   int enable_home_velocity_slow;
   int enable_interpolation_time_period;
+  int enable_ip;
   int enable_maximum_acceleration;
   int enable_maximum_current;
   int enable_maximum_deceleration;
@@ -157,11 +160,13 @@ typedef struct {
   int enable_opmode;
   int enable_opmode_display;
   int enable_polarity;
+  int enable_pp;
   int enable_profile_accel;
   int enable_profile_decel;
   int enable_profile_end_velocity;
   int enable_profile_max_velocity;
   int enable_profile_velocity;
+  int enable_pv;
   int enable_target_position;
   int enable_target_torque;
   int enable_target_velocity;
@@ -169,12 +174,14 @@ typedef struct {
   int enable_torque_demand;
   int enable_torque_profile_type;
   int enable_torque_slope;
+  int enable_tq;
   int enable_velocity_demand;
   int enable_velocity_error_time;
   int enable_velocity_error_window;
   int enable_velocity_sensor_selector;
   int enable_velocity_threshold_time;
   int enable_velocity_threshold_window;
+  int enable_vl;
   int enable_vl_accel;
   int enable_vl_decel;
   int enable_vl_maximum;
@@ -345,56 +352,57 @@ lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, unsigned int max
 // next is 0x1240
 
 // "enable" modParams
-#define CIA402_MP_ENABLE_ACTUAL_CURRENT            0x22d0
-#define CIA402_MP_ENABLE_ACTUAL_FOLLOWING_ERROR    0x2100
-#define CIA402_MP_ENABLE_ACTUAL_TORQUE             0x2110
-#define CIA402_MP_ENABLE_ACTUAL_VELOCITY_SENSOR    0x2120
-#define CIA402_MP_ENABLE_ACTUAL_VL                 0x2330
-#define CIA402_MP_ENABLE_ACTUAL_VOLTAGE            0x22e0
-#define CIA402_MP_ENABLE_CSP                       0x2020
-#define CIA402_MP_ENABLE_CST                       0x2080
-#define CIA402_MP_ENABLE_CSV                       0x2030
-#define CIA402_MP_ENABLE_DEMAND_VL                 0x2320
-#define CIA402_MP_ENABLE_DIGITAL_INPUT             0x2490
-#define CIA402_MP_ENABLE_DIGITAL_OUTPUT            0x24a0
-#define CIA402_MP_ENABLE_ERROR_CODE                0x2480
-#define CIA402_MP_ENABLE_FOLLOWING_ERROR_TIMEOUT   0x2130
-#define CIA402_MP_ENABLE_FOLLOWING_ERROR_WINDOW    0x2140
-#define CIA402_MP_ENABLE_HM                        0x2040
-#define CIA402_MP_ENABLE_HOME_ACCEL                0x2150
-#define CIA402_MP_ENABLE_INTERPOLATION_TIME_PERIOD 0x2160
-#define CIA402_MP_ENABLE_IP                        0x2050
-#define CIA402_MP_ENABLE_MAXIMUM_ACCELERATION      0x2170
-#define CIA402_MP_ENABLE_MAXIMUM_CURRENT           0x22a0
-#define CIA402_MP_ENABLE_MAXIMUM_DECELERATION      0x2180
-#define CIA402_MP_ENABLE_MAXIMUM_MOTOR_RPM         0x2190
-#define CIA402_MP_ENABLE_MAXIMUM_TORQUE            0x21a0
-#define CIA402_MP_ENABLE_MOTION_PROFILE            0x21b0
-#define CIA402_MP_ENABLE_MOTOR_RATED_CURRENT       0x22c0
-#define CIA402_MP_ENABLE_MOTOR_RATED_TORQUE        0x21c0
-#define CIA402_MP_ENABLE_POLARITY                  0x21d0
-#define CIA402_MP_ENABLE_PP                        0x2000
-#define CIA402_MP_ENABLE_PROFILE_ACCEL             0x21e0
-#define CIA402_MP_ENABLE_PROFILE_DECEL             0x21f0
-#define CIA402_MP_ENABLE_PROFILE_END_VELOCITY      0x2200
-#define CIA402_MP_ENABLE_PROFILE_MAX_VELOCITY      0x2210
-#define CIA402_MP_ENABLE_PROFILE_VELOCITY          0x2220
-#define CIA402_MP_ENABLE_PV                        0x2010
-#define CIA402_MP_ENABLE_TARGET_TORQUE             0x2290
-#define CIA402_MP_ENABLE_TARGET_VL                 0x2310
-#define CIA402_MP_ENABLE_TORQUE_DEMAND             0x22b0
-#define CIA402_MP_ENABLE_TORQUE_PROFILE_TYPE       0x2300
-#define CIA402_MP_ENABLE_TORQUE_SLOPE              0x22f0
-#define CIA402_MP_ENABLE_TQ                        0x2070
-#define CIA402_MP_ENABLE_VELOCITY_DEMAND           0x2230
-#define CIA402_MP_ENABLE_VELOCITY_ERROR_TIME       0x2240
-#define CIA402_MP_ENABLE_VELOCITY_ERROR_WINDOW     0x2250
-#define CIA402_MP_ENABLE_VELOCITY_SENSOR_SELECTOR  0x2260
-#define CIA402_MP_ENABLE_VELOCITY_THRESHOLD_TIME   0x2270
-#define CIA402_MP_ENABLE_VELOCITY_THRESHOLD_WINDOW 0x2280
-#define CIA402_MP_ENABLE_VL                        0x2060
-#define CIA402_MP_ENABLE_VL_ACCEL                  0x2360
-#define CIA402_MP_ENABLE_VL_DECEL                  0x2370
-#define CIA402_MP_ENABLE_VL_MAXIMUM                0x2350
-#define CIA402_MP_ENABLE_VL_MINIMUM                0x2340
-// next is 0x24b0
+#define CIA402_MP_ENABLE_actual_current            0x22d0
+#define CIA402_MP_ENABLE_actual_following_error    0x2100
+#define CIA402_MP_ENABLE_actual_torque             0x2110
+#define CIA402_MP_ENABLE_actual_velocity_sensor    0x2120
+#define CIA402_MP_ENABLE_actual_vl                 0x2330
+#define CIA402_MP_ENABLE_actual_voltage            0x22e0
+#define CIA402_MP_ENABLE_csp                       0x2020
+#define CIA402_MP_ENABLE_cst                       0x2080
+#define CIA402_MP_ENABLE_csv                       0x2030
+#define CIA402_MP_ENABLE_demand_vl                 0x2320
+#define CIA402_MP_ENABLE_digital_input             0x2490
+#define CIA402_MP_ENABLE_digital_output            0x24a0
+#define CIA402_MP_ENABLE_error_code                0x2480
+#define CIA402_MP_ENABLE_following_error_timeout   0x2130
+#define CIA402_MP_ENABLE_following_error_window    0x2140
+#define CIA402_MP_ENABLE_hm                        0x2040
+#define CIA402_MP_ENABLE_home_accel                0x2150
+#define CIA402_MP_ENABLE_interpolation_time_period 0x2160
+#define CIA402_MP_ENABLE_ip                        0x2050
+#define CIA402_MP_ENABLE_maximum_acceleration      0x2170
+#define CIA402_MP_ENABLE_maximum_current           0x22a0
+#define CIA402_MP_ENABLE_maximum_deceleration      0x2180
+#define CIA402_MP_ENABLE_maximum_motor_rpm         0x2190
+#define CIA402_MP_ENABLE_maximum_torque            0x21a0
+#define CIA402_MP_ENABLE_motion_profile            0x21b0
+#define CIA402_MP_ENABLE_motor_rated_current       0x22c0
+#define CIA402_MP_ENABLE_motor_rated_torque        0x21c0
+#define CIA402_MP_ENABLE_polarity                  0x21d0
+#define CIA402_MP_ENABLE_pp                        0x2000
+#define CIA402_MP_ENABLE_profile_accel             0x21e0
+#define CIA402_MP_ENABLE_profile_decel             0x21f0
+#define CIA402_MP_ENABLE_profile_end_velocity      0x2200
+#define CIA402_MP_ENABLE_profile_max_velocity      0x2210
+#define CIA402_MP_ENABLE_profile_velocity          0x2220
+#define CIA402_MP_ENABLE_pv                        0x2010
+#define CIA402_MP_ENABLE_target_torque             0x2290
+#define CIA402_MP_ENABLE_target_vl                 0x2310
+#define CIA402_MP_ENABLE_torque_demand             0x22b0
+#define CIA402_MP_ENABLE_torque_profile_type       0x2300
+#define CIA402_MP_ENABLE_torque_slope              0x22f0
+#define CIA402_MP_ENABLE_tq                        0x2070
+#define CIA402_MP_ENABLE_velocity_demand           0x2230
+#define CIA402_MP_ENABLE_velocity_error_time       0x2240
+#define CIA402_MP_ENABLE_velocity_error_window     0x2250
+#define CIA402_MP_ENABLE_velocity_sensor_selector  0x2260
+#define CIA402_MP_ENABLE_velocity_threshold_time   0x2270
+#define CIA402_MP_ENABLE_velocity_threshold_window 0x2280
+#define CIA402_MP_ENABLE_vl                        0x2060
+#define CIA402_MP_ENABLE_vl_accel                  0x2360
+#define CIA402_MP_ENABLE_vl_decel                  0x2370
+#define CIA402_MP_ENABLE_vl_maximum                0x2350
+#define CIA402_MP_ENABLE_vl_minimum                0x2340
+#define CIA402_MP_ENABLE_opmode                    0x23b0
+// next is 0x24c0

--- a/src/devices/lcec_class_cia402_opt.h
+++ b/src/devices/lcec_class_cia402_opt.h
@@ -225,6 +225,58 @@
 #define PDO_PIN_TYPE_vl_maximum                HAL_S32
 #define PDO_PIN_TYPE_vl_minimum                HAL_S32
 
+// Pin names
+#define PDO_PIN_NAME_actual_current            "actual-current"
+#define PDO_PIN_NAME_actual_following_error    "actual-following-error"
+#define PDO_PIN_NAME_actual_position           "actual-position"
+#define PDO_PIN_NAME_actual_torque             "actual-torque"
+#define PDO_PIN_NAME_actual_velocity           "actual-velocity"
+#define PDO_PIN_NAME_actual_velocity_sensor    "actual-velocity-sensor"
+#define PDO_PIN_NAME_actual_vl                 "actual-vl"
+#define PDO_PIN_NAME_actual_voltage            "actual-voltage"
+#define PDO_PIN_NAME_error_code                "error-code"
+#define PDO_PIN_NAME_demand_vl                 "demand-vl"
+#define PDO_PIN_NAME_opmode_display            "opmode-display"
+#define PDO_PIN_NAME_torque_demand             "torque-demand"
+#define PDO_PIN_NAME_velocity_demand           "velocity-demand"
+#define PDO_PIN_NAME_following_error_timeout   "following-error-timeout"
+#define PDO_PIN_NAME_following_error_window    "following-error-window"
+#define PDO_PIN_NAME_home_accel                "home-accel"
+#define PDO_PIN_NAME_home_method               "home-method"
+#define PDO_PIN_NAME_home_velocity_fast        "home-velocity-fast"
+#define PDO_PIN_NAME_home_velocity_slow        "home-velocity-slow"
+#define PDO_PIN_NAME_interpolation_time_period "interpolation-time-period"
+#define PDO_PIN_NAME_maximum_acceleration      "maximum-acceleration"
+#define PDO_PIN_NAME_maximum_current           "maximum-current"
+#define PDO_PIN_NAME_maximum_deceleration      "maximum-deceleration"
+#define PDO_PIN_NAME_maximum_motor_rpm         "maximum-motor-rpm"
+#define PDO_PIN_NAME_maximum_torque            "torque-maximum"
+#define PDO_PIN_NAME_motion_profile            "motion-profile"
+#define PDO_PIN_NAME_motor_rated_current       "motor-rated-current"
+#define PDO_PIN_NAME_motor_rated_torque        "motor-rated-torque"
+#define PDO_PIN_NAME_opmode                    "opmode"
+#define PDO_PIN_NAME_polarity                  "polarity"
+#define PDO_PIN_NAME_profile_accel             "profile-accel"
+#define PDO_PIN_NAME_profile_decel             "profile-decel"
+#define PDO_PIN_NAME_profile_end_velocity      "profile-end-velocity"
+#define PDO_PIN_NAME_profile_max_velocity      "profile-max-velocity"
+#define PDO_PIN_NAME_profile_velocity          "profile-velocity"
+#define PDO_PIN_NAME_target_position           "target-position"
+#define PDO_PIN_NAME_target_torque             "target-torque"
+#define PDO_PIN_NAME_target_velocity           "target-velocity"
+#define PDO_PIN_NAME_target_vl                 "target-vl"
+#define PDO_PIN_NAME_torque_profile_type       "torque-profile-type"
+#define PDO_PIN_NAME_torque_slope              "torque-slope"
+#define PDO_PIN_NAME_velocity_error_time       "velocity-error-time"
+#define PDO_PIN_NAME_velocity_error_window     "velocity-error-window"
+#define PDO_PIN_NAME_velocity_sensor_selector  "velocity-sensor-selector"
+#define PDO_PIN_NAME_velocity_threshold_time   "velocity-threshold-time"
+#define PDO_PIN_NAME_velocity_threshold_window "velocity-threshold-window"
+#define PDO_PIN_NAME_vl_accel                  "vl-accel"
+#define PDO_PIN_NAME_vl_decel                  "vl-decel"
+#define PDO_PIN_NAME_vl_maximum                "vl-maximum"
+#define PDO_PIN_NAME_vl_minimum                "vl-minimum"
+
 // Next, the length of the object for each.   Usually 8, 16, or 32.
 #define PDO_BITS_actual_current            16
 #define PDO_BITS_actual_following_error    32
@@ -279,7 +331,7 @@
 #define PDO_BITS_vl_maximum                16
 #define PDO_BITS_vl_minimum                16
 
-// Finally (?), the signeded-ness of each object.  This should match
+// The signeded-ness of each object.  This should match
 // PDO_PIN_TYPE_foo, but we don't *necessarily* have PDO_PIN_TYPE_foo
 // for all objects.
 #define PDO_SIGN_actual_current            S
@@ -333,6 +385,61 @@
 #define PDO_SIGN_vl_maximum                S
 #define PDO_SIGN_vl_minimum                S
 
+// define modParam names for each setting.
+#define PDO_MP_NAME_actual_current            "enableActualCurrent"
+#define PDO_MP_NAME_actual_following_error    "enableActualFollowingError"
+#define PDO_MP_NAME_actual_torque             "enableActualTorque"
+#define PDO_MP_NAME_actual_vl                 "enableActualVL"
+#define PDO_MP_NAME_actual_velocity_sensor    "enableActualVelocitySensor"
+#define PDO_MP_NAME_actual_voltage            "enableActualVoltage"
+#define PDO_MP_NAME_demand_vl                 "enableDemandVL"
+#define PDO_MP_NAME_digital_input             "enableDigitalInput"
+#define PDO_MP_NAME_digital_output            "enableDigitalOutput"
+#define PDO_MP_NAME_error_code                "enableErrorCode"
+#define PDO_MP_NAME_following_error_timeout   "enableFollowingErrorTimeout"
+#define PDO_MP_NAME_following_error_window    "enableFollowingErrorWindow"
+#define PDO_MP_NAME_home_accel                "enableHomeAccel"
+#define PDO_MP_NAME_interpolation_time_period "enableInterpolationTimePeriod"
+#define PDO_MP_NAME_maximum_acceleration      "enableMaximumAcceleration"
+#define PDO_MP_NAME_maximum_current           "enableMaximumCurrent"
+#define PDO_MP_NAME_maximum_deceleration      "enableMaximumDeceleration"
+#define PDO_MP_NAME_maximum_motor_rpm         "enableMaximumMotorRPM"
+#define PDO_MP_NAME_maximum_torque            "enableMaximumTorque"
+#define PDO_MP_NAME_motor_rated_current       "enableMotorRatedCurrent"
+#define PDO_MP_NAME_motor_rated_torque        "enableMotorRatedTorque"
+#define PDO_MP_NAME_polarity                  "enablePolarity"
+#define PDO_MP_NAME_profile_accel             "enableProfileAccel"
+#define PDO_MP_NAME_profile_decel             "enableProfileDecel"
+#define PDO_MP_NAME_profile_end_velocity      "enableProfileEndVelocity"
+#define PDO_MP_NAME_profile_max_velocity      "enableProfileMaxVelocity"
+#define PDO_MP_NAME_profile_velocity          "enableProfileVelocity"
+#define PDO_MP_NAME_target_torque             "enableTargetTorque"
+#define PDO_MP_NAME_target_vl                 "enableTargetVL"
+#define PDO_MP_NAME_torque_demand             "enableTorqueDemand"
+#define PDO_MP_NAME_torque_profile_type       "enableTorqueProfileType"
+#define PDO_MP_NAME_torque_slope              "enableTorqueSlope"
+#define PDO_MP_NAME_vl_accel                  "enableVLAccel"
+#define PDO_MP_NAME_vl_decel                  "enableVLDecel"
+#define PDO_MP_NAME_vl_maximum                "enableVLMaximum"
+#define PDO_MP_NAME_vl_minimum                "enableVLMinimum"
+#define PDO_MP_NAME_velocity_demand           "enableVelocityDemand"
+#define PDO_MP_NAME_velocity_error_time       "enableVelocityErrorTime"
+#define PDO_MP_NAME_velocity_error_window     "enableVelocityErrorWindow"
+#define PDO_MP_NAME_velocity_sensor_selector  "enableVelocitySensorSelector"
+#define PDO_MP_NAME_velocity_threshold_time   "enableVelocityThresholdTime"
+#define PDO_MP_NAME_velocity_threshold_window "enableVelocityThresholdWindow"
+#define PDO_MP_NAME_pp                        "enablePP"
+#define PDO_MP_NAME_pv                        "enablePV"
+#define PDO_MP_NAME_csp                       "enableCSP"
+#define PDO_MP_NAME_cst                       "enableCST"
+#define PDO_MP_NAME_csv                       "enableCSV"
+#define PDO_MP_NAME_hm                        "enableHM"
+#define PDO_MP_NAME_ip                        "enableIP"
+#define PDO_MP_NAME_tq                        "enableTQ"
+#define PDO_MP_NAME_vl                        "enableVL"
+#define PDO_MP_NAME_opmode                    "enableOpmode"
+#define PDO_MP_NAME_motion_profile            "enableMotionProfile"
+
 // These work around a couple C pre-processor shortcomings.  In a few
 // places, I want to concatenate FOO and BAR into FOOBAR, and then
 // evaluate FOOBAR for macro substitution before then taking the
@@ -350,3 +457,83 @@
 #define SUBSTJOIN2(a, b)          JOIN2(a, b)
 #define SUBSTJOIN3(a, b, c)       JOIN3(a, b, c)
 #define SUBSTJOIN5(a, b, c, d, e) JOIN5(a, b, c, d, e)
+
+// Now for the fun stuff.  These iterate over a set of things, calling
+// a specified function (or macro!) for each.
+
+// This is the list of read PDOs.  These all need to be initialized,
+// mapped, and read.
+#define FOR_ALL_READ_PDOS_DO(thing) \
+  thing(actual_current);            \
+  thing(actual_following_error);    \
+  thing(actual_position);           \
+  thing(actual_torque);             \
+  thing(actual_velocity);           \
+  thing(actual_velocity_sensor);    \
+  thing(actual_vl);                 \
+  thing(actual_voltage);            \
+  thing(error_code);                \
+  thing(demand_vl);                 \
+  thing(opmode_display);            \
+  thing(torque_demand);             \
+  thing(velocity_demand);
+
+// This is the list of write SDOs.  These need to be initialized, mapped, and written.
+#define FOR_ALL_WRITE_PDOS_DO(thing) \
+  thing(home_method);                \
+  thing(interpolation_time_period);  \
+  thing(opmode);                     \
+  thing(profile_velocity);           \
+  thing(target_position);            \
+  thing(target_torque);              \
+  thing(target_velocity);            \
+  thing(target_vl);
+
+// This is the list of write *SDOs*.  These need to be initialized differently and written, but not mapped.
+#define FOR_ALL_WRITE_SDOS_DO(thing) \
+  thing(following_error_timeout);    \
+  thing(following_error_window);     \
+  thing(home_accel);                 \
+  thing(home_velocity_fast);         \
+  thing(home_velocity_slow);         \
+  thing(maximum_acceleration);       \
+  thing(maximum_current);            \
+  thing(maximum_deceleration);       \
+  thing(maximum_motor_rpm);          \
+  thing(maximum_torque);             \
+  thing(motion_profile);             \
+  thing(motor_rated_current);        \
+  thing(motor_rated_torque);         \
+  thing(polarity);                   \
+  thing(profile_accel);              \
+  thing(profile_decel);              \
+  thing(profile_end_velocity);       \
+  thing(profile_max_velocity);       \
+  thing(torque_profile_type);        \
+  thing(torque_slope);               \
+  thing(velocity_error_time);        \
+  thing(velocity_error_window);      \
+  thing(velocity_sensor_selector);   \
+  thing(velocity_threshold_time);    \
+  thing(velocity_threshold_window);  \
+  thing(vl_accel);                   \
+  thing(vl_decel);                   \
+  thing(vl_maximum);                 \
+  thing(vl_minimum);
+
+// This is all items that have entries in `enabled`.  It is neither a
+// proper superset not proper subset of the above entries.
+//
+// Also, `clang-format` *really* doesn't know what to do with this.
+#define FOR_ALL_OPTS_DO(thing)                                                                                                             \
+  thing(actual_current) thing(actual_following_error) thing(actual_torque) thing(actual_velocity_sensor) thing(actual_vl)                  \
+      thing(actual_voltage) thing(csp) thing(cst) thing(csv) thing(demand_vl) thing(digital_input) thing(digital_output) thing(error_code) \
+          thing(following_error_timeout) thing(following_error_window) thing(hm) thing(home_accel) thing(interpolation_time_period)        \
+              thing(ip) thing(maximum_acceleration) thing(maximum_current) thing(maximum_deceleration) thing(maximum_motor_rpm)            \
+                  thing(maximum_torque) thing(motion_profile) thing(motor_rated_current) thing(motor_rated_torque) thing(opmode)           \
+                      thing(polarity) thing(pp) thing(profile_accel) thing(profile_decel) thing(profile_end_velocity)                      \
+                          thing(profile_max_velocity) thing(profile_velocity) thing(pv) thing(target_torque) thing(target_vl)              \
+                              thing(torque_demand) thing(torque_profile_type) thing(torque_slope) thing(tq) thing(velocity_demand)         \
+                                  thing(velocity_error_time) thing(velocity_error_window) thing(velocity_sensor_selector)                  \
+                                      thing(velocity_threshold_time) thing(velocity_threshold_window) thing(vl) thing(vl_accel)            \
+                                          thing(vl_decel) thing(vl_maximum) thing(vl_minimum)


### PR DESCRIPTION
I'm a bit worried that this is approaching the debuggability event horizon, but I *know* that we're over the "keep 13 lists consistent" event horizon, which is demonstrated by the number of items that were not, in fact, in all of the lists that they were supposed to be here.