### PR TITLE
fix(cia402): Add PDO entry limits, and modparams to adjust them

### DIFF
--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -122,6 +122,7 @@ typedef struct {
 /// an array of per-channel options.
 typedef struct {
   int channels;                                     ///< Number of channels;
+  int rxpdolimit, txpdolimit;                       ///< Maximum number of PDO entries allowed per PDO.
   lcec_class_cia402_channel_options_t *channel[8];  ///< Room for 8 channel options.
 } lcec_class_cia402_options_t;
 
@@ -311,8 +312,8 @@ int lcec_cia402_handle_modparam(struct lcec_slave *slave, const lcec_slave_modpa
 lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t const *orig);
 lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_mps);
 lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options);
-int lcec_cia402_add_output_sync(lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
-int lcec_cia402_add_input_sync(lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
+int lcec_cia402_add_output_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
+int lcec_cia402_add_input_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, unsigned int max_denominator);
 
 #define ADD_TYPES_WITH_CIA402_MODPARAMS(types, mps)        \

--- a/src/devices/lcec_class_cia402_opt.h
+++ b/src/devices/lcec_class_cia402_opt.h
@@ -481,6 +481,11 @@
 #define PDO_MP_NAME_vl_decel                  "enableVLDecel"
 #define PDO_MP_NAME_vl_maximum                "enableVLMaximum"
 #define PDO_MP_NAME_vl_minimum                "enableVLMinimum"
+#define PDO_MP_NAME_target_position           ""  // not individually enableable
+#define PDO_MP_NAME_target_velocity           ""  // not individually enableable
+#define PDO_MP_NAME_actual_position           ""  // not individually enableable
+#define PDO_MP_NAME_actual_velocity           ""  // not individually enableable
+#define PDO_MP_NAME_opmode_display            ""  // not individually enableable
 
 // These work around a couple C pre-processor shortcomings.  In a few
 // places, I want to concatenate FOO and BAR into FOOBAR, and then
@@ -568,6 +573,9 @@
   thing(vl_decel);                   \
   thing(vl_maximum);                 \
   thing(vl_minimum);
+
+// This is the list of CiA 402 modes:
+#define FOR_ALL_CIA402_MODES_DO(thing) thing(pp) thing(pv) thing(csp) thing(csv) thing(cst) thing(hm) thing(ip) thing(tq) thing(vl)
 
 // This is all items that have entries in `enabled`.  It is neither a
 // proper superset not proper subset of the above entries.

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -443,10 +443,10 @@ static int lcec_rtec_init(int comp_id, lcec_slave_t *slave) {
   // doesn't map all of the PDOs that we need, so we need to set up
   // our own mappings.
   lcec_syncs_t *syncs = lcec_cia402_init_sync(slave, options);
-  lcec_cia402_add_output_sync(syncs, options);
+  lcec_cia402_add_output_sync(slave, syncs, options);
   // No output PDOs right now.
 
-  lcec_cia402_add_input_sync(syncs, options);
+  lcec_cia402_add_input_sync(slave, syncs, options);
   lcec_syncs_add_pdo_info(syncs, 0x1a02);
   lcec_syncs_add_pdo_entry(syncs, 0x200e, 0x00, 16);  // alarm codes
   lcec_syncs_add_pdo_entry(syncs, 0x200f, 0x00, 16);  // status codes

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -1252,9 +1252,9 @@ static void parseModParamAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
   char *s = NULL;
   switch (modparams->type) {
     case MODPARAM_TYPE_BIT:
-      if ((strcmp("1", pval) == 0) || (strcasecmp("TRUE", pval) == 0)) {
+      if (!strcmp("1", pval) || !strcasecmp("TRUE", pval) || !strcasecmp("ENABLED", pval)) {
         p->value.bit = 1;
-      } else if ((strcmp("0", pval) == 0) || (strcasecmp("FALSE", pval)) == 0) {
+      } else if (!strcmp("0", pval) || !strcasecmp("FALSE", pval) || !strcasecmp("DISABLED", pval)) {
         p->value.bit = 0;
       } else {
         fprintf(stderr, "%s: ERROR: Invalid modparam bit value '%s' for param '%s'\n", modname, pval, pname);

--- a/tests/scottlaird-lcectest1/fulltest.xml
+++ b/tests/scottlaird-lcectest1/fulltest.xml
@@ -154,8 +154,8 @@
     <slave idx="21" type="basic_cia402" vid="0x00004321" pid="0x00002100" name="D22">
       <!--2CL3-EC507(COE)-->
       <modParam name="ciaChannels" value="2"/>
-      <modParam name="ch1enablePP" value="true"/>
-      <modParam name="ch1enablePV" value="true"/>
+      <modParam name="ch1enablePP" value="disabled"/>
+      <modParam name="ch1enablePV" value="disabled"/>
       <modParam name="ch1enableCSP" value="true"/>
       <modParam name="ch1enableHM" value="true"/>
       <modParam name="ch1enableCSP" value="true"/>


### PR DESCRIPTION
As mentioned in #343, it's completely possible (and in fact annoyingly easy) to create a config that tries to map more CiA 402 PDO entries than the hardware can actually support.  Leadshine and Delta, for example, only allow 8 entries per PDO.

I've mostly mitigated this for writable PDOs, but readable ones are still a mess.  A naive config for a Leadshine 2CS3E-D507 currently has 15 or 16 read PDO entries, vs a hardware limit of 8.  Annoyingly, this wasn't actually *failing*, it just failed to work properly, making debugging difficult.

This PR does a few things:
- (In `basic_cia402`) Adds `ciaRxPDOEntryLimit` and `ciaTxPDOEntryLimit` modparams.  This is the maximum number of PDO entries that the CiA 402 code will try to add per PDO.  They default to 8, which is annoyingly common.
- Adds `rxpdolimit` and `txpdolimit` entries in `lcec_class_cia402_options_t`.  This is what the modParam (above) sets.  They default to 0 if unset.  Code treats 0 as unlimited.
- Adds checks in `lcec_add_input_sync()` and `lcec_add_output_sync()` that abort startup if any channel tries to add more PDOs than the configured limit.   See below for error message.
- Adds code in `lcec_configgen` to attempt to detect the number of Rx and Tx PDO entries for CiA 402 hardware, and feeds that into modParams.
- (in `lcec_conf.c`) Adds `enabled` and `disabled` as synonyms for `true` and `false` in boolean modParams.
- (in `lcec_configgen`) Makes `IP` mode default to "disabled" if it's present, rather than "true".  This way it's visible in the generated XML but is hopefully somewhat clear.

Here's the error message that my Leadshine generates, with the more-or-less default config from `lcec_configgen`, but `enablePP` and `enablePV` set to `disabled`:

```
LCEC: slave 0.D22: FAILURE: FAILURE: more input PDO entries configured than your hardware supports.
Axis 1 has 15 PDO entries, vs a configured limit of 8.  You will need to edit your XML
configuration and either remove some <modParam name="enable*"> entries or increase
<modParam name="ciaTxPDOEntryLimit">. Check your CiA 402 slave's hardware manual to determine the
correct limit.

Enabled features that impact this limit are:

  -  <modParam name="enableActualCurrent" value="true">
  -  <modParam name="enableActualFollowingError" value="true">
  -  <modParam name="enableActualTorque" value="true">
  -  <modParam name="enableActualVelocitySensor" value="true">
  -  <modParam name="enableActualVoltage" value="true">
  -  <modParam name="enableControlEffort" value="true">
  -  <modParam name="enableErrorCode" value="true">
  -  <modParam name="enablePositionDemand" value="true">
  -  <modParam name="enableProbeStatus" value="true">
  -  <modParam name="enableTorqueDemand" value="true">
  -  <modParam name="enableVelocityDemand" value="true">

In addition, disabling unneeded CiA 402 modes may help, as some implicitly add additional PDO entries:

  -  <modParam name="enableCSP" value="true">
  -  <modParam name="enableHM" value="true">
```

The lists of modParams are fed from `enabled` using `FOR_ALL_READ_PDOS_DO()` and friends, so they should match the current config *and* not need to be updated when new controls are added.
