### PR TITLE
fix(cia402): fix din/dout mistake

### DIFF
--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -434,9 +434,9 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   if (enabled->enable_digital_output) {
     char *dname;
     data->dout = lcec_dout_allocate_channels(opt->digital_out_channels + 1);
-    if (data->din == NULL) {
+    if (data->dout == NULL) {
       rtapi_print_msg(
-          RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_din_allocate_channels() for slave %s.%s failed\n", slave->master->name, slave->name);
+          RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_dout_allocate_channels() for slave %s.%s failed\n", slave->master->name, slave->name);
       return NULL;
     }
     dname = hal_malloc(sizeof(char[20]));

--- a/tests/scottlaird-lcectest1/fulltest.xml
+++ b/tests/scottlaird-lcectest1/fulltest.xml
@@ -159,9 +159,9 @@
       <modParam name="ch1enableCSP" value="true"/>
       <modParam name="ch1enableHM" value="true"/>
       <modParam name="ch1enableCSP" value="true"/>
-      <modParam name="ch1enableActualCurrent" value="true"/>
-      <modParam name="ch1enableActualTorque" value="true"/>
-      <modParam name="ch1enableDigitalInput" value="true"/>
+<!--      <modParam name="ch1enableActualCurrent" value="true"/> -->
+<!--      <modParam name="ch1enableActualTorque" value="true"/> -->
+      <modParam name="ch1enableDigitalInput" value="true"/> 
       <modParam name="ch1digitalInChannels" value="16"/>
       <modParam name="ch1enableDigitalOutput" value="true"/>
       <modParam name="ch1digitalOutChannels" value="16"/>
@@ -190,7 +190,7 @@
       <modParam name="ch1enableTorqueSlope" value="true"/>
       <modParam name="ch1enableVelocityErrorTime" value="true"/>
       <modParam name="ch1enableVelocityErrorWindow" value="true"/>
-      <modParam name="ch1enableVelocitySensorSelector" value="true"/>
+<!--      <modParam name="ch1enableVelocitySensorSelector" value="true"/> -->
       <modParam name="ch1enableVelocityThresholdTime" value="true"/>
       <modParam name="ch1enableVelocityThresholdWindow" value="true"/>
       <modParam name="ch2enablePP" value="disabled"/>
@@ -198,8 +198,8 @@
       <modParam name="ch2enableCSP" value="true"/>
       <modParam name="ch2enableHM" value="true"/>
       <modParam name="ch2enableCSP" value="true"/>
-      <modParam name="ch2enableActualCurrent" value="true"/>
-      <modParam name="ch2enableActualTorque" value="true"/>
+<!--      <modParam name="ch2enableActualCurrent" value="true"/> -->
+<!--      <modParam name="ch2enableActualTorque" value="true"/>-->
       <modParam name="ch2enableDigitalInput" value="true"/>
       <modParam name="ch2digitalInChannels" value="16"/>
       <modParam name="ch2enableDigitalOutput" value="true"/>
@@ -229,7 +229,7 @@
       <modParam name="ch2enableTorqueSlope" value="true"/>
       <modParam name="ch2enableVelocityErrorTime" value="true"/>
       <modParam name="ch2enableVelocityErrorWindow" value="true"/>
-      <modParam name="ch2enableVelocitySensorSelector" value="true"/>
+<!--      <modParam name="ch2enableVelocitySensorSelector" value="true"/> -->
       <modParam name="ch2enableVelocityThresholdTime" value="true"/>
       <modParam name="ch2enableVelocityThresholdWindow" value="true"/>
           </slave>


### PR DESCRIPTION
Cut-and-paste error; if you enable dout but not din things break.