### PR TITLE
refactor: switch lcec_param* to use param types instead of pin types

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,11 +5,14 @@ all: all-deps realtime user
 -include $(MODINC)
 include Makefile.clean
 
+#CC=g++
+#EXTRA_CFLAGS += -fpermissive
+
 RTLDFLAGS += -Wl,-rpath,$(LIBDIR)
 RTEXTRA_LDFLAGS += -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -L$(LIBDIR) -llinuxcnchal -lethercat -lrt
 
 #EXTRA_CFLAGS += --std=c2x
-EXTRA_CFLAGS += -Wall  # Increase debugging level
+EXTRA_CFLAGS += -Wall # Increase debugging level
 #EXTRA_CFLAGS += -fanalyzer # Use GCC's static analyzer tool, doubles compile time
 
 ## targets

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -65,7 +65,7 @@ static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave);
 // PID.  Feel free to add multiple devices here if they can share the
 // same driver.
 static lcec_typelist_t types[] = {
-    {"basic_cia402", /* fake vid */ -1, /* fake pid */ -1, 0, NULL, lcec_basic_cia402_init, /* modparams implicitly added below */},
+    {"basic_cia402", /* fake vid */ 0xffffffff, /* fake pid */ 0xffffffff, 0, NULL, lcec_basic_cia402_init, /* modparams implicitly added below */},
     {NULL},
 };
 ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_lcec_basic_cia402)

--- a/src/devices/lcec_class_ax5.c
+++ b/src/devices/lcec_class_ax5.c
@@ -42,16 +42,16 @@ static const lcec_pindesc_t slave_diag_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_class_ax5_chan_t, scale), "%s.%s.%s.%ssrv-scale"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_class_ax5_chan_t, vel_scale), "%s.%s.%s.%ssrv-vel-scale"},
     {HAL_U32, HAL_RO, offsetof(lcec_class_ax5_chan_t, pos_resolution), "%s.%s.%s.%ssrv-pos-resolution"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
-static const lcec_pindesc_t slave_fb2_params[] = {
+static const lcec_paramdesc_t slave_fb2_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_class_ax5_chan_t, scale_fb2), "%s.%s.%s.%ssrv-scale-fb2"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static int get_param_flag(lcec_slave_t *slave, int id) {

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -30,9 +30,9 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_BIT, HAL_RW, offsetof(lcec_class_dout_channel_t, invert), "%s.%s.%s.%s-invert"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 /// @brief Allocates a block of memory for holding the result of `count`

--- a/src/devices/lcec_class_enc.c
+++ b/src/devices/lcec_class_enc.c
@@ -39,11 +39,11 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_U32, HAL_RW, offsetof(lcec_class_enc_data_t, raw_home), "%s.%s.%s.%s-raw-home"},
     {HAL_U32, HAL_RO, offsetof(lcec_class_enc_data_t, raw_bits), "%s.%s.%s.%s-raw-bits"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_class_enc_data_t, pprev_scale), "%s.%s.%s.%s-pprev-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static int32_t raw_diff(int shift, uint32_t raw_a, uint32_t raw_b);

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -193,13 +193,13 @@ static const lcec_pindesc_t slave_pins_csp[] = {
 };
 
 // Exposed parameters are identical for both drives and modes
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_deasda_data_t, pos_scale), "%s.%s.%s.pos-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_deasda_data_t, extenc_scale), "%s.%s.%s.extenc-scale"},
     {HAL_U32, HAL_RW, offsetof(lcec_deasda_data_t, pprev), "%s.%s.%s.srv-pulses-per-rev"},
     {HAL_U32, HAL_RW, offsetof(lcec_deasda_data_t, fault_autoreset_cycles), "%s.%s.%s.srv-fault-autoreset-cycles"},
     {HAL_U32, HAL_RW, offsetof(lcec_deasda_data_t, fault_autoreset_retries), "%s.%s.%s.srv-fault-autoreset-retries"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_deasda_in[] = {

--- a/src/devices/lcec_dems300.c
+++ b/src/devices/lcec_dems300.c
@@ -121,10 +121,10 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_BIT, HAL_RW, offsetof(lcec_dems300_data_t, auto_fault_reset), "%s.%s.%s.auto-fault-reset"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_dems300_data_t, vel_scale), "%s.%s.%s.vel-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_dems300_in[] = {

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -95,13 +95,13 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, freq), "%s.%s.%s.stp-freq"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, maxvel), "%s.%s.%s.stp-maxvel"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, maxaccel_fall), "%s.%s.%s.stp-maxaccel-fall"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, maxaccel_rise), "%s.%s.%s.stp-maxaccel-rise"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el2521_data_t, pos_scale), "%s.%s.%s.stp-pos-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_el2521_in[] = {

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -246,11 +246,11 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el70x1_data_t, stm_pos_scale), "%s.%s.%s.srv-pos-scale"},
     {HAL_BIT, HAL_RW, offsetof(lcec_el70x1_data_t, auto_fault_reset), "%s.%s.%s.auto-fault-reset"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el70x1_data_t, auto_reduce_tourque_delay), "%s.%s.%s.auto-reduce-torque-delay"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static int lcec_el7031_init(int comp_id, lcec_slave_t *slave) {

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -130,7 +130,7 @@ static const lcec_pindesc_t slave_pins_el7201_9014[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, scale), "%s.%s.%s.scale"},
     {HAL_U32, HAL_RO, offsetof(lcec_el7211_data_t, vel_resolution), "%s.%s.%s.vel-resolution"},
     {HAL_U32, HAL_RO, offsetof(lcec_el7211_data_t, pos_resolution), "%s.%s.%s.pos-resolution"},
@@ -138,7 +138,7 @@ static const lcec_pindesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, max_vel), "%s.%s.%s.max-vel"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, max_accel), "%s.%s.%s.max-accel"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, at_speed_window), "%s.%s.%s.at-speed-window"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_el7211_in_pos[] = {

--- a/src/devices/lcec_em7004.c
+++ b/src/devices/lcec_em7004.c
@@ -128,9 +128,9 @@ static const lcec_pindesc_t slave_dout_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_dout_params[] = {
+static const lcec_paramdesc_t slave_dout_params[] = {
     {HAL_BIT, HAL_RW, offsetof(lcec_em7004_dout_t, invert), "%s.%s.%s.dout-%d-invert"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static const lcec_pindesc_t slave_aout_pins[] = {

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -210,7 +210,7 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_00_scale), "%s.%s.%s.axis0-enc-scale"},
+static const lcec_paramdesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_00_scale), "%s.%s.%s.axis0-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_01_scale), "%s.%s.%s.axis1-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_02_scale), "%s.%s.%s.axis2-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_03_scale), "%s.%s.%s.axis3-enc-scale"},
@@ -234,7 +234,8 @@ static const lcec_pindesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_
     {HAL_BIT, HAL_RW, offsetof(lcec_fr4000_data_t, update_03_position), "%s.%s.%s.axis3-update-position"},
     {HAL_BIT, HAL_RW, offsetof(lcec_fr4000_data_t, update_04_position), "%s.%s.%s.axis4-update-position"},
 
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED},
+};
 
 static ec_pdo_entry_info_t lcec_fr4000_pdo_entries[] = {
     {0x7000, 0x01, 16}, /* Spindle vel */

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -161,10 +161,10 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_omrg5_data_t, pos_scale), "%s.%s.%s.pos-scale"},
     {HAL_BIT, HAL_RW, offsetof(lcec_omrg5_data_t, auto_fault_reset), "%s.%s.%s.auto-fault-reset"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_omrg5_in[] = {

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -102,20 +102,23 @@ static const lcec_pindesc_t enc_pins[] = {{HAL_BIT, HAL_IO, offsetof(lcec_ph3lm2
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_valid), "%s.%s.%s.%s-latch-valid"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_state), "%s.%s.%s.%s-latch-state"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_state_not), "%s.%s.%s.%s-latch-state-not"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},};
 
-static const lcec_pindesc_t enc_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_ph3lm2rm_enc_data_t, scale), "%s.%s.%s.%s-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+static const lcec_paramdesc_t enc_params[] = {
+  {HAL_FLOAT, HAL_RW, offsetof(lcec_ph3lm2rm_enc_data_t, scale), "%s.%s.%s.%s-scale"},
+  {HAL_TYPE_UNSPECIFIED},
+};
 
 static const lcec_pindesc_t lm_pins[] = {{HAL_U32, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level), "%s.%s.%s.%s-signal-level"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_warn), "%s.%s.%s.%s-signal-level-warn"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_err), "%s.%s.%s.%s-signal-level-err"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},};
 
-static const lcec_pindesc_t lm_params[] = {
+static const lcec_paramdesc_t lm_params[] = {
     {HAL_U32, HAL_RW, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_warn_val), "%s.%s.%s.%s-signal-level-warn-val"},
     {HAL_U32, HAL_RW, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_err_val), "%s.%s.%s.%s-signal-level-err-val"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED},
+};
 
 static const lcec_pindesc_t rm_pins[] = {{HAL_BIT, HAL_IN, offsetof(lcec_ph3lm2rm_rm_data_t, latch_sel_idx), "%s.%s.%s.%s-latch-sel-idx"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -159,12 +159,13 @@ static const lcec_pindesc_t slave_pins[] = {{HAL_FLOAT, HAL_IN, offsetof(lcec_st
     {HAL_BIT, HAL_IN, offsetof(lcec_stmds5k_data_t, fast_ramp), "%s.%s.%s.srv-fast-ramp"},
     {HAL_BIT, HAL_IN, offsetof(lcec_stmds5k_data_t, brake), "%s.%s.%s.srv-brake"}, {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
 
-static const lcec_pindesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, pos_scale), "%s.%s.%s.srv-pos-scale"},
+static const lcec_paramdesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, pos_scale), "%s.%s.%s.srv-pos-scale"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, torque_reference), "%s.%s.%s.srv-torque-ref"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, speed_max_rpm), "%s.%s.%s.srv-max-rpm"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, speed_max_rpm_sp), "%s.%s.%s.srv-max-rpm-sp"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, extenc_scale), "%s.%s.%s.extenc-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED},
+};
 
 static const lcec_stmds5k_syncs_t lcec_stmds5k_syncs_tmpl = {.out_ch1 =
                                                                  {

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -23,6 +23,10 @@
 #ifndef _LCEC_H_
 #define _LCEC_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ecrt.h"
 #include "hal.h"
 #include "lcec_conf.h"
@@ -30,6 +34,10 @@
 #include "rtapi_ctype.h"
 #include "rtapi_math.h"
 #include "rtapi_string.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 // list macros
 #define LCEC_LIST_APPEND(first, last, item) \
@@ -106,7 +114,7 @@ typedef struct {
 
 /// @brief Definition of a device that LinuxCNC-Ethercat supports.
 typedef struct {
-  char *name;                             ///< The device's name ("EL1008")
+  const char *name;                             ///< The device's name ("EL1008")
   uint32_t vid;                           ///< The EtherCAT vendor ID
   uint32_t pid;                           ///< The EtherCAT product ID
   int is_fsoe_logic;                      ///< Does this device use Safety-over-EtherCAT?
@@ -272,6 +280,14 @@ typedef struct {
   const char *fmt;    ///< Format string for generating pin names via sprintf().
 } lcec_pindesc_t;
 
+/// @brief HAL pin description.
+typedef struct {
+  hal_type_t type;    ///< HAL type of this pin (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
+  hal_param_dir_t dir;  ///< Direction for this pin (`HAL_IN`, `HAL_OUT`, or `HAL_IO`).
+  int offset;         ///< Offset for this pin's data in `hal_data`.
+  const char *fmt;    ///< Format string for generating pin names via sprintf().
+} lcec_paramdesc_t;
+
 /// @brief Sync manager configuration.
 typedef struct {
   lcec_slave_t *slave; ///< For debugging messages
@@ -323,8 +339,8 @@ int lcec_write_sdo32_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subin
 
 int lcec_pin_newf(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_addr, const char *fmt, ...);
 int lcec_pin_newf_list(void *base, const lcec_pindesc_t *list, ...);
-int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, ...);
-int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...);
+int lcec_param_newf(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, ...);
+int lcec_param_newf_list(void *base, const lcec_paramdesc_t *list, ...);
 
 void copy_fsoe_data(lcec_slave_t *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
 void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) __attribute__((nonnull));
@@ -333,8 +349,8 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
 void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);
 
 const lcec_typelist_t *lcec_findslavetype(const char *name) __attribute__((nonnull));
-void lcec_addtype(lcec_typelist_t *type, char *sourcefile) __attribute__((nonnull));
-void lcec_addtypes(lcec_typelist_t types[], char *sourcefile) __attribute__((nonnull));
+void lcec_addtype(lcec_typelist_t *type, const char *sourcefile) __attribute__((nonnull));
+void lcec_addtypes(lcec_typelist_t types[], const char *sourcefile) __attribute__((nonnull));
 
 int lcec_lookupint(const lcec_lookuptable_int_t *table, const char *key, int default_value) __attribute__((nonnull));
 int lcec_lookupint_i(const lcec_lookuptable_int_t *table, const char *key, int default_value) __attribute__((nonnull));

--- a/src/lcec_devicelist.c
+++ b/src/lcec_devicelist.c
@@ -25,7 +25,7 @@ lcec_typelinkedlist_t *typeslist = NULL;
 
 /// @brief Register a single slave type with LinuxCNC-Ethercat.
 /// @param[in] type the definition of the device type to add.
-void lcec_addtype(lcec_typelist_t *type, char *sourcefile) {
+void lcec_addtype(lcec_typelist_t *type, const char *sourcefile) {
   lcec_typelinkedlist_t *t, *l;
 
   // using malloc instead of hal_malloc because this can be called
@@ -58,7 +58,7 @@ void lcec_addtype(lcec_typelist_t *type, char *sourcefile) {
 
 /// @brief Register an array of new slave types with LinuxCNC-Ethercat.
 /// @param[in] types A list of types to add, terminated with a `NULL`.
-void lcec_addtypes(lcec_typelist_t types[], char *sourcefile) {
+void lcec_addtypes(lcec_typelist_t types[], const char *sourcefile) {
   lcec_typelist_t *type;
 
   for (type = types; type->name != NULL; type++) {

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -22,8 +22,8 @@
 
 #include "lcec.h"
 
-static int lcec_param_newfv(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, va_list ap);
-static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list ap);
+static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, va_list ap);
+static int lcec_param_newfv_list(void *base, const lcec_paramdesc_t *list, va_list ap);
 int lcec_comp_id = -1;
 
 /// @brief Find the slave with a specified index underneath a specific master.
@@ -474,7 +474,7 @@ int lcec_read_idn(lcec_slave_t *slave, uint8_t drive_no, uint16_t idn, uint8_t *
   return 0;
 }
 
-static int lcec_param_newfv(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, va_list ap) {
+static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, va_list ap) {
   char name[HAL_NAME_LEN + 1];
   int sz;
   int err;
@@ -512,7 +512,7 @@ static int lcec_param_newfv(hal_type_t type, hal_pin_dir_t dir, void *data_addr,
 }
 
 /// @brief Create a new LinuxCNC `param` dynamically.
-int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, ...) {
+int lcec_param_newf(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, ...) {
   va_list ap;
   int err;
 
@@ -523,10 +523,10 @@ int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const c
   return err;
 }
 
-static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list ap) {
+static int lcec_param_newfv_list(void *base, const lcec_paramdesc_t *list, va_list ap) {
   va_list ac;
   int err;
-  const lcec_pindesc_t *p;
+  const lcec_paramdesc_t *p;
 
   for (p = list; p->type != HAL_TYPE_UNSPECIFIED; p++) {
     va_copy(ac, ap);
@@ -541,7 +541,7 @@ static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list
 }
 
 /// @brief Create a list of new LinuxCNC params dynamically, using sprintf() to create names.
-int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...) {
+int lcec_param_newf_list(void *base, const lcec_paramdesc_t *list, ...) {
   va_list ap;
   int err;
 

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -51,12 +51,12 @@ static const lcec_pindesc_t master_pins[] = {
 };
 
 /// @brief Master params
-static const lcec_pindesc_t master_params[] = {
+static const lcec_paramdesc_t master_params[] = {
 #ifdef RTAPI_TASK_PLL_SUPPORT
     {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, pll_step), "%s.pll-step"},
     {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, pll_max_err), "%s.pll-max-err"},
 #endif
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 /// @brief Basic Slave pins


### PR DESCRIPTION
This is part of a set of PRs to make LCEC compliable with a C++ compiler.  The goal isn't to move LCEC to C++, but rather to be able to make use of C++'s generally-better error checking tools.

This fixes a bunch of minor issues around `lcec_param*` functions expecting `lcec_pin*` parameters but then interpreting them as `hal_param*`.  This is mostly workable in C, but results in the possibility of subtle errors.  This splits the two cases apart so we can enforce types better and catch problems.