### PR TITLE
fix(cia402): Assorted bugfixes to get CSP working

### DIFF
--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -39,12 +39,14 @@
 #define M_CHANNELS   0
 #define M_RXPDOLIMIT 1
 #define M_TXPDOLIMIT 2
+#define M_PDOINCREMENT 3
 
 /// @brief Device-specific modparam settings available via XML.
 static const lcec_modparam_desc_t modparams_lcec_basic_cia402[] = {
     {"ciaChannels", M_CHANNELS, MODPARAM_TYPE_U32},
     {"ciaRxPDOEntryLimit", M_RXPDOLIMIT, MODPARAM_TYPE_U32},
     {"ciaTxPDOEntryLimit", M_TXPDOLIMIT, MODPARAM_TYPE_U32},
+    {"pdoIncrement", M_PDOINCREMENT, MODPARAM_TYPE_U32},
     // XXXX, add device-specific modparams here.
     {NULL},
 };
@@ -100,6 +102,9 @@ static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *op
       case M_TXPDOLIMIT:
         options->txpdolimit = p->value.u32;
         break;
+      case M_PDOINCREMENT:
+	options->pdo_increment = p->value.u32;
+	break;
       default:
         // Handle cia402 generic modparams
         v = lcec_cia402_handle_modparam(slave, p, options);

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -144,6 +144,7 @@ lcec_class_cia402_channels_t *lcec_cia402_allocate_channels(int count) {
 lcec_class_cia402_options_t *lcec_cia402_options(void) {
   lcec_class_cia402_options_t *opts = LCEC_HAL_ALLOCATE(lcec_class_cia402_options_t);
   opts->channels = 1;
+  opts->pdo_increment = 1;
 
   for (int channel = 0; channel < 8; channel++) {
     opts->channel[channel] = lcec_cia402_channel_options();
@@ -214,10 +215,11 @@ int lcec_cia402_add_output_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_c
   for (int channel = 0; channel < options->channels; channel++) {
     unsigned int offset = 0x6000 + 0x800 * channel;
     int entrycount = syncs->pdo_entry_count;
+    int channelbase = 0x1600 + channel * options->pdo_increment;
 
     lcec_class_cia402_enabled_t *enabled = lcec_cia402_enabled(options->channel[channel]);
 
-    lcec_syncs_add_pdo_info(syncs, 0x1600 + channel);
+    lcec_syncs_add_pdo_info(syncs, channelbase);
     lcec_syncs_add_pdo_entry(syncs, offset + 0x40, 0x00, 16);  // Control word
 
     // Map all writeable PDOs, plus `digital_output` which is special
@@ -259,10 +261,11 @@ int lcec_cia402_add_input_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_cl
   for (int channel = 0; channel < options->channels; channel++) {
     unsigned int offset = 0x6000 + 0x800 * channel;
     int entrycount = syncs->pdo_entry_count;
+    int channelbase = 0x1a00 + channel * options->pdo_increment;
 
     lcec_class_cia402_enabled_t *enabled = lcec_cia402_enabled(options->channel[channel]);
 
-    lcec_syncs_add_pdo_info(syncs, 0x1a00 + channel);
+    lcec_syncs_add_pdo_info(syncs, channelbase);
     lcec_syncs_add_pdo_entry(syncs, offset + 0x41, 0x00, 16);  // Status word
 
     // Map all readable PDOs, plus `digital_input` which is special

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -55,6 +55,7 @@ typedef struct {
   int digital_in_channels;
   int digital_out_channels;
 
+
   int enable_opmode;  ///< Enable opmode and opmode-display.  They're technically optional in the spec.
   int enable_pp;      ///< If true, enable required PP-mode pins: `-actual-position` and `-target-position`.
   int enable_pv;      ///< If true, enable required PV-mode pins: `-actual-velocity` and `-target-velocity`.
@@ -121,6 +122,7 @@ typedef struct {
 typedef struct {
   int channels;                                     ///< Number of channels;
   int rxpdolimit, txpdolimit;                       ///< Maximum number of PDO entries allowed per PDO.
+  int pdo_increment;
   lcec_class_cia402_channel_options_t *channel[8];  ///< Room for 8 channel options.
 } lcec_class_cia402_options_t;
 

--- a/tests/scottlaird-lcectest1/cia402-all.hal
+++ b/tests/scottlaird-lcectest1/cia402-all.hal
@@ -1,29 +1,102 @@
+loadrt [KINS]KINEMATICS
+loadrt [EMCMOT]EMCMOT servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[KINS]JOINTS
+
 loadusr -W lcec_conf cia402-all.xml
 loadrt lcec
-#loadrt cia402 count=2
+loadrt cia402 count=5
 
-loadrt threads name1=servo-thread period1=1000000
+loadrt pid names=0-pid,1-pid,2-pid
+
+#loadrt threads name1=servo-thread period1=1000000
 addf lcec.read-all servo-thread
-#addf cia402.0.read-all servo-thread
+addf cia402.0.read-all servo-thread
+addf cia402.1.read-all servo-thread
+addf cia402.2.read-all servo-thread
+addf cia402.3.read-all servo-thread
+addf cia402.4.read-all servo-thread
 
+addf motion-command-handler servo-thread
+addf motion-controller servo-thread
+addf 0-pid.do-pid-calcs servo-thread
+addf 1-pid.do-pid-calcs servo-thread
+addf 2-pid.do-pid-calcs servo-thread
+
+addf cia402.0.write-all servo-thread
+addf cia402.1.write-all servo-thread
+addf cia402.2.write-all servo-thread
+addf cia402.3.write-all servo-thread
+addf cia402.4.write-all servo-thread
 addf lcec.write-all servo-thread
-#addf cia402.0.write-all servo-thread
+
 
 show
 
-#net rtec-statusword lcec.0.D22.srv-1-cia-statusword => cia402.0.statusword
-#net rtec-opmode-display lcec.0.D22.srv-1-opmode-display => cia402.0.opmode-display
-#net rtec-drv-act-pos lcec.0.D22.srv-1-actual-position => cia402.0.drv-actual-position
-#net rtec-drv-act-velo lcec.0.D22.srv-1-actual-velocity => cia402.0.drv-actual-velocity
-#
-#net rtec-controlword cia402.0.controlword => lcec.0.D22.srv-1-cia-controlword
-#net rtec-modes-of-operation cia402.0.opmode => lcec.0.D22.srv-1-opmode
-#net rtec-drv-target-pos cia402.0.drv-target-position => lcec.0.D22.srv-1-target-position
-#net rtec-drv-target-velo cia402.0.drv-target-velocity => lcec.0.D22.srv-1-target-velocity
+net ls1-statusword lcec.0.ls-2cl3.srv-1-cia-statusword => cia402.0.statusword
+net ls1-opmode-display lcec.0.ls-2cl3.srv-1-opmode-display => cia402.0.opmode-display
+net ls1-drv-act-pos lcec.0.ls-2cl3.srv-1-actual-position => cia402.0.drv-actual-position
+net ls1-drv-act-velo lcec.0.ls-2cl3.srv-1-actual-velocity => cia402.0.drv-actual-velocity
+net ls1-controlword cia402.0.controlword => lcec.0.ls-2cl3.srv-1-cia-controlword
+net ls1-modes-of-operation cia402.0.opmode => lcec.0.ls-2cl3.srv-1-opmode
+net ls1-drv-target-pos cia402.0.drv-target-position => lcec.0.ls-2cl3.srv-1-target-position
+net ls1-drv-target-velo cia402.0.drv-target-velocity => lcec.0.ls-2cl3.srv-1-target-velocity
+net 0-home-index <= joint.0.index-enable => cia402.0.home
+net 0-enable <= joint.0.amp-enable-out => cia402.0.enable
+net 0-amp-fault => joint.0.amp-fault-in <= cia402.0.drv-fault
+net 0-pos-cmd <= joint.0.motor-pos-cmd => cia402.0.pos-cmd
+net 0-pos-fb => joint.0.motor-pos-fb <= cia402.0.pos-fb
 
-#setp cia402.0.csp-mode 1  # velocity mode, for testing.
+net ls2-statusword lcec.0.ls-2cl3.srv-2-cia-statusword => cia402.1.statusword
+net ls2-opmode-display lcec.0.ls-2cl3.srv-2-opmode-display => cia402.1.opmode-display
+net ls2-drv-act-pos lcec.0.ls-2cl3.srv-2-actual-position => cia402.1.drv-actual-position
+net ls2-drv-act-velo lcec.0.ls-2cl3.srv-2-actual-velocity => cia402.1.drv-actual-velocity
+net ls2-controlword cia402.1.controlword => lcec.0.ls-2cl3.srv-2-cia-controlword
+net ls2-modes-of-operation cia402.1.opmode => lcec.0.ls-2cl3.srv-2-opmode
+net ls2-drv-target-pos cia402.1.drv-target-position => lcec.0.ls-2cl3.srv-2-target-position
+net ls2-drv-target-velo cia402.1.drv-target-velocity => lcec.0.ls-2cl3.srv-2-target-velocity
 
-start
+net rtdrv-statusword lcec.0.rt-ect60.srv-cia-statusword => cia402.3.statusword
+net rtdrv-opmode-display lcec.0.rt-ect60.srv-opmode-display => cia402.3.opmode-display
+net rtdrv-drv-act-pos lcec.0.rt-ect60.srv-actual-position => cia402.3.drv-actual-position
+net rtdrv-drv-act-velo lcec.0.rt-ect60.srv-actual-velocity => cia402.3.drv-actual-velocity
+net rtdrv-controlword cia402.3.controlword => lcec.0.rt-ect60.srv-cia-controlword
+net rtdrv-modes-of-operation cia402.3.opmode => lcec.0.rt-ect60.srv-opmode
+net rtdrv-drv-target-pos cia402.3.drv-target-position => lcec.0.rt-ect60.srv-target-position
+net rtdrv-drv-target-velo cia402.3.drv-target-velocity => lcec.0.rt-ect60.srv-target-velocity
+net 2-home-index <= joint.2.index-enable => cia402.3.home
+net 2-enable <= joint.2.amp-enable-out => cia402.3.enable
+net 2-amp-fault => joint.2.amp-fault-in <= cia402.3.drv-fault
+net 2-pos-cmd <= joint.2.motor-pos-cmd => cia402.3.pos-cmd
+net 2-pos-fb => joint.2.motor-pos-fb <= cia402.3.pos-fb
 
-# don't exit immediately
-waitusr lcec_conf
+#net rtect-statusword lcec.0.rt-ect60.srv-cia-statusword => cia402.2.statusword
+#net rtect-opmode-display lcec.0.rt-ect60.srv-opmode-display => cia402.2.opmode-display
+#net rtect-drv-act-pos lcec.0.rt-ect60.srv-actual-position => cia402.2.drv-actual-position
+#net rtect-drv-act-velo lcec.0.rt-ect60.srv-actual-velocity => cia402.2.drv-actual-velocity
+#net rtect-controlword cia402.2.controlword => lcec.0.rt-ect60.srv-cia-controlword
+#net rtect-modes-of-operation cia402.2.opmode => lcec.0.rt-ect60.srv-opmode
+#net rtect-drv-target-pos cia402.2.drv-target-position => lcec.0.rt-ect60.srv-target-position
+#net rtect-drv-target-velo cia402.2.drv-target-velocity => lcec.0.rt-ect60.srv-target-velocity
+
+net rtecr1-statusword lcec.0.rt-ecr60x2.srv-2-cia-statusword => cia402.4.statusword
+net rtecr1-opmode-display lcec.0.rt-ecr60x2.srv-2-opmode-display => cia402.4.opmode-display
+net rtecr1-drv-act-pos lcec.0.rt-ecr60x2.srv-2-actual-position => cia402.4.drv-actual-position
+net rtecr1-drv-act-velo lcec.0.rt-ecr60x2.srv-2-actual-velocity => cia402.4.drv-actual-velocity
+net rtecr1-controlword cia402.4.controlword => lcec.0.rt-ecr60x2.srv-2-cia-controlword
+net rtecr1-modes-of-operation cia402.4.opmode => lcec.0.rt-ecr60x2.srv-2-opmode
+net rtecr1-drv-target-pos cia402.4.drv-target-position => lcec.0.rt-ecr60x2.srv-2-target-position
+net rtecr1-drv-target-velo cia402.4.drv-target-velocity => lcec.0.rt-ecr60x2.srv-2-target-velocity
+net 1-home-index <= joint.1.index-enable => cia402.4.home
+net 1-enable <= joint.1.amp-enable-out => cia402.4.enable
+net 1-amp-fault => joint.1.amp-fault-in <= cia402.4.drv-fault
+net 1-pos-cmd <= joint.1.motor-pos-cmd => cia402.4.pos-cmd
+net 1-pos-fb => joint.1.motor-pos-fb <= cia402.4.pos-fb
+
+
+setp cia402.0.csp-mode 1
+setp cia402.1.csp-mode 1
+setp cia402.2.csp-mode 1
+setp cia402.3.csp-mode 1
+setp cia402.4.csp-mode 1
+
+net emc-enable => iocontrol.0.emc-enable-in
+sets emc-enable 1

--- a/tests/scottlaird-lcectest1/cia402-all.ini
+++ b/tests/scottlaird-lcectest1/cia402-all.ini
@@ -1,0 +1,181 @@
+[EMC]
+# The version string for this INI file.
+VERSION = 1.1
+
+MACHINE = EtherCAT Machine
+DEBUG = 1
+
+[TRAJ]
+
+HOME = 0 0 0
+COORDINATES = XYZ
+LINEAR_UNITS = mm
+ANGULAR_UNITS = deg
+DEFAULT_LINEAR_VELOCITY = 50
+MAX_LINEAR_VELOCITY = 100
+DEFAULT_ANGULAR_VELOCITY = 360
+MAX_ANGULAR_VELOCITY = 720
+POSITION_FILE = position.txt
+
+[HAL]
+HALFILE=cia402-all.hal
+HALUI = halui
+
+[HALUI]
+
+
+[EMCIO]
+
+# Name of IO controller program, e.g., iov2 has tool changer stuff
+EMCIO = 		iov2
+
+# cycle time, in seconds
+CYCLE_TIME =    0.100
+
+# tool table file
+TOOL_TABLE =    cia402.tbl
+TOOL_CHANGE_POSITION = 0 0 50.8
+#RANDOM_TOOLCHANGER
+
+[DISPLAY]
+DISPLAY = axis
+EDITOR = gedit
+
+#PYVCP = pyvcp_panel.xml
+
+# places the pyvcp panel at the bottom of the Axis window
+PYVCP_POSITION = RIGHT
+
+# Cycle time, in seconds, that display will sleep between polls
+CYCLE_TIME =            0.100
+
+# Path to help file
+HELP_FILE =             doc/help.txt
+
+# Initial display setting for position, RELATIVE or MACHINE
+POSITION_OFFSET = RELATIVE
+POSITION_FEEDBACK = ACTUAL
+MAX_FEED_OVERRIDE = 1.2
+# Prefix to be used
+PROGRAM_PREFIX = /home/demo/linuxcnc/nc_files
+INTRO_GRAPHIC = linuxcnc.gif
+INTRO_TIME = 0
+INCREMENTS = 5mm 1mm .5mm .1mm .05mm .01mm .005mm
+
+
+[FILTER]
+PROGRAM_EXTENSION = .png,.gif,.jpg Greyscale Depth Image
+PROGRAM_EXTENSION = .py Python Script
+png = image-to-gcode
+gif = image-to-gcode
+jpg = image-to-gcode
+py = python
+nc = /usr/bin/axis
+
+[TASK]
+TASK = milltask
+CYCLE_TIME = 0.005
+
+[RS274NGC]
+PARAMETER_FILE = linuxcnc.var
+
+[EMCMOT]
+
+EMCMOT = motmod
+COMM_TIMEOUT = 1.0
+BASE_PERIOD =  0
+SERVO_PERIOD = 1000000
+
+[KINS]
+JOINTS = 3
+KINEMATICS = trivkins kinstype=both coordinates=xyz
+
+[AXIS_X]
+MIN_LIMIT = -1
+MAX_LIMIT = 1200
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 5000.0
+
+[JOINT_0]
+TYPE = LINEAR
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 5000
+# The values below should be 25% larger than MAX_VELOCITY and MAX_ACCELERATION
+# If using BACKLASH compensation STEPGEN_MAXACCEL should be 100% larger.
+# is this applicable for ethercat????
+STEPGEN_MAXVEL = 100
+STEPGEN_MAXACCEL = 5000
+SCALE = 1
+FERROR = 2000
+MIN_FERROR = 500
+MIN_LIMIT = -1
+MAX_LIMIT = 1200
+HOME					= 0
+HOME_OFFSET				= 0
+HOME_SEQUENCE			= 0
+
+HOME_SEARCH_VEL			= 15.625
+HOME_LATCH_VEL			= 15.625
+
+HOME_IGNORE_LIMITS	    = YES
+HOME_USE_INDEX          = YES
+
+[AXIS_Y]
+MIN_LIMIT = -1
+MAX_LIMIT = 1200
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 5000.0
+
+[JOINT_1]
+TYPE = LINEAR
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 5000
+# The values below should be 25% larger than MAX_VELOCITY and MAX_ACCELERATION
+# If using BACKLASH compensation STEPGEN_MAXACCEL should be 100% larger.
+# is this applicable for ethercat????
+STEPGEN_MAXVEL = 100
+STEPGEN_MAXACCEL = 5000
+SCALE = 1
+FERROR = 2000
+MIN_FERROR = 500
+MIN_LIMIT = -1
+MAX_LIMIT = 1200
+HOME					= 0
+HOME_OFFSET				= 0
+HOME_SEQUENCE			= 0
+
+HOME_SEARCH_VEL			= 15.625
+HOME_LATCH_VEL			= 15.625
+
+HOME_IGNORE_LIMITS	    = YES
+HOME_USE_INDEX          = YES
+
+[AXIS_Z]
+MIN_LIMIT = -1
+MAX_LIMIT = 1200
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 5000.0
+
+[JOINT_2]
+TYPE = LINEAR
+MAX_VELOCITY = 100
+MAX_ACCELERATION = 5000
+# The values below should be 25% larger than MAX_VELOCITY and MAX_ACCELERATION
+# If using BACKLASH compensation STEPGEN_MAXACCEL should be 100% larger.
+# is this applicable for ethercat????
+STEPGEN_MAXVEL = 100
+STEPGEN_MAXACCEL = 5000
+SCALE = 1
+FERROR = 200
+MIN_FERROR = 50
+MIN_LIMIT = -1
+MAX_LIMIT = 1200
+HOME					= 0
+HOME_OFFSET				= 0
+HOME_SEQUENCE			= 0
+
+HOME_SEARCH_VEL			= 15.625
+HOME_LATCH_VEL			= 15.625
+
+HOME_IGNORE_LIMITS	    = YES
+HOME_USE_INDEX          = YES

--- a/tests/scottlaird-lcectest1/cia402-all.xml
+++ b/tests/scottlaird-lcectest1/cia402-all.xml
@@ -1,6 +1,7 @@
 <masters>
-  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="-1">
     <slave idx="25" type="basic_cia402" vid="0x00004321" pid="0x00002100" name="ls-2cl3">
+      <dcConf assignActivate="700" sync0Cycle="*1" sync0Shift="0"/>
       <!--2CL3-EC507(COE)-->
       <modParam name="ciaChannels" value="2"/>
       <modParam name="ciaRxPDOEntryLimit" value="8"/>
@@ -80,6 +81,7 @@
       <modParam name="ciaChannels" value="2"/>
       <modParam name="ciaRxPDOEntryLimit" value="16"/>
       <modParam name="ciaTxPDOEntryLimit" value="16"/>
+      <modParam name="pdoIncrement" value="16"/>
       <modParam name="ch1enablePP" value="true"/>
       <modParam name="ch1enablePV" value="false"/>
       <modParam name="ch1enableCSP" value="true"/>
@@ -127,8 +129,62 @@
       <modParam name="ch4enableProfileMaxVelocity" value="true"/>
       <modParam name="ch4enableProfileVelocity" value="true"/> -->
     </slave>
+
+    <!--    <slave idx="27" type="generic" vid="00000a88" pid="0a880002" configPdos="true" name="rt-ect60">
+      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
+      <sdoConfig idx="2000" subIdx="0">
+	<sdoDataRaw data="70 17"/>
+      </sdoConfig>
+      <sdoConfig idx="2007" subIdx="6">
+	<sdoDataRaw data="05"/>
+      </sdoConfig>
+      <sdoConfig idx="2007" subIdx="5">
+	<sdoDataRaw data="00"/>
+      </sdoConfig>
+      <sdoConfig idx="200D" subIdx="O">
+	<sdoDataRaw data="01"/>
+      </sdoConfig>
+      <sdoConfig idx="2011" subIdx="0">
+	<sdoDataRaw data="01 00"/>
+      </sdoConfig>
+      <syncManager idx="2" dir="out">
+	<pdo idx="1600">
+	  <pdoEntry idx="6040" subIdx="00" bitLen="16" halPin="srv-cia-controlword" halType="u32"/>
+	  <pdoEntry idx="6060" subIdx="00" bitLen="8" halPin="srv-opmode" halType="s32"/>
+	  <pdoEntry idx="607A" subIdx="00" bitLen="32" halPin="srv-target-position" halType="s32"/>
+	  <pdoEntry idx="60FF" subIdx="00" bitLen="32" halPin="srv-target-velocity" halType="s32"/>
+	  <pdoEntry idx="204A" subIdx="0" bitLen="16" halType="complex">
+	    <complexEntry bitLen="1" halPin="out-1" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="out-2" halType="bit"/>
+	    <complexEntry bitLen="14"/>
+	  </pdoEntry>
+	  <pdoEntry idx="6077" subIdx="00" bitLen="32" halPin="srv-actual-torque" halType="s32"/>
+	  <pdoEntry idx="60FD" subIdx="0" bitLen="32" halType="complex">
+	    <complexEntry bitLen="1" halPin="CW-limit" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="CCW-limit" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="in-home" halType="bit"/>
+	    <complexEntry bitLen="13"/>
+	    <complexEntry bitLen="1" halPin="in-1" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="in-2" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="in-3" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="in-4" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="in-5" halType="bit"/>
+	    <complexEntry bitLen="1" halPin="in-6" halType="bit"/>
+	    <complexEntry bitLen="10"/>
+	  </pdoEntry>
+	</pdo>
+      </syncManager>
+      <syncManager idx="3" dir="in">
+	<pdo idx="1a00">
+	  <pdoEntry idx="6041" subIdx="00" bitLen="16" halPin="srv-cia-statusword" halType="u32"/>
+	  <pdoEntry idx="6061" subIdx="00" bitLen="8" halPin="srv-opmode-display" halType="s32"/>
+	  <pdoEntry idx="6064" subIdx="00" bitLen="32" halPin="srv-actual-position" halType="s32"/>
+	  <pdoEntry idx="606C" subIdx="00" bitLen="32" halPin="srv-actual-velocity" halType="s32"/>
+	</pdo>
+      </syncManager>
+    </slave> -->
     <slave idx="27" type="basic_cia402" vid="0x00000a88" pid="0x0a880002" name="rt-ect60">
-      <!--ECT60V202(COE)-->
+      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
       <modParam name="ciaRxPDOEntryLimit" value="16"/>
       <modParam name="ciaTxPDOEntryLimit" value="16"/>
       <modParam name="enablePP" value="true"/>
@@ -149,36 +205,31 @@
       <modParam name="enableProfileVelocity" value="true"/>
     </slave>
     <slave idx="28" type="basic_cia402" vid="0x00000a88" pid="0x0a880005" name="rt-ecr60x2">
-      <modParam name="ciaChannels" value="1"/>
+      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
+      <modParam name="ciaChannels" value="2"/>
+      <modParam name="pdoIncrement" value="16"/>
       <modParam name="ciaRxPDOEntryLimit" value="16"/>
       <modParam name="ciaTxPDOEntryLimit" value="16"/>
       <modParam name="ch1enablePP" value="true"/>
       <modParam name="ch1enablePV" value="true"/>
       <modParam name="ch1enableCSP" value="true"/>
       <modParam name="ch1enableCSV" value="true"/>
-      <modParam name="ch1enableDigitalInput" value="true"/>
-      <modParam name="ch1digitalInChannels" value="16"/>
-      <modParam name="ch1enableDigitalOutput" value="true"/>
-      <modParam name="ch1digitalOutChannels" value="16"/>
       <modParam name="ch1enableErrorCode" value="true"/>
       <modParam name="ch1enableProfileAccel" value="true"/>
       <modParam name="ch1enableProfileDecel" value="true"/>
       <modParam name="ch1enableProfileVelocity" value="true"/>
-<!--      <modParam name="ch2enablePP" value="true"/>
+      <modParam name="ch2enablePP" value="true"/>
       <modParam name="ch2enablePV" value="true"/>
       <modParam name="ch2enableCSP" value="true"/>
       <modParam name="ch2enableCSV" value="true"/>
-      <modParam name="ch2enableDigitalInput" value="true"/>
-      <modParam name="ch2digitalInChannels" value="16"/>
-      <modParam name="ch2enableDigitalOutput" value="true"/>
-      <modParam name="ch2digitalOutChannels" value="16"/>
       <modParam name="ch2enableErrorCode" value="true"/>
       <modParam name="ch2enableProfileAccel" value="true"/>
       <modParam name="ch2enableProfileDecel" value="true"/>
-      <modParam name="ch2enableProfileVelocity" value="true"/> -->
+      <modParam name="ch2enableProfileVelocity" value="true"/>
     </slave>
     <slave idx="29" type="basic_cia402" vid="0x00000a88" pid="0x0a880042" name="rt-drv400">
       <!--DRV400E(COE)-->
+      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
       <modParam name="ciaRxPDOEntryLimit" value="16"/>
       <modParam name="ciaTxPDOEntryLimit" value="16"/>
       <modParam name="enablePP" value="true"/>


### PR DESCRIPTION
This includes a handful of small fixes needed to get CSP working for my CiA 402 test devices, plus a set of config files.

The most important change is a bunch of `dcConf` tags in the XML; it's *amazing* how painful that was to catch.  There's also a change to allow CiA 402 devices to use non-consecutive PDO numbers.  Weirdly, the ECR60x2 has 0x1600, 0x1610, etc, but not 0x1601.