### PR TITLE
fix(cia402): Actually make reading from PDOs work, and fix VL mappings

### DIFF
--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -111,8 +111,6 @@ typedef struct {
   int enable_velocity_sensor_selector;
   int enable_velocity_threshold_time;
   int enable_velocity_threshold_window;
-  int enable_vl_accel;
-  int enable_vl_decel;
   int enable_vl_maximum;
   int enable_vl_minimum;
 } lcec_class_cia402_channel_options_t;
@@ -195,8 +193,6 @@ typedef struct {
   int enable_velocity_threshold_time;
   int enable_velocity_threshold_window;
   int enable_vl;
-  int enable_vl_accel;
-  int enable_vl_decel;
   int enable_vl_maximum;
   int enable_vl_minimum;
 } lcec_class_cia402_enabled_t;
@@ -251,10 +247,8 @@ typedef struct {
   SDO_PIN(velocity_sensor_selector, hal_s32_t);
   SDO_PIN(velocity_threshold_time, hal_u32_t);
   SDO_PIN(velocity_threshold_window, hal_u32_t);
-  SDO_PIN(vl_accel, hal_u32_t);
-  SDO_PIN(vl_decel, hal_u32_t);
-  SDO_PIN(vl_maximum, hal_s32_t);
-  SDO_PIN(vl_minimum, hal_s32_t);
+  SDO_PIN(vl_maximum, hal_u32_t);
+  SDO_PIN(vl_minimum, hal_u32_t);
 
   // In.
   PDO_PIN(statusword, hal_u32_t);
@@ -369,7 +363,9 @@ lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, unsigned int max
 #define CIA402_MP_GEAR_RATIO           0x1210
 #define CIA402_MP_FEED_RATIO           0x1220
 #define CIA402_MP_EGEAR_RATIO          0x1230
-// next is 0x1260
+#define CIA402_MP_VL_ACCEL             0x1260
+#define CIA402_MP_VL_DECEL             0x1270
+// next is 0x1280
 
 // "enable" modParams
 #define CIA402_MP_ENABLE_actual_current            0x22d0
@@ -420,8 +416,6 @@ lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, unsigned int max
 #define CIA402_MP_ENABLE_velocity_threshold_time   0x2270
 #define CIA402_MP_ENABLE_velocity_threshold_window 0x2280
 #define CIA402_MP_ENABLE_vl                        0x2060
-#define CIA402_MP_ENABLE_vl_accel                  0x2360
-#define CIA402_MP_ENABLE_vl_decel                  0x2370
 #define CIA402_MP_ENABLE_vl_maximum                0x2350
 #define CIA402_MP_ENABLE_vl_minimum                0x2340
 #define CIA402_MP_ENABLE_opmode                    0x23b0

--- a/src/devices/lcec_class_cia402_opt.h
+++ b/src/devices/lcec_class_cia402_opt.h
@@ -116,8 +116,6 @@
 #define PDO_IDX_OFFSET_velocity_sensor_selector  0x6a
 #define PDO_IDX_OFFSET_velocity_threshold_time   0x70
 #define PDO_IDX_OFFSET_velocity_threshold_window 0x6f
-#define PDO_IDX_OFFSET_vl_accel                  0x48
-#define PDO_IDX_OFFSET_vl_decel                  0x49
 #define PDO_IDX_OFFSET_vl_maximum                0x46
 #define PDO_IDX_OFFSET_vl_minimum                0x46
 
@@ -177,8 +175,6 @@
 #define PDO_SIDX_velocity_sensor_selector  0
 #define PDO_SIDX_velocity_threshold_time   0
 #define PDO_SIDX_velocity_threshold_window 0
-#define PDO_SIDX_vl_accel                  0
-#define PDO_SIDX_vl_decel                  0
 #define PDO_SIDX_vl_maximum                2
 #define PDO_SIDX_vl_minimum                1
 
@@ -238,10 +234,8 @@
 #define PDO_PIN_TYPE_velocity_sensor_selector  HAL_S32
 #define PDO_PIN_TYPE_velocity_threshold_time   HAL_U32
 #define PDO_PIN_TYPE_velocity_threshold_window HAL_U32
-#define PDO_PIN_TYPE_vl_accel                  HAL_U32
-#define PDO_PIN_TYPE_vl_decel                  HAL_U32
-#define PDO_PIN_TYPE_vl_maximum                HAL_S32
-#define PDO_PIN_TYPE_vl_minimum                HAL_S32
+#define PDO_PIN_TYPE_vl_maximum                HAL_U32
+#define PDO_PIN_TYPE_vl_minimum                HAL_U32
 
 // Pin names
 #define PDO_PIN_NAME_actual_current            "actual-current"
@@ -296,8 +290,6 @@
 #define PDO_PIN_NAME_velocity_sensor_selector  "velocity-sensor-selector"
 #define PDO_PIN_NAME_velocity_threshold_time   "velocity-threshold-time"
 #define PDO_PIN_NAME_velocity_threshold_window "velocity-threshold-window"
-#define PDO_PIN_NAME_vl_accel                  "vl-accel"
-#define PDO_PIN_NAME_vl_decel                  "vl-decel"
 #define PDO_PIN_NAME_vl_maximum                "vl-maximum"
 #define PDO_PIN_NAME_vl_minimum                "vl-minimum"
 
@@ -356,10 +348,8 @@
 #define PDO_BITS_velocity_sensor_selector  16
 #define PDO_BITS_velocity_threshold_time   16
 #define PDO_BITS_velocity_threshold_window 16
-#define PDO_BITS_vl_accel                  32
-#define PDO_BITS_vl_decel                  32
-#define PDO_BITS_vl_maximum                16
-#define PDO_BITS_vl_minimum                16
+#define PDO_BITS_vl_maximum                32
+#define PDO_BITS_vl_minimum                32
 
 // The signeded-ness of each object.  This should match
 // PDO_PIN_TYPE_foo, but we don't *necessarily* have PDO_PIN_TYPE_foo
@@ -416,10 +406,8 @@
 #define PDO_SIGN_velocity_sensor_selector  S
 #define PDO_SIGN_velocity_threshold_time   U
 #define PDO_SIGN_velocity_threshold_window U
-#define PDO_SIGN_vl_accel                  U
-#define PDO_SIGN_vl_decel                  U
-#define PDO_SIGN_vl_maximum                S
-#define PDO_SIGN_vl_minimum                S
+#define PDO_SIGN_vl_maximum                U
+#define PDO_SIGN_vl_minimum                U
 
 // define modParam names for each setting.
 #define PDO_MP_NAME_actual_current            "enableActualCurrent"
@@ -477,8 +465,6 @@
 #define PDO_MP_NAME_velocity_threshold_time   "enableVelocityThresholdTime"
 #define PDO_MP_NAME_velocity_threshold_window "enableVelocityThresholdWindow"
 #define PDO_MP_NAME_vl                        "enableVL"
-#define PDO_MP_NAME_vl_accel                  "enableVLAccel"
-#define PDO_MP_NAME_vl_decel                  "enableVLDecel"
 #define PDO_MP_NAME_vl_maximum                "enableVLMaximum"
 #define PDO_MP_NAME_vl_minimum                "enableVLMinimum"
 #define PDO_MP_NAME_target_position           ""  // not individually enableable
@@ -569,8 +555,6 @@
   thing(velocity_sensor_selector);   \
   thing(velocity_threshold_time);    \
   thing(velocity_threshold_window);  \
-  thing(vl_accel);                   \
-  thing(vl_decel);                   \
   thing(vl_maximum);                 \
   thing(vl_minimum);
 
@@ -591,7 +575,6 @@
                           thing(profile_max_velocity) thing(profile_velocity) thing(pv) thing(target_torque) thing(target_vl)              \
                               thing(torque_demand) thing(torque_profile_type) thing(torque_slope) thing(tq) thing(velocity_demand)         \
                                   thing(velocity_error_time) thing(velocity_error_window) thing(velocity_sensor_selector)                  \
-                                      thing(velocity_threshold_time) thing(velocity_threshold_window) thing(vl) thing(vl_accel)            \
-                                          thing(vl_decel) thing(vl_maximum) thing(vl_minimum) thing(positioning_window)                    \
+                                      thing(velocity_threshold_time) thing(velocity_threshold_window) thing(vl) thing(vl_maximum) thing(vl_minimum) thing(positioning_window)                    \
                                               thing(positioning_time) thing(maximum_slippage) thing(probe_status) thing(position_demand)   \
                                                   thing(control_effort)

--- a/tests/scottlaird-lcectest1/cia402-all.xml
+++ b/tests/scottlaird-lcectest1/cia402-all.xml
@@ -213,14 +213,14 @@
       <!--3G3AX-MX2-ECT EtherCAT Communication Unit for 3G3MX2-->
       <modParam name="ciaRxPDOEntryLimit" value="8"/>
       <modParam name="ciaTxPDOEntryLimit" value="8"/>
+      <modParam name="enablePP" value="false"/>
+      <modParam name="enablePV" value="false"/>
       <modParam name="enableVL" value="true"/>
-      <modParam name="enableDemandVL" value="true"/>
+      <!-- <modParam name="enableDemandVL" value="true"/>-->
       <modParam name="digitalInChannels" value="16"/>
       <modParam name="digitalOutChannels" value="16"/>
       <modParam name="enableErrorCode" value="true"/>
-      <modParam name="enableTargetVL" value="true"/>
-      <modParam name="enableVLAccel" value="true"/>
-      <modParam name="enableVLDecel" value="true"/>
+      <!-- <modParam name="enableTargetVL" value="true"/> -->
       <modParam name="enableVLMaximum" value="true"/>
       <modParam name="enableVLMinimum" value="true"/>
     </slave>


### PR DESCRIPTION
This fixes a couple problems.  First, a bunch of the VL-mode params don't match what my MX2 expects to see.  A couple were the wrong size, and a couple are actually ratios and need extra code.  Switched to modparams for now for those, although I guess we could do floats if we really wanted to.  Hmm. 

Second, somehow in the middle of refactoring, I completely stopped registering readable PDOs.  The first symptom is that `opmode-display` was always 0.  This should be fixed now.

Issue #180 
