### PR TITLE
feat(malloc): Update memory allocation across LCEC with LCEC*ALLOC helpers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,6 @@ all: all-deps realtime user
 include Makefile.clean
 
 #CC=g++
-#EXTRA_CFLAGS += -fpermissive
 
 RTLDFLAGS += -Wl,-rpath,$(LIBDIR)
 RTEXTRA_LDFLAGS += -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -L$(LIBDIR) -llinuxcnchal -lethercat -lrt
@@ -16,7 +15,7 @@ EXTRA_CFLAGS += -Wall # Increase debugging level
 #EXTRA_CFLAGS += -fanalyzer # Use GCC's static analyzer tool, doubles compile time
 
 ## targets
-lcec-common-objs := lcec_devicelist.o lcec_ethercat.o lcec_pins.o lcec_lookup.o lcec_modparam.o
+lcec-common-objs := lcec_devicelist.o lcec_ethercat.o lcec_pins.o lcec_lookup.o lcec_modparam.o lcec_malloc.o
 lcec-objs := lcec_main.o $(lcec-common-objs)
 lcec-conf-srcs := $(wildcard lcec_conf*.c)
 lcec-conf-objs = $(subst .c,.o,$(lcec-conf-srcs))

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,11 +5,14 @@ all: all-deps realtime user
 -include $(MODINC)
 include Makefile.clean
 
+#CC=g++
+#EXTRA_CFLAGS += -fpermissive
+
 RTLDFLAGS += -Wl,-rpath,$(LIBDIR)
 RTEXTRA_LDFLAGS += -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -L$(LIBDIR) -llinuxcnchal -lethercat -lrt
 
 #EXTRA_CFLAGS += --std=c2x
-EXTRA_CFLAGS += -Wall  # Increase debugging level
+EXTRA_CFLAGS += -Wall # Increase debugging level
 #EXTRA_CFLAGS += -fanalyzer # Use GCC's static analyzer tool, doubles compile time
 
 ## targets

--- a/src/devices/lcec_ax5100.c
+++ b/src/devices/lcec_ax5100.c
@@ -65,7 +65,6 @@ static void lcec_ax5100_write(lcec_slave_t *slave, long period);
 }
 
 static int lcec_ax5100_init(int comp_id, lcec_slave_t *slave) {
-  lcec_master_t *master = slave->master;
   lcec_ax5100_data_t *hal_data;
   int err;
 
@@ -74,11 +73,7 @@ static int lcec_ax5100_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_ax5100_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_ax5100_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_ax5100_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_ax5100_data_t);
   slave->hal_data = hal_data;
 
   // init subclasses

--- a/src/devices/lcec_ax5200.c
+++ b/src/devices/lcec_ax5200.c
@@ -65,7 +65,6 @@ static void lcec_ax5200_write(lcec_slave_t *slave, long period);
 }
 
 static int lcec_ax5200_init(int comp_id, lcec_slave_t *slave) {
-  lcec_master_t *master = slave->master;
   lcec_ax5200_data_t *hal_data;
   int i;
   lcec_class_ax5_chan_t *chan;
@@ -77,11 +76,7 @@ static int lcec_ax5200_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_ax5200_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_ax5200_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_ax5200_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_ax5200_data_t);
   slave->hal_data = hal_data;
 
   // initialize pins

--- a/src/devices/lcec_ax5805.c
+++ b/src/devices/lcec_ax5805.c
@@ -134,11 +134,7 @@ static int lcec_ax5805_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_ax5805_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_ax5805_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_ax5805_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_ax5805_data_t);
   slave->hal_data = hal_data;
 
   // initialize POD entries

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -127,7 +127,7 @@ static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave) {
   int err;
 
   // XXXX: you can remove this if you replace the /* fake vid */ and /* fake pid */ in `types`, above.
-  if (slave->vid == -1 || slave->pid == -1) {
+  if (slave->vid == 0xffffffff || slave->pid == 0xffffffff) {
     rtapi_print_msg(RTAPI_MSG_ERR,
         LCEC_MSG_PFX "basic_cia402 device slave %s.%s not configured correctly, you must specify vid and pid in the XML file.\n",
         slave->master->name, slave->name);
@@ -135,11 +135,7 @@ static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_basic_cia402_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_basic_cia402_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_basic_cia402_data_t);
   slave->hal_data = hal_data;
 
   // initialize callbacks

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -65,7 +65,7 @@ static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave);
 // PID.  Feel free to add multiple devices here if they can share the
 // same driver.
 static lcec_typelist_t types[] = {
-    {"basic_cia402", /* fake vid */ -1, /* fake pid */ -1, 0, NULL, lcec_basic_cia402_init, /* modparams implicitly added below */},
+    {"basic_cia402", /* fake vid */ 0xffffffff, /* fake pid */ 0xffffffff, 0, NULL, lcec_basic_cia402_init, /* modparams implicitly added below */},
     {NULL},
 };
 ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_lcec_basic_cia402)

--- a/src/devices/lcec_class_ain.c
+++ b/src/devices/lcec_class_ain.c
@@ -73,15 +73,10 @@ static const lcec_pindesc_t slave_pins_status[] = {
 lcec_class_ain_channels_t *lcec_ain_allocate_channels(int count) {
   lcec_class_ain_channels_t *channels;
 
-  channels = hal_malloc(sizeof(lcec_class_ain_channels_t));
-  if (channels == NULL) {
-    return NULL;
-  }
+  channels = LCEC_HAL_ALLOCATE(lcec_class_ain_channels_t);
   channels->count = count;
-  channels->channels = hal_malloc(sizeof(lcec_class_ain_channel_t *) * count);
-  if (channels->channels == NULL) {
-    return NULL;
-  }
+  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_ain_channel_t *, count);
+
   return channels;
 }
 
@@ -91,13 +86,7 @@ lcec_class_ain_channels_t *lcec_ain_allocate_channels(int count) {
 /// `lcec_ain_register_channel`, so we can safely just memset
 /// everything to 0 here.
 lcec_class_ain_options_t *lcec_ain_options(void) {
-  lcec_class_ain_options_t *opts = hal_malloc(sizeof(lcec_class_ain_options_t));
-  if (opts == NULL) {
-    return NULL;
-  }
-  memset(opts, 0, sizeof(lcec_class_ain_options_t));
-
-  return opts;
+  return LCEC_HAL_ALLOCATE(lcec_class_ain_options_t);
 }
 
 /// @brief registers a single analog-input channel and publishes it as a LinuxCNC HAL pin.
@@ -144,7 +133,7 @@ lcec_class_ain_channel_t *lcec_ain_register_channel(lcec_slave_t *slave, int id,
   if (opt && opt->syncerror_sidx) syncerror_sidx = opt->syncerror_sidx;
 
   // The default name depends on the port type.
-  char *name_prefix = "ain";
+  const char *name_prefix = "ain";
   if (is_temperature) name_prefix = "temp";
   if (is_pressure) name_prefix = "pressure";
   if (opt && opt->name_prefix) name_prefix = opt->name_prefix;
@@ -154,19 +143,10 @@ lcec_class_ain_channel_t *lcec_ain_register_channel(lcec_slave_t *slave, int id,
   // so we don't need to repeat the above default code downstream.
   if (!opt) {
     opt = lcec_ain_options();
-    if (opt == NULL) {
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
-      return NULL;
-    }
   }
 
   // Allocate memory for per-channel data.
-  data = hal_malloc(sizeof(lcec_class_ain_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
-    return NULL;
-  }
-  memset(data, 0, sizeof(lcec_class_ain_channel_t));
+  data = LCEC_HAL_ALLOCATE(lcec_class_ain_channel_t);
 
   // Save important options for later use.  None of the _idx/_sidx will be needed outside of this function.
   data->options = opt;

--- a/src/devices/lcec_class_ain.h
+++ b/src/devices/lcec_class_ain.h
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 
 typedef struct {
-  char *name_prefix;               ///< Prefix for device naming, defaults to "aio".
+  const char *name_prefix;               ///< Prefix for device naming, defaults to "aio".
   int has_sync;                    ///< Device supports the sync_err PDO.
   int valueonly;                   ///< Only read the value from the sensor, do not read over/under range or error PDOs.
   int is_temperature;              ///< Device is a temperature sensor.

--- a/src/devices/lcec_class_aout.c
+++ b/src/devices/lcec_class_aout.c
@@ -50,15 +50,9 @@ static const lcec_pindesc_t slave_pins_basic[] = {
 lcec_class_aout_channels_t *lcec_aout_allocate_channels(int count) {
   lcec_class_aout_channels_t *channels;
 
-  channels = hal_malloc(sizeof(lcec_class_aout_channels_t));
-  if (channels == NULL) {
-    return NULL;
-  }
+  channels = LCEC_HAL_ALLOCATE(lcec_class_aout_channels_t);
   channels->count = count;
-  channels->channels = hal_malloc(sizeof(lcec_class_aout_channel_t *) * count);
-  if (channels->channels == NULL) {
-    return NULL;
-  }
+  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_aout_channel_t *, count);
   return channels;
 }
 
@@ -68,13 +62,7 @@ lcec_class_aout_channels_t *lcec_aout_allocate_channels(int count) {
 /// `lcec_aout_register_channel`, so we can safely just memset
 /// everything to 0 here.
 lcec_class_aout_options_t *lcec_aout_options(void) {
-  lcec_class_aout_options_t *opts = hal_malloc(sizeof(lcec_class_aout_options_t));
-  if (opts == NULL) {
-    return NULL;
-  }
-  memset(opts, 0, sizeof(lcec_class_aout_options_t));
-
-  return opts;
+  return LCEC_HAL_ALLOCATE(lcec_class_aout_options_t);
 }
 
 /// @brief registers a single analog-output channel and publishes it as a set of LinuxCNC HAL pins.
@@ -104,7 +92,7 @@ lcec_class_aout_channel_t *lcec_aout_register_channel(lcec_slave_t *slave, int i
   if (opt && opt->value_sidx) value_sidx = opt->value_sidx;
 
   // The default name depends on the port type.
-  char *name_prefix = "aout";
+  const char *name_prefix = "aout";
   if (opt && opt->name_prefix) name_prefix = opt->name_prefix;
 
   // If we were passed a NULL opt, then create a new
@@ -112,19 +100,10 @@ lcec_class_aout_channel_t *lcec_aout_register_channel(lcec_slave_t *slave, int i
   // so we don't need to repeat the above default code downstream.
   if (!opt) {
     opt = lcec_aout_options();
-    if (opt == NULL) {
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
-      return NULL;
-    }
   }
 
   // Allocate memory for per-channel data.
-  data = hal_malloc(sizeof(lcec_class_aout_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %d failed\n", slave->master->name, slave->name, id);
-    return NULL;
-  }
-  memset(data, 0, sizeof(lcec_class_aout_channel_t));
+  data = LCEC_HAL_ALLOCATE(lcec_class_aout_channel_t);
 
   // Save important options for later use.  None of the _idx/_sidx will be needed outside of this function.
   data->options = opt;

--- a/src/devices/lcec_class_aout.h
+++ b/src/devices/lcec_class_aout.h
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 
 typedef struct {
-  char *name_prefix;               ///< Prefix for device naming, defaults to "aio".
+  const char *name_prefix;               ///< Prefix for device naming, defaults to "aio".
   int max_value;                   ///< The maximum value returned for "normal" output channels.
   double default_scale;            ///< Default scale for the device.
   double default_offset;           ///< Default value offset for the device.

--- a/src/devices/lcec_class_ax5.c
+++ b/src/devices/lcec_class_ax5.c
@@ -42,16 +42,16 @@ static const lcec_pindesc_t slave_diag_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_class_ax5_chan_t, scale), "%s.%s.%s.%ssrv-scale"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_class_ax5_chan_t, vel_scale), "%s.%s.%s.%ssrv-vel-scale"},
     {HAL_U32, HAL_RO, offsetof(lcec_class_ax5_chan_t, pos_resolution), "%s.%s.%s.%ssrv-pos-resolution"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
-static const lcec_pindesc_t slave_fb2_params[] = {
+static const lcec_paramdesc_t slave_fb2_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_class_ax5_chan_t, scale_fb2), "%s.%s.%s.%ssrv-scale-fb2"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static int get_param_flag(lcec_slave_t *slave, int id) {

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -69,10 +69,7 @@ FOR_ALL_WRITE_SDOS_DO(OPTIONAL_PIN_WRITE);
 /// `lcec_class_cia402_channel_options_t`.
 static lcec_class_cia402_enabled_t *lcec_cia402_enabled(lcec_class_cia402_channel_options_t *opt) {
   lcec_class_cia402_enabled_t *enabled;
-  enabled = hal_malloc(sizeof(lcec_class_cia402_enabled_t));
-  if (enabled == NULL) return NULL;
-
-  memset(enabled, 0, sizeof(lcec_class_cia402_enabled_t));
+  enabled = LCEC_HAL_ALLOCATE(lcec_class_cia402_enabled_t);
 
   if (opt->enable_opmode) {
     enabled->enable_opmode = 1;
@@ -139,25 +136,15 @@ static lcec_class_cia402_enabled_t *lcec_cia402_enabled(lcec_class_cia402_channe
 lcec_class_cia402_channels_t *lcec_cia402_allocate_channels(int count) {
   lcec_class_cia402_channels_t *channels;
 
-  channels = hal_malloc(sizeof(lcec_class_cia402_channels_t));
-  if (channels == NULL) {
-    return NULL;
-  }
+  channels = LCEC_HAL_ALLOCATE(lcec_class_cia402_channels_t);
   channels->count = count;
-  channels->channels = hal_malloc(sizeof(lcec_class_cia402_channel_t *) * count);
-  if (channels->channels == NULL) {
-    return NULL;
-  }
+  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_cia402_channel_t *, count);
   return channels;
 }
 
 /// @brief Allocates a `lcec_class_cia402_options_t` and initializes it.
 lcec_class_cia402_options_t *lcec_cia402_options(void) {
-  lcec_class_cia402_options_t *opts = hal_malloc(sizeof(lcec_class_cia402_options_t));
-  if (opts == NULL) {
-    return NULL;
-  }
-  memset(opts, 0, sizeof(lcec_class_cia402_options_t));
+  lcec_class_cia402_options_t *opts = LCEC_HAL_ALLOCATE(lcec_class_cia402_options_t);
   opts->channels = 1;
 
   for (int channel = 0; channel < 8; channel++) {
@@ -169,11 +156,7 @@ lcec_class_cia402_options_t *lcec_cia402_options(void) {
 
 /// @brief Allocates a `lcec_class_cia402_channel_options_t` and initializes it.
 lcec_class_cia402_channel_options_t *lcec_cia402_channel_options(void) {
-  lcec_class_cia402_channel_options_t *opts = hal_malloc(sizeof(lcec_class_cia402_channel_options_t));
-  if (opts == NULL) {
-    return NULL;
-  }
-  memset(opts, 0, sizeof(lcec_class_cia402_channel_options_t));
+  lcec_class_cia402_channel_options_t *opts = LCEC_HAL_ALLOCATE(lcec_class_cia402_channel_options_t);
   opts->enable_opmode = 1;  // Should almost always be enabled.
   opts->digital_in_channels = 16;
   opts->digital_out_channels = 16;
@@ -188,7 +171,7 @@ lcec_class_cia402_channel_options_t *lcec_cia402_channel_options(void) {
 /// use names like `srv-1-foo` instead.
 void lcec_cia402_rename_multiaxis_channels(lcec_class_cia402_options_t *opt) {
   for (int channel = 0; channel < opt->channels; channel++) {
-    char *prefix = hal_malloc(16);
+    char *prefix = LCEC_HAL_ALLOCATE_STRING(16);
     snprintf(prefix, 16, "srv-%d", channel + 1);
     opt->channel[channel]->name_prefix = prefix;
   }
@@ -200,11 +183,7 @@ void lcec_cia402_rename_multiaxis_channels(lcec_class_cia402_options_t *opt) {
 lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options) {
   lcec_syncs_t *syncs;
 
-  syncs = hal_malloc(sizeof(lcec_syncs_t));
-  if (syncs == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for lcec_cia402_init_sync failed\n");
-    return NULL;
-  }
+  syncs = LCEC_HAL_ALLOCATE(lcec_syncs_t);
   lcec_syncs_init(slave, syncs);
   lcec_syncs_add_sync(syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);
   lcec_syncs_add_sync(syncs, EC_DIR_INPUT, EC_WD_DEFAULT);
@@ -239,7 +218,6 @@ int lcec_cia402_add_output_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_c
     int entrycount = syncs->pdo_entry_count;
 
     lcec_class_cia402_enabled_t *enabled = lcec_cia402_enabled(options->channel[channel]);
-    if (enabled == NULL) return -1;
 
     lcec_syncs_add_pdo_info(syncs, 0x1600 + channel);
     lcec_syncs_add_pdo_entry(syncs, offset + 0x40, 0x00, 16);  // Control word
@@ -285,7 +263,6 @@ int lcec_cia402_add_input_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_cl
     int entrycount = syncs->pdo_entry_count;
 
     lcec_class_cia402_enabled_t *enabled = lcec_cia402_enabled(options->channel[channel]);
-    if (enabled == NULL) return -1;
 
     lcec_syncs_add_pdo_info(syncs, 0x1a00 + channel);
     lcec_syncs_add_pdo_entry(syncs, offset + 0x41, 0x00, 16);  // Status word
@@ -339,7 +316,7 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   lcec_class_cia402_enabled_t *enabled;
 
   // The default name depends on the port type.
-  char *name_prefix = "srv";
+  const char *name_prefix = "srv";
   if (opt && opt->name_prefix) name_prefix = opt->name_prefix;
 
   // If we were passed a NULL opt, then create a new
@@ -347,29 +324,15 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   // so we don't need to repeat the above default code downstream.
   if (!opt) {
     opt = lcec_cia402_channel_options();
-    if (opt == NULL) {
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-      return NULL;
-    }
   }
 
   // Allocate memory for per-channel data.
-  data = hal_malloc(sizeof(lcec_class_cia402_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-    return NULL;
-  }
-  memset(data, 0, sizeof(lcec_class_cia402_channel_t));
-
+  data = LCEC_HAL_ALLOCATE(lcec_class_cia402_channel_t);
   data->options = opt;
   data->base_idx = base_idx;
 
   // Set the `enabled` struct from `opt`.
   enabled = lcec_cia402_enabled(opt);
-  if (enabled == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-    return NULL;
-  }
   data->enabled = enabled;
 
   // Register PDOs
@@ -403,29 +366,22 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   if (enabled->enable_digital_input) {
     char *dname;
     data->din = lcec_din_allocate_channels(opt->digital_in_channels + 4);
-    if (data->din == NULL) {
-      rtapi_print_msg(
-          RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_din_allocate_channels() for slave %s.%s failed\n", slave->master->name, slave->name);
-      return NULL;
-    }
 
-    dname = hal_malloc(sizeof(char[20]));
+    dname = LCEC_HAL_ALLOCATE_STRING(20);
     snprintf(dname, 20, "%s-din-cw-limit", name_prefix);
     data->din->channels[0] = lcec_din_register_channel_packed(slave, base_idx + 0xfd, 0, 0, dname);  // negative limit switch
-    dname = hal_malloc(sizeof(char[20]));
+    dname = LCEC_HAL_ALLOCATE_STRING(20);
     snprintf(dname, 20, "%s-din-ccw-limit", name_prefix);
     data->din->channels[1] = lcec_din_register_channel_packed(slave, base_idx + 0xfd, 0, 1, dname);  // positive limit switch
-    dname = hal_malloc(sizeof(char[20]));
+    dname = LCEC_HAL_ALLOCATE_STRING(20);
     snprintf(dname, 20, "%s-din-home", name_prefix);
     data->din->channels[2] = lcec_din_register_channel_packed(slave, base_idx + 0xfd, 0, 2, dname);  // home
-    dname = hal_malloc(sizeof(char[20]));
+    dname = LCEC_HAL_ALLOCATE_STRING(20);
     snprintf(dname, 20, "%s-din-interlock", name_prefix);
     data->din->channels[3] = lcec_din_register_channel_packed(slave, base_idx + 0xfd, 0, 3, dname);  // interlock?
 
     for (int channel = 0; channel < opt->digital_in_channels; channel++) {
-      dname = hal_malloc(sizeof(char[20]));
-      if (dname == NULL) return NULL;
-
+      dname = LCEC_HAL_ALLOCATE_STRING(20);
       snprintf(dname, 20, "%s-din-%d", name_prefix, channel);
       data->din->channels[4 + channel] = lcec_din_register_channel_packed(slave, base_idx + 0xfd, 0, 16 + channel, dname);
     }
@@ -434,18 +390,11 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   if (enabled->enable_digital_output) {
     char *dname;
     data->dout = lcec_dout_allocate_channels(opt->digital_out_channels + 1);
-    if (data->din == NULL) {
-      rtapi_print_msg(
-          RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_din_allocate_channels() for slave %s.%s failed\n", slave->master->name, slave->name);
-      return NULL;
-    }
-    dname = hal_malloc(sizeof(char[20]));
+    dname = LCEC_HAL_ALLOCATE_STRING(20);
     snprintf(dname, 20, "%s-dout-brake", name_prefix);
     data->dout->channels[0] = lcec_dout_register_channel_packed(slave, base_idx + 0xfe, 1, 0, dname);  // brake
     for (int channel = 0; channel < opt->digital_out_channels; channel++) {
-      dname = hal_malloc(sizeof(char[20]));
-      if (dname == NULL) return NULL;
-
+      dname = LCEC_HAL_ALLOCATE_STRING(20);
       snprintf(dname, 20, "%s-dout-%d", name_prefix, channel);
       data->dout->channels[1 + channel] = lcec_dout_register_channel_packed(slave, base_idx + 0xfe, 1, 16 + channel, dname);
     }
@@ -677,28 +626,21 @@ static const lcec_modparam_desc_t per_channel_modparams[] = {
 /// a different list.
 lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t const *orig) {
   lcec_modparam_desc_t *mp;
-  int l;
+  int l, len;
 
-  l = lcec_modparam_desc_len(orig);
+  len = lcec_modparam_desc_len(orig);
 
-  mp = malloc(sizeof(lcec_modparam_desc_t) * (l * 9 + 1));
-  if (mp == NULL) {
-    return NULL;
-  }
+  mp = LCEC_ALLOCATE_ARRAY(lcec_modparam_desc_t, len * 9 + 1);
 
-  mp[l * 9] = orig[l];  // Copy terminator.
+  mp[(len-1) * 9] = orig[(len-1)];  // Copy terminator.
 
-  for (l = 0; orig[l].name != NULL; l++) {
+  for (l = 0; l<len; l++) {
     mp[l * 9] = orig[l];
     for (int i = 1; i < 9; i++) {
       char *name;
       mp[l * 9 + i] = orig[l];
 
-      name = malloc(strlen(orig[l].name) + 10);
-      if (name == NULL) {
-        free(mp);
-        return NULL;
-      }
+      name = LCEC_ALLOCATE_STRING(strlen(orig[l].name) + 10);
       sprintf(name, "ch%d%s", i, orig[l].name);
       mp[l * 9 + i].name = name;
       mp[l * 9 + i].id += i - 1;
@@ -715,7 +657,6 @@ lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t con
 /// device-specific `<modParam>`settings.
 lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_mps) {
   const lcec_modparam_desc_t *channelized_mps = lcec_cia402_channelized_modparams(per_channel_modparams);
-  if (channelized_mps == NULL) return NULL;
 
   return lcec_modparam_desc_concat(device_mps, channelized_mps);
 }
@@ -872,9 +813,9 @@ int lcec_cia402_handle_modparam(lcec_slave_t *slave, const lcec_slave_modparam_t
 ///   computing a rational approximation of a FP number.  Generally,
 ///   you'll want to pick the largest int representable by the
 ///   register that you're writing it into.
-lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, unsigned int max_denominator) {
+lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, int max_denominator) {
   lcec_ratio result;
-  char *slash = strchr(value, '/');
+  const char *slash = strchr(value, '/');
 
   // If there's no "/", then try a colon.
   if (slash == NULL) slash = strchr(value, ':');

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -51,7 +51,7 @@
 /// At the moment, only pp/pv/csp/csv are even slightly implemented.
 /// More will follow as hardware support grows.
 typedef struct {
-  char *name_prefix;  ///< Prefix for device naming, defaults to "srv".
+  const char *name_prefix;  ///< Prefix for device naming, defaults to "srv".
   int digital_in_channels;
   int digital_out_channels;
 
@@ -314,7 +314,7 @@ lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_m
 lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_output_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_input_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
-lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, unsigned int max_denominator);
+lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, int max_denominator);
 
 #define ADD_TYPES_WITH_CIA402_MODPARAMS(types, mps)        \
   static void AddTypes(void) __attribute__((constructor)); \

--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -34,22 +34,13 @@ static const lcec_pindesc_t slave_pins[] = {
 /// @brief allocates a block of memory for holding the result of
 /// `count` calls to `lcec_din_register_device()`.
 ///
-/// It is the caller's responsibility to verify that the result is not
-/// NULL.
-///
 /// @param count The number of input pins to allocate memory for.
 lcec_class_din_channels_t *lcec_din_allocate_channels(int count) {
   lcec_class_din_channels_t *channels;
 
-  channels = hal_malloc(sizeof(lcec_class_din_channels_t));
-  if (channels == NULL) {
-    return NULL;
-  }
+  channels = LCEC_HAL_ALLOCATE(lcec_class_din_channels_t);
   channels->count = count;
-  channels->channels = hal_malloc(sizeof(lcec_class_din_channel_t *) * count);
-  if (channels->channels == NULL) {
-    return NULL;
-  }
+  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_din_channel_t *,count);
 
   return channels;
 }
@@ -84,11 +75,7 @@ lcec_class_din_channel_t *lcec_din_register_channel_named(lcec_slave_t *slave, u
   lcec_class_din_channel_t *data;
   int err;
 
-  data = hal_malloc(sizeof(lcec_class_din_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
-    return NULL;
-  }
+  data = LCEC_HAL_ALLOCATE(lcec_class_din_channel_t);
   memset(data, 0, sizeof(lcec_class_din_channel_t));
   data->name = name;
   data->pdo_bp_packed = 0xffff;  // Flag value, this isn't a packed channel.
@@ -121,11 +108,7 @@ lcec_class_din_channel_t *lcec_din_register_channel_packed(lcec_slave_t *slave, 
   lcec_class_din_channel_t *data;
   int err;
 
-  data = hal_malloc(sizeof(lcec_class_din_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
-    return NULL;
-  }
+  data = LCEC_HAL_ALLOCATE(lcec_class_din_channel_t);
   memset(data, 0, sizeof(lcec_class_din_channel_t));
   data->name = name;
 

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -45,15 +45,12 @@ static const lcec_paramdesc_t slave_params[] = {
 lcec_class_dout_channels_t *lcec_dout_allocate_channels(int count) {
   lcec_class_dout_channels_t *channels;
 
-  channels = hal_malloc(sizeof(lcec_class_dout_channels_t));
+  channels = LCEC_HAL_ALLOCATE(lcec_class_dout_channels_t);
   if (channels == NULL) {
     return NULL;
   }
   channels->count = count;
-  channels->channels = hal_malloc(sizeof(lcec_class_dout_channel_t *) * count);
-  if (channels->channels == NULL) {
-    return NULL;
-  }
+  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_dout_channel_t *, count);
 
   return channels;
 }
@@ -83,16 +80,11 @@ lcec_class_dout_channel_t *lcec_dout_register_channel(lcec_slave_t *slave, int i
 /// @param name The base pin name to use, usually `dout-<ID>`.
 ///
 /// See lcec_el2xxx.c for an example of use.
-lcec_class_dout_channel_t *lcec_dout_register_channel_named(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, char *name) {
+lcec_class_dout_channel_t *lcec_dout_register_channel_named(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, const char *name) {
   lcec_class_dout_channel_t *data;
   int err;
 
-  data = hal_malloc(sizeof(lcec_class_dout_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
-    return NULL;
-  }
-  memset(data, 0, sizeof(lcec_class_dout_channel_t));
+  data = LCEC_HAL_ALLOCATE(lcec_class_dout_channel_t);
   data->name = name;
   data->pdo_bp_packed = 0xffff;
 
@@ -125,16 +117,11 @@ lcec_class_dout_channel_t *lcec_dout_register_channel_named(lcec_slave_t *slave,
 /// @param os  The offset from `LCEC_PDO_INIT()`.
 /// @param bit  The bit offset for the digital out channel.
 /// @param name The base name to use for the channel, `dout-<ID>` is common.
-lcec_class_dout_channel_t *lcec_dout_register_channel_packed(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, int bit, char *name) {
+lcec_class_dout_channel_t *lcec_dout_register_channel_packed(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, int bit, const char *name) {
   lcec_class_dout_channel_t *data;
   int err;
 
-  data = hal_malloc(sizeof(lcec_class_dout_channel_t));
-  if (data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s pin %s failed\n", slave->master->name, slave->name, name);
-    return NULL;
-  }
-  memset(data, 0, sizeof(lcec_class_dout_channel_t));
+  data = LCEC_HAL_ALLOCATE(lcec_class_dout_channel_t);
 
   // Register the whole PDO, hopefully this does the sane thing if we register the same PDO repeatedly.
   lcec_pdo_init(slave, idx, sidx, &data->pdo_os, &data->pdo_bp);

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -30,9 +30,9 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_BIT, HAL_RW, offsetof(lcec_class_dout_channel_t, invert), "%s.%s.%s.%s-invert"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 /// @brief Allocates a block of memory for holding the result of `count`

--- a/src/devices/lcec_class_dout.h
+++ b/src/devices/lcec_class_dout.h
@@ -24,7 +24,7 @@
 #include "../lcec.h"
 
 typedef struct {
-  char *name;                  ///< Used for debugging only
+  const char *name;                  ///< Used for debugging only
   hal_bit_t *out;              ///< -dout-X pin in LinuxCNC
   hal_bit_t invert;            ///< Is the value inverted?
   unsigned int pdo_os;         ///< Byte offset in PDO data struct
@@ -39,8 +39,8 @@ typedef struct {
 
 lcec_class_dout_channels_t *lcec_dout_allocate_channels(int count);
 lcec_class_dout_channel_t *lcec_dout_register_channel(struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
-lcec_class_dout_channel_t *lcec_dout_register_channel_named(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, char *name);
-lcec_class_dout_channel_t *lcec_dout_register_channel_packed(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, char *name);
+lcec_class_dout_channel_t *lcec_dout_register_channel_named(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, const char *name);
+lcec_class_dout_channel_t *lcec_dout_register_channel_packed(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, const char *name);
 void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data);
 void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_channels_t *pins);
 

--- a/src/devices/lcec_class_enc.c
+++ b/src/devices/lcec_class_enc.c
@@ -39,11 +39,11 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_U32, HAL_RW, offsetof(lcec_class_enc_data_t, raw_home), "%s.%s.%s.%s-raw-home"},
     {HAL_U32, HAL_RO, offsetof(lcec_class_enc_data_t, raw_bits), "%s.%s.%s.%s-raw-bits"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_class_enc_data_t, pprev_scale), "%s.%s.%s.%s-pprev-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static int32_t raw_diff(int shift, uint32_t raw_a, uint32_t raw_b);

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -52,7 +52,7 @@ static const lcec_modparam_desc_t lcec_deasda_modparams[] = {
 };
 
 typedef struct {
-  char *name;      // Mode type name
+  const char *name;      // Mode type name
   uint16_t value;  // Which value needs to be set in 0x6060:00 to enable this mode
 } drive_operationmodes_t;
 
@@ -303,11 +303,7 @@ static int lcec_deasda_init(int comp_id, lcec_slave_t *slave) {
     slave->proc_write = lcec_deasda_write_csp;
   }
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_deasda_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_deasda_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_deasda_data_t);
   slave->hal_data = hal_data;
 
   // Set up digital outputs.  These names should match the A3, unclear about other models.

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -193,13 +193,13 @@ static const lcec_pindesc_t slave_pins_csp[] = {
 };
 
 // Exposed parameters are identical for both drives and modes
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_deasda_data_t, pos_scale), "%s.%s.%s.pos-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_deasda_data_t, extenc_scale), "%s.%s.%s.extenc-scale"},
     {HAL_U32, HAL_RW, offsetof(lcec_deasda_data_t, pprev), "%s.%s.%s.srv-pulses-per-rev"},
     {HAL_U32, HAL_RW, offsetof(lcec_deasda_data_t, fault_autoreset_cycles), "%s.%s.%s.srv-fault-autoreset-cycles"},
     {HAL_U32, HAL_RW, offsetof(lcec_deasda_data_t, fault_autoreset_retries), "%s.%s.%s.srv-fault-autoreset-retries"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_deasda_in[] = {

--- a/src/devices/lcec_dems300.c
+++ b/src/devices/lcec_dems300.c
@@ -184,11 +184,7 @@ static int lcec_dems300_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_dems300_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_dems300_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_dems300_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_dems300_data_t);
   slave->hal_data = hal_data;
 
   // initialize sync info

--- a/src/devices/lcec_dems300.c
+++ b/src/devices/lcec_dems300.c
@@ -121,10 +121,10 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_BIT, HAL_RW, offsetof(lcec_dems300_data_t, auto_fault_reset), "%s.%s.%s.auto-fault-reset"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_dems300_data_t, vel_scale), "%s.%s.%s.vel-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_dems300_in[] = {

--- a/src/devices/lcec_digitalcombo.c
+++ b/src/devices/lcec_digitalcombo.c
@@ -128,11 +128,7 @@ static int lcec_digitalcombo_init(int comp_id, lcec_slave_t *slave) {
   if (out_channels > 0) slave->proc_write = lcec_digitalcombo_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_digitalcombo_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_digitalcombo_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_digitalcombo_data_t);
   slave->hal_data = hal_data;
 
   // Allocate memory for I/O pin definitions

--- a/src/devices/lcec_easyio.c
+++ b/src/devices/lcec_easyio.c
@@ -51,11 +51,7 @@ static int lcec_easyio_init(int comp_id, lcec_slave_t *slave) {
   int i;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_easyio_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_easyio_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_easyio_data_t);
   slave->hal_data = hal_data;
 
   // initialize callbacks

--- a/src/devices/lcec_el1904.c
+++ b/src/devices/lcec_el1904.c
@@ -101,11 +101,7 @@ static int lcec_el1904_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el1904_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el1904_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el1904_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el1904_data_t);
   slave->hal_data = hal_data;
 
   // initialize POD entries

--- a/src/devices/lcec_el1918_logic.c
+++ b/src/devices/lcec_el1918_logic.c
@@ -119,7 +119,7 @@ static int export_std_pins(lcec_slave_t *slave, int pid, hal_bit_t **pin, hal_pi
     }
 
     // export pin
-    if ((err = lcec_pin_newf(HAL_BIT, dir, (void *)pin, "%s.%s.%s.%s", LCEC_MODULE_NAME, master->name, slave->name, p->value.str)) != 0) {
+    if ((err = lcec_pin_newf(HAL_BIT, dir, (void **)pin, "%s.%s.%s.%s", LCEC_MODULE_NAME, master->name, slave->name, p->value.str)) != 0) {
       return err;
     }
 
@@ -204,11 +204,7 @@ int lcec_el1918_logic_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el1918_logic_data_t) + fsoe_idx * sizeof(lcec_el1918_logic_fsoe_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el1918_logic_data_t));
+  hal_data = LCEC_HAL_ALLOCATE_ARRAY(lcec_el1918_logic_data_t, fsoe_idx* sizeof(lcec_el1918_logic_fsoe_t));
   hal_data->fsoe_count = fsoe_idx;
   slave->hal_data = hal_data;
 
@@ -250,11 +246,7 @@ int lcec_el1918_logic_init(int comp_id, lcec_slave_t *slave) {
       fsoeConf = fsoe_slave->fsoeConf;
 
       // alloc crc hal memory
-      if ((fsoe_data->fsoe_crc = hal_malloc(fsoeConf->data_channels * sizeof(lcec_el1918_logic_fsoe_crc_t))) == NULL) {
-        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for fsoe_slave %s.%s crc data failed\n", master->name, fsoe_slave->name);
-        return -EIO;
-      }
-      memset(fsoe_data->fsoe_crc, 0, sizeof(lcec_el1918_logic_fsoe_crc_t));
+      fsoe_data->fsoe_crc = LCEC_HAL_ALLOCATE_ARRAY(lcec_el1918_logic_fsoe_crc_t, fsoeConf->data_channels);
 
       // initialize POD entries
       lcec_pdo_init(slave, 0x7080 + (fsoe_idx << 4), 0x01, &fsoe_data->fsoe_slave_cmd_os, NULL);

--- a/src/devices/lcec_el1xxx.c
+++ b/src/devices/lcec_el1xxx.c
@@ -58,7 +58,7 @@ static void lcec_el1xxx_read(lcec_slave_t *slave, long period);
 
 static int lcec_el1xxx_init(int comp_id, lcec_slave_t *slave) {
   lcec_class_din_channels_t *hal_data;
-  int i;
+  unsigned int i;
 
   // initialize callbacks
   slave->proc_read = lcec_el1xxx_read;

--- a/src/devices/lcec_el2202.c
+++ b/src/devices/lcec_el2202.c
@@ -102,11 +102,7 @@ static int lcec_el2202_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el2202_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el2202_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el2202_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el2202_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -146,11 +146,7 @@ static int lcec_el2521_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el2521_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el2521_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el2521_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el2521_data_t);
   slave->hal_data = hal_data;
 
   // read sdos

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -95,13 +95,13 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, freq), "%s.%s.%s.stp-freq"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, maxvel), "%s.%s.%s.stp-maxvel"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, maxaccel_fall), "%s.%s.%s.stp-maxaccel-fall"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_el2521_data_t, maxaccel_rise), "%s.%s.%s.stp-maxaccel-rise"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el2521_data_t, pos_scale), "%s.%s.%s.stp-pos-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_el2521_in[] = {

--- a/src/devices/lcec_el2904.c
+++ b/src/devices/lcec_el2904.c
@@ -113,11 +113,7 @@ static int lcec_el2904_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el2904_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el2904_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el2904_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el2904_data_t);
   slave->hal_data = hal_data;
 
   // initialize POD entries

--- a/src/devices/lcec_el2xxx.c
+++ b/src/devices/lcec_el2xxx.c
@@ -55,7 +55,7 @@ static void lcec_el2xxx_write(lcec_slave_t *slave, long period);
 
 static int lcec_el2xxx_init(int comp_id, lcec_slave_t *slave) {
   lcec_class_dout_channels_t *hal_data;
-  int i;
+  unsigned int i;
 
   // initialize callbacks
   slave->proc_write = lcec_el2xxx_write;

--- a/src/devices/lcec_el31x2.c
+++ b/src/devices/lcec_el31x2.c
@@ -99,11 +99,7 @@ static int lcec_el31x2_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el31x2_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el31x2_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el31x2_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el31x2_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el3255.c
+++ b/src/devices/lcec_el3255.c
@@ -156,11 +156,7 @@ static int lcec_el3255_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el3255_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el3255_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el3255_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el3255_data_t);
   slave->hal_data = hal_data;
 
   // initialize sync info

--- a/src/devices/lcec_el3403.c
+++ b/src/devices/lcec_el3403.c
@@ -205,11 +205,7 @@ static int lcec_el3403_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el3403_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el3403_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el3403_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el3403_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el3xxx.c
+++ b/src/devices/lcec_el3xxx.c
@@ -220,7 +220,6 @@ static int set_wires(lcec_slave_t *slave, char *wires_name, lcec_class_ain_chann
 
 /// @brief Initialize an EL3xxx device.
 static int lcec_el3xxx_init(int comp_id, lcec_slave_t *slave) {
-  lcec_master_t *master = slave->master;
   lcec_class_ain_channels_t *hal_data;
   uint64_t flags;
 
@@ -230,10 +229,6 @@ static int lcec_el3xxx_init(int comp_id, lcec_slave_t *slave) {
   rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "- slave is %p\n", slave);
 
   hal_data = lcec_ain_allocate_channels(INPORTS(slave->flags));
-  if (hal_data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
   slave->hal_data = hal_data;
 
   for (int i = 0; i < hal_data->count; i++) {
@@ -243,7 +238,6 @@ static int lcec_el3xxx_init(int comp_id, lcec_slave_t *slave) {
     options->is_pressure = flags & F_PRESSURE;
 
     hal_data->channels[i] = lcec_ain_register_channel(slave, i, 0x6000 + (i << 4), options);
-    if (hal_data->channels[i] == NULL) return -EIO;
   }
 
   slave->proc_read = lcec_el3xxx_read;

--- a/src/devices/lcec_el41x2.c
+++ b/src/devices/lcec_el41x2.c
@@ -104,11 +104,7 @@ static int lcec_el41x2_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el41x2_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el41x2_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el41x2_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el41x2_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el4xxx.c
+++ b/src/devices/lcec_el4xxx.c
@@ -75,18 +75,13 @@ ADD_TYPES(types);
 static void lcec_el4xxx_write(lcec_slave_t *slave, long period);
 
 static int lcec_el4xxx_init(int comp_id, lcec_slave_t *slave) {
-  lcec_master_t *master = slave->master;
   lcec_class_aout_channels_t *hal_data;
-  int i;
+  unsigned int i;
 
   // initialize callbacks
   slave->proc_write = lcec_el4xxx_write;
 
   hal_data = lcec_aout_allocate_channels(OUTPORTS(slave->flags));
-  if (hal_data == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
   slave->hal_data = hal_data;
 
   // initialize pins

--- a/src/devices/lcec_el5002.c
+++ b/src/devices/lcec_el5002.c
@@ -238,11 +238,7 @@ static int lcec_el5002_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el5002_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el5002_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el5002_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el5002_data_t);
   slave->hal_data = hal_data;
 
   // initialize sync info

--- a/src/devices/lcec_el5032.c
+++ b/src/devices/lcec_el5032.c
@@ -138,11 +138,7 @@ static int lcec_el5032_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el5032_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el5032_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el5032_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el5032_data_t);
   slave->hal_data = hal_data;
 
   // initialize sync info

--- a/src/devices/lcec_el5101.c
+++ b/src/devices/lcec_el5101.c
@@ -155,11 +155,7 @@ static int lcec_el5101_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el5101_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el5101_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el5101_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el5101_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el5102.c
+++ b/src/devices/lcec_el5102.c
@@ -142,11 +142,7 @@ static int lcec_el5102_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el5102_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el5102_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el5102_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el5102_data_t);
   slave->hal_data = hal_data;
 
   for (int channel = 0; channel < 2; channel++) {

--- a/src/devices/lcec_el5151.c
+++ b/src/devices/lcec_el5151.c
@@ -184,11 +184,7 @@ static int lcec_el5151_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el5151_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el5151_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el5151_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el5151_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el5152.c
+++ b/src/devices/lcec_el5152.c
@@ -174,11 +174,7 @@ static int lcec_el5152_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el5152_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el5152_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el5152_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el5152_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_el6090.c
+++ b/src/devices/lcec_el6090.c
@@ -261,11 +261,7 @@ static int lcec_el6090_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el6090_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el6090_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el6090_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el6090_data_t);
   slave->hal_data = hal_data;
 
   // initialize sync info

--- a/src/devices/lcec_el6900.c
+++ b/src/devices/lcec_el6900.c
@@ -140,7 +140,7 @@ static int init_std_pdos(lcec_slave_t *slave, int pid, lcec_el6900_fsoe_io_t *io
     lcec_pdo_init(slave, index, 0x01 + count, &io->os, &io->bp);
 
     // export pin
-    if ((err = lcec_pin_newf(HAL_BIT, dir, (void *)&io->pin, "%s.%s.%s.%s", LCEC_MODULE_NAME, master->name, slave->name, p->value.str)) !=
+    if ((err = lcec_pin_newf(HAL_BIT, dir, (void **)&io->pin, "%s.%s.%s.%s", LCEC_MODULE_NAME, master->name, slave->name, p->value.str)) !=
         0) {
       return err;
     }
@@ -226,11 +226,7 @@ static int lcec_el6900_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el6900_data_t) + fsoe_idx * sizeof(lcec_el6900_fsoe_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el6900_data_t));
+  hal_data = LCEC_HAL_ALLOCATE_ARRAY(lcec_el6900_data_t, fsoe_idx * sizeof(lcec_el6900_fsoe_t));
   hal_data->fsoe_count = fsoe_idx;
   slave->hal_data = hal_data;
 
@@ -268,11 +264,7 @@ static int lcec_el6900_init(int comp_id, lcec_slave_t *slave) {
       fsoeConf = fsoe_slave->fsoeConf;
 
       // alloc crc hal memory
-      if ((fsoe_data->fsoe_crc = hal_malloc(fsoeConf->data_channels * sizeof(lcec_el6900_fsoe_crc_t))) == NULL) {
-        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for fsoe_slave %s.%s crc data failed\n", master->name, fsoe_slave->name);
-        return -EIO;
-      }
-      memset(fsoe_data->fsoe_crc, 0, sizeof(lcec_el6900_fsoe_crc_t));
+      fsoe_data->fsoe_crc = LCEC_HAL_ALLOCATE_ARRAY(lcec_el6900_fsoe_crc_t, fsoeConf->data_channels);
 
       // initialize POD entries
       lcec_pdo_init(slave, 0x7000 + (fsoe_idx << 4), 0x01, &fsoe_data->fsoe_slave_cmd_os, NULL);

--- a/src/devices/lcec_el7041.c
+++ b/src/devices/lcec_el7041.c
@@ -502,11 +502,7 @@ static int lcec_el7041_init(int comp_id, lcec_slave_t *s) {
   s->proc_write = lcec_el7041_write;
 
   // alloc hal memory
-  if ((hd = hal_malloc(sizeof(lcec_el7041_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", m->name, s->name);
-    return -EIO;
-  }
-  memset(hd, 0, sizeof(lcec_el7041_data_t));
+  hd = LCEC_HAL_ALLOCATE(lcec_el7041_data_t);
   s->hal_data = hd;
 
   // initialize sync info

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -320,11 +320,7 @@ static int lcec_el70x1_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el70x1_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el70x1_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el70x1_data_t);
   slave->hal_data = hal_data;
 
   // initialize POD entries

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -246,11 +246,11 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el70x1_data_t, stm_pos_scale), "%s.%s.%s.srv-pos-scale"},
     {HAL_BIT, HAL_RW, offsetof(lcec_el70x1_data_t, auto_fault_reset), "%s.%s.%s.auto-fault-reset"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el70x1_data_t, auto_reduce_tourque_delay), "%s.%s.%s.auto-reduce-torque-delay"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static int lcec_el7031_init(int comp_id, lcec_slave_t *slave) {

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -207,16 +207,7 @@ static void lcec_el7201_9014_read(lcec_slave_t *slave, long period);
 static void lcec_el7211_write(lcec_slave_t *slave, long period);
 
 static lcec_el7211_data_t *lcec_el7211_alloc_hal(lcec_master_t *master, lcec_slave_t *slave) {
-  lcec_el7211_data_t *hal_data;
-
-  // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el7211_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return NULL;
-  }
-  memset(hal_data, 0, sizeof(lcec_el7211_data_t));
-
-  return hal_data;
+  return LCEC_HAL_ALLOCATE(lcec_el7211_data_t);
 }
 
 static int lcec_el7211_export_pins(lcec_master_t *master, lcec_slave_t *slave, lcec_el7211_data_t *hal_data) {

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -130,7 +130,7 @@ static const lcec_pindesc_t slave_pins_el7201_9014[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, scale), "%s.%s.%s.scale"},
     {HAL_U32, HAL_RO, offsetof(lcec_el7211_data_t, vel_resolution), "%s.%s.%s.vel-resolution"},
     {HAL_U32, HAL_RO, offsetof(lcec_el7211_data_t, pos_resolution), "%s.%s.%s.pos-resolution"},
@@ -138,7 +138,7 @@ static const lcec_pindesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, max_vel), "%s.%s.%s.max-vel"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, max_accel), "%s.%s.%s.max-accel"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_el7211_data_t, at_speed_window), "%s.%s.%s.at-speed-window"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_el7211_in_pos[] = {

--- a/src/devices/lcec_el7342.c
+++ b/src/devices/lcec_el7342.c
@@ -395,11 +395,7 @@ static int lcec_el7342_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_el7342_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el7342_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el7342_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el7342_data_t);
   slave->hal_data = hal_data;
 
   // initialize sync info

--- a/src/devices/lcec_el95xx.c
+++ b/src/devices/lcec_el95xx.c
@@ -60,11 +60,7 @@ static int lcec_el95xx_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_read = lcec_el95xx_read;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_el95xx_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_el95xx_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_el95xx_data_t);
   slave->hal_data = hal_data;
 
   // initialize POD entries

--- a/src/devices/lcec_em7004.c
+++ b/src/devices/lcec_em7004.c
@@ -182,11 +182,7 @@ static int lcec_em7004_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_em7004_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_em7004_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_em7004_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_em7004_data_t);
   slave->hal_data = hal_data;
 
   // initialize global data

--- a/src/devices/lcec_em7004.c
+++ b/src/devices/lcec_em7004.c
@@ -128,9 +128,9 @@ static const lcec_pindesc_t slave_dout_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_dout_params[] = {
+static const lcec_paramdesc_t slave_dout_params[] = {
     {HAL_BIT, HAL_RW, offsetof(lcec_em7004_dout_t, invert), "%s.%s.%s.dout-%d-invert"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static const lcec_pindesc_t slave_aout_pins[] = {

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -210,7 +210,7 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_00_scale), "%s.%s.%s.axis0-enc-scale"},
+static const lcec_paramdesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_00_scale), "%s.%s.%s.axis0-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_01_scale), "%s.%s.%s.axis1-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_02_scale), "%s.%s.%s.axis2-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_03_scale), "%s.%s.%s.axis3-enc-scale"},
@@ -234,7 +234,8 @@ static const lcec_pindesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_
     {HAL_BIT, HAL_RW, offsetof(lcec_fr4000_data_t, update_03_position), "%s.%s.%s.axis3-update-position"},
     {HAL_BIT, HAL_RW, offsetof(lcec_fr4000_data_t, update_04_position), "%s.%s.%s.axis4-update-position"},
 
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED},
+};
 
 static ec_pdo_entry_info_t lcec_fr4000_pdo_entries[] = {
     {0x7000, 0x01, 16}, /* Spindle vel */

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -378,11 +378,7 @@ int lcec_fr4000_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_fr4000_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_fr4000_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_fr4000_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_fr4000_data_t);
   slave->hal_data = hal_data;
 
   // initializer sync info

--- a/src/devices/lcec_ex260.c
+++ b/src/devices/lcec_ex260.c
@@ -50,18 +50,14 @@ static int lcec_ex260_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_ex260_pin_t *hal_data;
   lcec_ex260_pin_t *pin;
-  int i;
+  unsigned int i;
   int err;
 
   // initialize callbacks
   slave->proc_write = lcec_ex260_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_ex260_pin_t) * slave->flags)) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_ex260_pin_t) * slave->flags);
+  hal_data = LCEC_HAL_ALLOCATE_ARRAY(lcec_ex260_pin_t, slave->flags);
   slave->hal_data = hal_data;
 
   // initialize pins
@@ -82,7 +78,7 @@ static void lcec_ex260_write(lcec_slave_t *slave, long period) {
   lcec_ex260_pin_t *hal_data = (lcec_ex260_pin_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
   lcec_ex260_pin_t *pin;
-  int i, s;
+  unsigned int i, s;
 
   // wait for slave to be operational
   if (!slave->state.operational) {

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -217,11 +217,7 @@ static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_omrg5_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_omrg5_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_omrg5_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_omrg5_data_t);
   slave->hal_data = hal_data;
 
   // set to cyclic synchronous position mode

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -161,10 +161,10 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t slave_params[] = {
+static const lcec_paramdesc_t slave_params[] = {
     {HAL_FLOAT, HAL_RW, offsetof(lcec_omrg5_data_t, pos_scale), "%s.%s.%s.pos-scale"},
     {HAL_BIT, HAL_RW, offsetof(lcec_omrg5_data_t, auto_fault_reset), "%s.%s.%s.auto-fault-reset"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 static ec_pdo_entry_info_t lcec_omrg5_in[] = {

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -151,11 +151,7 @@ static int lcec_ph3lm2rm_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_ph3lm2rm_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_ph3lm2rm_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_ph3lm2rm_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_ph3lm2rm_data_t);
   slave->hal_data = hal_data;
 
   // initialize POD entries

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -102,20 +102,23 @@ static const lcec_pindesc_t enc_pins[] = {{HAL_BIT, HAL_IO, offsetof(lcec_ph3lm2
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_valid), "%s.%s.%s.%s-latch-valid"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_state), "%s.%s.%s.%s-latch-state"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_state_not), "%s.%s.%s.%s-latch-state-not"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},};
 
-static const lcec_pindesc_t enc_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_ph3lm2rm_enc_data_t, scale), "%s.%s.%s.%s-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+static const lcec_paramdesc_t enc_params[] = {
+  {HAL_FLOAT, HAL_RW, offsetof(lcec_ph3lm2rm_enc_data_t, scale), "%s.%s.%s.%s-scale"},
+  {HAL_TYPE_UNSPECIFIED},
+};
 
 static const lcec_pindesc_t lm_pins[] = {{HAL_U32, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level), "%s.%s.%s.%s-signal-level"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_warn), "%s.%s.%s.%s-signal-level-warn"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_err), "%s.%s.%s.%s-signal-level-err"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},};
 
-static const lcec_pindesc_t lm_params[] = {
+static const lcec_paramdesc_t lm_params[] = {
     {HAL_U32, HAL_RW, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_warn_val), "%s.%s.%s.%s-signal-level-warn-val"},
     {HAL_U32, HAL_RW, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_err_val), "%s.%s.%s.%s-signal-level-err-val"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED},
+};
 
 static const lcec_pindesc_t rm_pins[] = {{HAL_BIT, HAL_IN, offsetof(lcec_ph3lm2rm_rm_data_t, latch_sel_idx), "%s.%s.%s.%s-latch-sel-idx"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -181,7 +181,7 @@ static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *op
   uint16_t input_polarity = 0, input_polarity_set = 0;
   uint16_t output_polarity = 0, output_polarity_set = 0;
   uint32_t uval;
-  int v;
+  int val, v;
 
   // Read current polarity values, so we don't overwrite them all.
   lcec_read_sdo16(slave, 0x2006, 0, &output_polarity);
@@ -205,123 +205,123 @@ static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *op
         if (lcec_write_sdo16_modparam(slave, 0x2003, 0, p->value.u32, p->name) < 0) return -1;
         break;
       case M_OUTPUT1FUNC:
-        uval = lcec_lookupint_i(rtec_outputfunc, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_outputfunc, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"output1Func\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2005, 1, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2005, 1, val, p->name) < 0) return -1;
         break;
       case M_OUTPUT2FUNC:
-        uval = lcec_lookupint_i(rtec_outputfunc, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_outputfunc, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"output2Func\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2005, 2, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2005, 2, val, p->name) < 0) return -1;
         break;
       case M_OUTPUT1POLARITY:
-        uval = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"output1Polarity\"> for slave %s.%s\n",
               master->name, slave->name);
           return -1;
         }
         output_polarity &= ~1;  // Clear the 0 bit.
-        output_polarity |= (uval & 1);
+        output_polarity |= (val & 1);
         output_polarity_set = 1;
         break;
       case M_OUTPUT2POLARITY:
-        uval = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"output2Polarity\"> for slave %s.%s\n",
               master->name, slave->name);
           return -1;
         }
         output_polarity &= ~2;  // Clear the 1 bit.
-        output_polarity |= (uval & 1) << 1;
+        output_polarity |= (val & 1) << 1;
         output_polarity_set = 1;
         break;
       case M_INPUT3FUNC:
-        uval = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input3Func\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2007, 3, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2007, 3, val, p->name) < 0) return -1;
         break;
       case M_INPUT4FUNC:
-        uval = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input4Func\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2007, 4, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2007, 4, val, p->name) < 0) return -1;
         break;
       case M_INPUT5FUNC:
-        uval = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input5Func\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2007, 5, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2007, 5, val, p->name) < 0) return -1;
         break;
       case M_INPUT6FUNC:
-        uval = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_inputfunc, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input6Func\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2007, 6, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2007, 6, val, p->name) < 0) return -1;
         break;
       case M_INPUT3POLARITY:
-        uval = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input3Polarity\"> for slave %s.%s\n",
               master->name, slave->name);
           return -1;
         }
         input_polarity &= ~(1 << 2);
-        input_polarity |= (uval & 1) << 2;
+        input_polarity |= (val & 1) << 2;
         input_polarity_set = 1;
         break;
       case M_INPUT4POLARITY:
-        uval = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input4Polarity\"> for slave %s.%s\n",
               master->name, slave->name);
           return -1;
         }
         input_polarity &= ~(1 << 3);
-        input_polarity |= (uval & 1) << 3;
+        input_polarity |= (val & 1) << 3;
         input_polarity_set = 1;
         break;
       case M_INPUT5POLARITY:
-        uval = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input5Polarity\"> for slave %s.%s\n",
               master->name, slave->name);
           return -1;
         }
         input_polarity &= ~(1 << 4);
-        input_polarity |= (uval & 1) << 4;
+        input_polarity |= (val & 1) << 4;
         input_polarity_set = 1;
         break;
       case M_INPUT6POLARITY:
-        uval = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_polarity, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"input6Polarity\"> for slave %s.%s\n",
               master->name, slave->name);
           return -1;
         }
         input_polarity &= ~(1 << 5);
-        input_polarity |= (uval & 1) << 5;
+        input_polarity |= (val & 1) << 5;
         input_polarity_set = 1;
         break;
       case M_FILTERTIME:
@@ -334,22 +334,22 @@ static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *op
         if (lcec_write_sdo16_modparam(slave, 0x200b, 1, !!p->value.bit, p->name) < 0) return -1;
         break;
       case M_STEPPERPHASES:
-        uval = lcec_lookupint_i(rtec_stepperphases, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_stepperphases, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"stepperPhases\"> for slave %s.%s\n", master->name,
               slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x200c, 1, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x200c, 1, val, p->name) < 0) return -1;
         break;
       case M_CONTROLMODE:
-        uval = lcec_lookupint_i(rtec_controlmode, p->value.str, -1);
-        if (uval == -1) {
+        val = lcec_lookupint_i(rtec_controlmode, p->value.str, -1);
+        if (val == -1) {
           rtapi_print_msg(
               RTAPI_MSG_ERR, LCEC_MSG_PFX "invalid value for <modparam name=\"controlMode\"> for slave %s.%s\n", master->name, slave->name);
           return -1;
         }
-        if (lcec_write_sdo16_modparam(slave, 0x2011, 0, uval, p->name) < 0) return -1;
+        if (lcec_write_sdo16_modparam(slave, 0x2011, 0, val, p->name) < 0) return -1;
         break;
       case M_ENCODER_RESOLUTION:
         if (lcec_write_sdo16_modparam(slave, 0x2020, 0, p->value.u32, p->name) < 0) return -1;
@@ -402,11 +402,7 @@ static int lcec_rtec_init(int comp_id, lcec_slave_t *slave) {
   int err;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_rtec_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", slave->master->name, slave->name);
-    return -EIO;
-  }
-  memset(hal_data, 0, sizeof(lcec_rtec_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_rtec_data_t);
   slave->hal_data = hal_data;
 
   // initialize callbacks

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -159,12 +159,13 @@ static const lcec_pindesc_t slave_pins[] = {{HAL_FLOAT, HAL_IN, offsetof(lcec_st
     {HAL_BIT, HAL_IN, offsetof(lcec_stmds5k_data_t, fast_ramp), "%s.%s.%s.srv-fast-ramp"},
     {HAL_BIT, HAL_IN, offsetof(lcec_stmds5k_data_t, brake), "%s.%s.%s.srv-brake"}, {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
 
-static const lcec_pindesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, pos_scale), "%s.%s.%s.srv-pos-scale"},
+static const lcec_paramdesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, pos_scale), "%s.%s.%s.srv-pos-scale"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, torque_reference), "%s.%s.%s.srv-torque-ref"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, speed_max_rpm), "%s.%s.%s.srv-max-rpm"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, speed_max_rpm_sp), "%s.%s.%s.srv-max-rpm-sp"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, extenc_scale), "%s.%s.%s.extenc-scale"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
+    {HAL_TYPE_UNSPECIFIED},
+};
 
 static const lcec_stmds5k_syncs_t lcec_stmds5k_syncs_tmpl = {.out_ch1 =
                                                                  {

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -274,11 +274,7 @@ static int lcec_stmds5k_init(int comp_id, lcec_slave_t *slave) {
   slave->proc_write = lcec_stmds5k_write;
 
   // alloc hal memory
-  if ((hal_data = hal_malloc(sizeof(lcec_stmds5k_data_t))) == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for slave %s.%s failed\n", master->name, slave->name);
-    return -ENOMEM;
-  }
-  memset(hal_data, 0, sizeof(lcec_stmds5k_data_t));
+  hal_data = LCEC_HAL_ALLOCATE(lcec_stmds5k_data_t);
   slave->hal_data = hal_data;
 
   // read sdos

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -23,6 +23,10 @@
 #ifndef _LCEC_H_
 #define _LCEC_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ecrt.h"
 #include "hal.h"
 #include "lcec_conf.h"
@@ -30,6 +34,10 @@
 #include "rtapi_ctype.h"
 #include "rtapi_math.h"
 #include "rtapi_string.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 // list macros
 #define LCEC_LIST_APPEND(first, last, item) \
@@ -106,7 +114,7 @@ typedef struct {
 
 /// @brief Definition of a device that LinuxCNC-Ethercat supports.
 typedef struct {
-  char *name;                             ///< The device's name ("EL1008")
+  const char *name;                             ///< The device's name ("EL1008")
   uint32_t vid;                           ///< The EtherCAT vendor ID
   uint32_t pid;                           ///< The EtherCAT product ID
   int is_fsoe_logic;                      ///< Does this device use Safety-over-EtherCAT?
@@ -272,6 +280,14 @@ typedef struct {
   const char *fmt;    ///< Format string for generating pin names via sprintf().
 } lcec_pindesc_t;
 
+/// @brief HAL pin description.
+typedef struct {
+  hal_type_t type;    ///< HAL type of this pin (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
+  hal_param_dir_t dir;  ///< Direction for this pin (`HAL_IN`, `HAL_OUT`, or `HAL_IO`).
+  int offset;         ///< Offset for this pin's data in `hal_data`.
+  const char *fmt;    ///< Format string for generating pin names via sprintf().
+} lcec_paramdesc_t;
+
 /// @brief Sync manager configuration.
 typedef struct {
   lcec_slave_t *slave; ///< For debugging messages
@@ -323,8 +339,8 @@ int lcec_write_sdo32_modparam(lcec_slave_t *slave, uint16_t index, uint8_t subin
 
 int lcec_pin_newf(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_addr, const char *fmt, ...);
 int lcec_pin_newf_list(void *base, const lcec_pindesc_t *list, ...);
-int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, ...);
-int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...);
+int lcec_param_newf(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, ...);
+int lcec_param_newf_list(void *base, const lcec_paramdesc_t *list, ...);
 
 void copy_fsoe_data(lcec_slave_t *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
 void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) __attribute__((nonnull));
@@ -333,8 +349,8 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
 void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);
 
 const lcec_typelist_t *lcec_findslavetype(const char *name) __attribute__((nonnull));
-void lcec_addtype(lcec_typelist_t *type, char *sourcefile) __attribute__((nonnull));
-void lcec_addtypes(lcec_typelist_t types[], char *sourcefile) __attribute__((nonnull));
+void lcec_addtype(lcec_typelist_t *type, const char *sourcefile) __attribute__((nonnull));
+void lcec_addtypes(lcec_typelist_t types[], const char *sourcefile) __attribute__((nonnull));
 
 int lcec_lookupint(const lcec_lookuptable_int_t *table, const char *key, int default_value) __attribute__((nonnull));
 int lcec_lookupint_i(const lcec_lookuptable_int_t *table, const char *key, int default_value) __attribute__((nonnull));

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -90,6 +90,33 @@ extern "C" {
 #define LCEC_MAX_PDO_INFO_COUNT  16    ///< The maximum number of PDOs in a sync.
 #define LCEC_MAX_SYNC_COUNT      4    ///< The maximum number of syncs.
 
+// Memory allocation macros.  These differ from malloc in a couple
+// substantial ways.  First, they check for NULL and call exit(1), so
+// there's no point in comparing their return value to NULL.  If
+// memory allocation fails, then we're broken and there's no point in
+// going on.  Next, they always 0 the allocated memory, so there's no
+// point in calling memset() on the result.  Finally, they take a
+// *type*, not a size_t, and cast the result into a pointer-to-type,
+// so compiling this as C++ doesn't cause untold numbers of errors.
+
+/// Allocate memory for an `expr`.  This zeros out the allocated memory automatically, and exits if malloc fails.
+#define LCEC_HAL_ALLOCATE(expr) ((__typeof__(expr) *)lcec_hal_malloc(sizeof(expr), __FILE__, __func__, __LINE__))
+
+/// Allocate memory for a string of `len` bytes.  This zeros out the allocated memory automatically, and exits if malloc fails.
+#define LCEC_HAL_ALLOCATE_STRING(len) ((char *)lcec_hal_malloc(len, __FILE__, __func__, __LINE__))
+
+/// Allocate memory for an array of `count` `expr`s.  This zeros out the allocated memory automatically, and exits if malloc fails.
+#define LCEC_HAL_ALLOCATE_ARRAY(expr, count) ((__typeof__(expr) *)lcec_hal_malloc(sizeof(expr) * count, __FILE__, __func__, __LINE__))
+
+/// Allocate memory for an `expr`.  This zeros out the allocated memory automatically, and exits if malloc fails.
+#define LCEC_ALLOCATE(expr) ((__typeof__(expr) *)lcec_malloc(sizeof(expr), __FILE__, __func__, __LINE__))
+
+/// Allocate memory for a string of `len` bytes.  This zeros out the allocated memory automatically, and exits if malloc fails.
+#define LCEC_ALLOCATE_STRING(len) ((char *)lcec_malloc(len, __FILE__, __func__, __LINE__))
+
+/// Allocate memory for an array of `count` `expr`s.  This zeros out the allocated memory automatically, and exits if malloc fails.
+#define LCEC_ALLOCATE_ARRAY(expr, count) ((__typeof__(expr) *)lcec_malloc(sizeof(expr) * count, __FILE__, __func__, __LINE__))
+
 typedef struct lcec_master lcec_master_t;
 typedef struct lcec_slave lcec_slave_t;
 
@@ -122,7 +149,7 @@ typedef struct {
   lcec_slave_init_t proc_init;            ///< init function.  Sets up the device.
   const lcec_modparam_desc_t *modparams;  ///< XML modparams, if any
   uint64_t flags;                         ///< Flags, passed through to `proc_init` as `slave->flags`.
-  char *sourcefile;                       ///< Source filename, autopopulated.
+  const char *sourcefile;                       ///< Source filename, autopopulated.
 } lcec_typelist_t;
 
 /// @brief Linked list for holding device type definitions.
@@ -365,5 +392,8 @@ lcec_pdo_entry_reg_t *lcec_allocate_pdo_entry_reg(int size);
 int lcec_pdo_init(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, unsigned int *os, unsigned int *bp);
 int lcec_pdo_entry_reg_len(lcec_pdo_entry_reg_t *reg);
 int lcec_append_pdo_entry_reg(lcec_pdo_entry_reg_t *dest, lcec_pdo_entry_reg_t *src);
+
+void *lcec_hal_malloc(size_t size, const char *file, const char *func, int line);
+void *lcec_malloc(size_t size, const char *file, const char *func, int line);
 
 #endif

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
   char buffer[BUFFSIZE];
   FILE *file;
   LCEC_CONF_NULL_T *end;
-  void *shmem_ptr;
+  char *shmem_ptr;
   LCEC_CONF_HEADER_T *header;
   uint64_t u;
   LCEC_CONF_XML_STATE_T state;
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
   }
 
   // allocate hal memory
-  conf_hal_data = hal_malloc(sizeof(LCEC_CONF_HAL_T));
+  conf_hal_data = LCEC_HAL_ALLOCATE(LCEC_CONF_HAL_T);
   if (conf_hal_data == NULL) {
     fprintf(stderr, "%s: ERROR: unable to allocate HAL shared memory\n", modname);
     goto fail1;
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
   }
 
   // set end marker
-  end = addOutputBuffer(&state.outputBuf, sizeof(LCEC_CONF_NULL_T));
+  end = ADD_OUTPUT_BUFFER(&state.outputBuf, LCEC_CONF_NULL_T);
   if (end == NULL) {
     goto fail4;
   }
@@ -205,13 +205,13 @@ int main(int argc, char **argv) {
     fprintf(stderr, "%s: ERROR: couldn't allocate user/RT shared memory\n", modname);
     goto fail4;
   }
-  if (lcec_rtapi_shmem_getptr(shmem_id, &shmem_ptr) < 0) {
+  if (lcec_rtapi_shmem_getptr(shmem_id, (void **)&shmem_ptr) < 0) {
     fprintf(stderr, "%s: ERROR: couldn't map user/RT shared memory\n", modname);
     goto fail5;
   }
 
   // setup header
-  header = shmem_ptr;
+  header = (LCEC_CONF_HEADER_T*)shmem_ptr;
   shmem_ptr += sizeof(LCEC_CONF_HEADER_T);
   header->magic = LCEC_CONF_SHMEM_MAGIC;
   header->length = state.outputBuf.len;
@@ -246,7 +246,7 @@ fail0:
 static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
-  LCEC_CONF_MASTER_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_MASTER_T));
+  LCEC_CONF_MASTER_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_MASTER_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -302,7 +302,7 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
 
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
-  LCEC_CONF_SLAVE_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_SLAVE_T));
+  LCEC_CONF_SLAVE_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_SLAVE_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -407,7 +407,7 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
 static void parseDcConfAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
-  LCEC_CONF_DC_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_DC_T));
+  LCEC_CONF_DC_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_DC_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -458,7 +458,7 @@ static void parseDcConfAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
 static void parseWatchdogAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
-  LCEC_CONF_WATCHDOG_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_WATCHDOG_T));
+  LCEC_CONF_WATCHDOG_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_WATCHDOG_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -492,7 +492,7 @@ static void parseSdoConfigAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
   int tmp;
-  LCEC_CONF_SDOCONF_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_SDOCONF_T));
+  LCEC_CONF_SDOCONF_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_SDOCONF_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -561,7 +561,7 @@ static void parseIdnConfigAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
   int tmp;
-  LCEC_CONF_IDNCONF_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_IDNCONF_T));
+  LCEC_CONF_IDNCONF_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_IDNCONF_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -570,7 +570,7 @@ static void parseIdnConfigAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char
   p->confType = lcecConfTypeIdnConfig;
   p->drive = 0;
   p->idn = 0xffff;
-  p->state = 0;
+  p->state = (ec_al_state_t)0;
   while (*attr) {
     const char *name = *(attr++);
     const char *val = *(attr++);
@@ -766,7 +766,7 @@ static void parseSyncManagerAttrs(LCEC_CONF_XML_INST_T *inst, int next, const ch
     return;
   }
 
-  p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_SYNCMANAGER_T));
+  p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_SYNCMANAGER_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -834,7 +834,7 @@ static void parsePdoAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **att
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
   int tmp;
-  LCEC_CONF_PDO_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_PDO_T));
+  LCEC_CONF_PDO_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_PDO_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -881,7 +881,7 @@ static void parsePdoEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
 
   int tmp;
   int floatReq;
-  LCEC_CONF_PDOENTRY_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_PDOENTRY_T));
+  LCEC_CONF_PDOENTRY_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_PDOENTRY_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -1052,7 +1052,7 @@ static void parseComplexEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const c
 
   int tmp;
   int floatReq;
-  LCEC_CONF_COMPLEXENTRY_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_COMPLEXENTRY_T));
+  LCEC_CONF_COMPLEXENTRY_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_COMPLEXENTRY_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;
@@ -1184,7 +1184,7 @@ static void parseModParamAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
     return;
   }
 
-  LCEC_CONF_MODPARAM_T *p = addOutputBuffer(&state->outputBuf, sizeof(LCEC_CONF_MODPARAM_T));
+  LCEC_CONF_MODPARAM_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_MODPARAM_T);
   if (p == NULL) {
     XML_StopParser(inst->parser, 0);
     return;

--- a/src/lcec_conf_icmds.c
+++ b/src/lcec_conf_icmds.c
@@ -98,7 +98,7 @@ static const LCEC_CONF_XML_HANLDER_T xml_states[] = {
     {"NULL", -1, -1, NULL, NULL},
 };
 
-static long int parse_int(LCEC_CONF_ICMDS_STATE_T *state, const char *s, int len, long int min, long int max);
+static long int parse_int(LCEC_CONF_ICMDS_STATE_T *state, const char *s, unsigned int len, long int min, long int max);
 static int parse_data(LCEC_CONF_ICMDS_STATE_T *state, const char *s, int len);
 
 int parseIcmds(LCEC_CONF_SLAVE_T *slave, LCEC_CONF_OUTBUF_T *outputBuf, const char *filename) {
@@ -219,7 +219,7 @@ static void xml_data_handler(void *data, const XML_Char *s, int len) {
 static void icmdTypeCoeIcmdStart(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
   LCEC_CONF_ICMDS_STATE_T *state = (LCEC_CONF_ICMDS_STATE_T *)inst;
 
-  state->currSdoConf = addOutputBuffer(state->outputBuf, sizeof(LCEC_CONF_SDOCONF_T));
+  state->currSdoConf = ADD_OUTPUT_BUFFER(state->outputBuf, LCEC_CONF_SDOCONF_T);
 
   if (state->currSdoConf == NULL) {
     XML_StopParser(inst->parser, 0);
@@ -265,7 +265,7 @@ static void icmdTypeCoeIcmdEnd(LCEC_CONF_XML_INST_T *inst, int next) {
 static void icmdTypeSoeIcmdStart(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
   LCEC_CONF_ICMDS_STATE_T *state = (LCEC_CONF_ICMDS_STATE_T *)inst;
 
-  state->currIdnConf = addOutputBuffer(state->outputBuf, sizeof(LCEC_CONF_IDNCONF_T));
+  state->currIdnConf = ADD_OUTPUT_BUFFER(state->outputBuf, LCEC_CONF_IDNCONF_T);
 
   if (state->currIdnConf == NULL) {
     XML_StopParser(inst->parser, 0);
@@ -275,7 +275,7 @@ static void icmdTypeSoeIcmdStart(LCEC_CONF_XML_INST_T *inst, int next, const cha
   state->currIdnConf->confType = lcecConfTypeIdnConfig;
   state->currIdnConf->drive = 0;
   state->currIdnConf->idn = 0xffff;
-  state->currIdnConf->state = 0;
+  state->currIdnConf->state = (ec_al_state_t)0;
 }
 
 static void icmdTypeSoeIcmdEnd(LCEC_CONF_XML_INST_T *inst, int next) {
@@ -296,7 +296,7 @@ static void icmdTypeSoeIcmdEnd(LCEC_CONF_XML_INST_T *inst, int next) {
   state->currSlave->idnConfigLength += sizeof(LCEC_CONF_IDNCONF_T) + state->currIdnConf->length;
 }
 
-static long int parse_int(LCEC_CONF_ICMDS_STATE_T *state, const char *s, int len, long int min, long int max) {
+static long int parse_int(LCEC_CONF_ICMDS_STATE_T *state, const char *s, unsigned int len, long int min, long int max) {
   char buf[32];
   char *end;
   long int ret;

--- a/src/lcec_conf_priv.h
+++ b/src/lcec_conf_priv.h
@@ -52,11 +52,13 @@ typedef struct {
   size_t len;
 } LCEC_CONF_OUTBUF_T;
 
-extern char *modname;
+extern const char *modname;
+
+#define ADD_OUTPUT_BUFFER(buf, type) ((type *)addOutputBuffer(buf, sizeof(type)))
 
 void initOutputBuffer(LCEC_CONF_OUTBUF_T *buf);
 void *addOutputBuffer(LCEC_CONF_OUTBUF_T *buf, size_t len);
-void copyFreeOutputBuffer(LCEC_CONF_OUTBUF_T *buf, void *dest);
+void copyFreeOutputBuffer(LCEC_CONF_OUTBUF_T *buf, char *dest);
 
 int parseIcmds(LCEC_CONF_SLAVE_T *slave, LCEC_CONF_OUTBUF_T *outputBuf, const char *filename);
 

--- a/src/lcec_conf_util.c
+++ b/src/lcec_conf_util.c
@@ -27,7 +27,7 @@
 #include "lcec_conf.h"
 #include "lcec_conf_priv.h"
 
-char *modname = "lcec_conf";
+const char *modname = "lcec_conf";
 
 static void xml_start_handler(void *data, const char *el, const char **attr);
 static void xml_end_handler(void *data, const char *el);
@@ -39,7 +39,7 @@ void initOutputBuffer(LCEC_CONF_OUTBUF_T *buf) {
 }
 
 void *addOutputBuffer(LCEC_CONF_OUTBUF_T *buf, size_t len) {
-  void *p = calloc(1, sizeof(LCEC_CONF_OUTBUF_ITEM_T) + len);
+  LCEC_CONF_OUTBUF_ITEM_T *p = (LCEC_CONF_OUTBUF_ITEM_T *)calloc(1, sizeof(LCEC_CONF_OUTBUF_ITEM_T) + len);
   if (p == NULL) {
     fprintf(stderr, "%s: ERROR: Couldn't allocate memory for config token\n", modname);
     return NULL;
@@ -63,11 +63,11 @@ void *addOutputBuffer(LCEC_CONF_OUTBUF_T *buf, size_t len) {
   return p;
 }
 
-void copyFreeOutputBuffer(LCEC_CONF_OUTBUF_T *buf, void *dest) {
-  void *p;
+void copyFreeOutputBuffer(LCEC_CONF_OUTBUF_T *buf, char *dest) {
+  char *p;
 
   while (buf->head != NULL) {
-    p = buf->head;
+    p = (char *)buf->head;
     if (dest != NULL) {
       memcpy(dest, p + sizeof(LCEC_CONF_OUTBUF_ITEM_T), buf->head->len);
       dest += buf->head->len;

--- a/src/lcec_devicelist.c
+++ b/src/lcec_devicelist.c
@@ -25,7 +25,7 @@ lcec_typelinkedlist_t *typeslist = NULL;
 
 /// @brief Register a single slave type with LinuxCNC-Ethercat.
 /// @param[in] type the definition of the device type to add.
-void lcec_addtype(lcec_typelist_t *type, char *sourcefile) {
+void lcec_addtype(lcec_typelist_t *type, const char *sourcefile) {
   lcec_typelinkedlist_t *t, *l;
 
   // using malloc instead of hal_malloc because this can be called
@@ -58,7 +58,7 @@ void lcec_addtype(lcec_typelist_t *type, char *sourcefile) {
 
 /// @brief Register an array of new slave types with LinuxCNC-Ethercat.
 /// @param[in] types A list of types to add, terminated with a `NULL`.
-void lcec_addtypes(lcec_typelist_t types[], char *sourcefile) {
+void lcec_addtypes(lcec_typelist_t types[], const char *sourcefile) {
   lcec_typelist_t *type;
 
   for (type = types; type->name != NULL; type++) {

--- a/src/lcec_devicelist.c
+++ b/src/lcec_devicelist.c
@@ -31,11 +31,8 @@ void lcec_addtype(lcec_typelist_t *type, const char *sourcefile) {
   // using malloc instead of hal_malloc because this can be called
   // from either lcec.so (inside of LinuxCNC) or lcec_conf (a
   // standalone binary).
-  t = malloc(sizeof(lcec_typelinkedlist_t));
-  if (t == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "Failed to allocate memory in lcec_addtype(), skipping\n");
-    return;
-  }
+  t = LCEC_ALLOCATE(lcec_typelinkedlist_t);
+
   type->sourcefile = sourcefile;
   t->type = type;
   t->next = NULL;

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -530,7 +530,7 @@ static int lcec_param_newfv_list(void *base, const lcec_paramdesc_t *list, va_li
 
   for (p = list; p->type != HAL_TYPE_UNSPECIFIED; p++) {
     va_copy(ac, ap);
-    err = lcec_param_newfv(p->type, p->dir, (void *)(base + p->offset), p->fmt, ac);
+    err = lcec_param_newfv(p->type, p->dir, ((char*)base + p->offset), p->fmt, ac);
     va_end(ac);
     if (err) {
       return err;
@@ -574,13 +574,12 @@ LCEC_CONF_MODPARAM_VAL_T *lcec_modparam_get(lcec_slave_t *slave, int id) {
 /// @param size The maximum number of entries to allocate room for.
 /// @return  A lcec_pdo_entry_reg_t, or NULL if memory allocation failed.
 lcec_pdo_entry_reg_t *lcec_allocate_pdo_entry_reg(int size) {
-  lcec_pdo_entry_reg_t *reg = hal_malloc(sizeof(lcec_pdo_entry_reg_t));
+  lcec_pdo_entry_reg_t *reg = LCEC_HAL_ALLOCATE(lcec_pdo_entry_reg_t);
   if (reg == NULL) return NULL;
 
   reg->max = size;
   reg->current = 0;
-  reg->pdo_entry_regs = hal_malloc(sizeof(ec_pdo_entry_reg_t) * size);
-  if (reg->pdo_entry_regs == NULL) return NULL;
+  reg->pdo_entry_regs = LCEC_HAL_ALLOCATE_ARRAY(ec_pdo_entry_reg_t, size);
 
   return reg;
 }

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -22,8 +22,8 @@
 
 #include "lcec.h"
 
-static int lcec_param_newfv(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, va_list ap);
-static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list ap);
+static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, va_list ap);
+static int lcec_param_newfv_list(void *base, const lcec_paramdesc_t *list, va_list ap);
 int lcec_comp_id = -1;
 
 /// @brief Find the slave with a specified index underneath a specific master.
@@ -474,7 +474,7 @@ int lcec_read_idn(lcec_slave_t *slave, uint8_t drive_no, uint16_t idn, uint8_t *
   return 0;
 }
 
-static int lcec_param_newfv(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, va_list ap) {
+static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, va_list ap) {
   char name[HAL_NAME_LEN + 1];
   int sz;
   int err;
@@ -512,7 +512,7 @@ static int lcec_param_newfv(hal_type_t type, hal_pin_dir_t dir, void *data_addr,
 }
 
 /// @brief Create a new LinuxCNC `param` dynamically.
-int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const char *fmt, ...) {
+int lcec_param_newf(hal_type_t type, hal_param_dir_t dir, void *data_addr, const char *fmt, ...) {
   va_list ap;
   int err;
 
@@ -523,10 +523,10 @@ int lcec_param_newf(hal_type_t type, hal_pin_dir_t dir, void *data_addr, const c
   return err;
 }
 
-static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list ap) {
+static int lcec_param_newfv_list(void *base, const lcec_paramdesc_t *list, va_list ap) {
   va_list ac;
   int err;
-  const lcec_pindesc_t *p;
+  const lcec_paramdesc_t *p;
 
   for (p = list; p->type != HAL_TYPE_UNSPECIFIED; p++) {
     va_copy(ac, ap);
@@ -541,7 +541,7 @@ static int lcec_param_newfv_list(void *base, const lcec_pindesc_t *list, va_list
 }
 
 /// @brief Create a list of new LinuxCNC params dynamically, using sprintf() to create names.
-int lcec_param_newf_list(void *base, const lcec_pindesc_t *list, ...) {
+int lcec_param_newf_list(void *base, const lcec_paramdesc_t *list, ...) {
   va_list ap;
   int err;
 

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -51,12 +51,12 @@ static const lcec_pindesc_t master_pins[] = {
 };
 
 /// @brief Master params
-static const lcec_pindesc_t master_params[] = {
+static const lcec_paramdesc_t master_params[] = {
 #ifdef RTAPI_TASK_PLL_SUPPORT
     {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, pll_step), "%s.pll-step"},
     {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, pll_max_err), "%s.pll-max-err"},
 #endif
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+    {HAL_TYPE_UNSPECIFIED},
 };
 
 /// @brief Basic Slave pins

--- a/src/lcec_malloc.c
+++ b/src/lcec_malloc.c
@@ -1,5 +1,5 @@
 //
-//    Copyright (C) 2012 Sascha Ittner <sascha.ittner@modusoft.de>
+//    Copyright (C) 2024 Scott Laird <scott@sigkill.org>
 //
 //    This program is free software; you can redistribute it and/or modify
 //    it under the terms of the GNU General Public License as published by
@@ -17,36 +17,27 @@
 //
 
 /// @file
-/// @brief Modparam-handling library code
+/// @brief Memory allocation helpers for LinuxCNC-Ethercat
 
 #include "lcec.h"
+#include <stdio.h>
 
-/// @brief Cound the number of entries in a `lcec_modparam_desc_t[]`.
-int lcec_modparam_desc_len(const lcec_modparam_desc_t *mp) {
-  int l;
 
-  for (l = 0; mp[l].name != NULL; l++)
-    ;
-
-  return l;
+void *lcec_hal_malloc(size_t size, const char *file, const char *func, int line) {
+  void *result = hal_malloc(size);
+  if (result==NULL) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "MEMORY ALLOCATION FAILURE, hal_malloc() returned NULL in function %s at %s:%d\n", func, file, line);
+    exit(1);
+  }
+  memset(result, 0, size);
+  return result;
 }
 
-lcec_modparam_desc_t *lcec_modparam_desc_concat(lcec_modparam_desc_t const *a, lcec_modparam_desc_t const *b) {
-  int a_len, b_len, i;
-  lcec_modparam_desc_t *c;
-
-  a_len = lcec_modparam_desc_len(a);
-  b_len = lcec_modparam_desc_len(b);
-
-  c = LCEC_ALLOCATE_ARRAY(lcec_modparam_desc_t, (a_len + b_len + 1));
-
-  for (i = 0; i < a_len; i++) {
-    c[i] = a[i];
+void *lcec_malloc(size_t size, const char *file, const char *func, int line) {
+  void *result = malloc(size);
+  if (result==NULL) {
+    fprintf(stderr, LCEC_MSG_PFX "MEMORY ALLOCATION FAILURE, hal_malloc() returned NULL in function %s at %s:%d\n", func, file, line);
+    exit(1);
   }
-  for (i = 0; i < b_len; i++) {
-    c[a_len + i] = b[i];
-  }
-  c[a_len + b_len] = a[a_len];  // Copy terminator
-
-  return c;
+  return result;
 }

--- a/src/lcec_pins.c
+++ b/src/lcec_pins.c
@@ -86,7 +86,7 @@ static int lcec_pin_newfv_list(void *base, const lcec_pindesc_t *list, va_list a
 
   for (p = list; p->type != HAL_TYPE_UNSPECIFIED; p++) {
     va_copy(ac, ap);
-    err = lcec_pin_newfv(p->type, p->dir, (void **)(base + p->offset), p->fmt, ac);
+    err = lcec_pin_newfv(p->type, p->dir, (void **)((char *)base + p->offset), p->fmt, ac);
     va_end(ac);
     if (err) {
       return err;


### PR DESCRIPTION
Re-merging an earlier PR that was mis-merged earlier today.

This changes memory allocation across LinuxCNC-Ethercat to use a set of macros instead of calling `hal_allocate()` and friends directly.  This has a few benefits:

- We now have consistent handling of alloc failures: we always just `exit()`.  We can't clean up after allocation failure, *and* we only allocate at startup, when failure is safe.  This removes a lot of messy NULL handling through the code.
- We can remove a lot of boilerplate.  Specifically, this always zeros allocated memory, which we *usually* did before.
- It's C++-clean, so we can compile with G++ as well as GCC.  I don't want to move to C++, *but* C++ compilers are much pickier than C compilers, and tend to flag dodgy code that C compilers let through.  This has found a few actual bugs already, like the change to VID/PID logic in basic_cia402 in here.