### PR TITLE
style: re-apply clang-format

### DIFF
--- a/src/devices/lcec_ax5100.c
+++ b/src/devices/lcec_ax5100.c
@@ -25,7 +25,10 @@
 static int lcec_ax5100_init(int comp_id, lcec_slave_t *slave);
 
 static lcec_modparam_desc_t lcec_ax5100_modparams[] = {
-  {"enableFB2", LCEC_AX5_PARAM_ENABLE_FB2, MODPARAM_TYPE_BIT}, {"enableDiag", LCEC_AX5_PARAM_ENABLE_DIAG, MODPARAM_TYPE_BIT}, {NULL},};
+    {"enableFB2", LCEC_AX5_PARAM_ENABLE_FB2, MODPARAM_TYPE_BIT},
+    {"enableDiag", LCEC_AX5_PARAM_ENABLE_DIAG, MODPARAM_TYPE_BIT},
+    {NULL},
+};
 
 static lcec_typelist_t types[] = {
     // AX5000 servo drives

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -36,9 +36,9 @@
 #include "lcec_class_dout.h"
 
 // Constants for modparams.  The basic_cia402 driver only has one:
-#define M_CHANNELS   0
-#define M_RXPDOLIMIT 1
-#define M_TXPDOLIMIT 2
+#define M_CHANNELS     0
+#define M_RXPDOLIMIT   1
+#define M_TXPDOLIMIT   2
 #define M_PDOINCREMENT 3
 
 /// @brief Device-specific modparam settings available via XML.
@@ -67,7 +67,8 @@ static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave);
 // PID.  Feel free to add multiple devices here if they can share the
 // same driver.
 static lcec_typelist_t types[] = {
-    {"basic_cia402", /* fake vid */ 0xffffffff, /* fake pid */ 0xffffffff, 0, NULL, lcec_basic_cia402_init, /* modparams implicitly added below */},
+    {"basic_cia402", /* fake vid */ 0xffffffff, /* fake pid */ 0xffffffff, 0, NULL, lcec_basic_cia402_init,
+        /* modparams implicitly added below */},
     {NULL},
 };
 ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_lcec_basic_cia402)
@@ -103,8 +104,8 @@ static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *op
         options->txpdolimit = p->value.u32;
         break;
       case M_PDOINCREMENT:
-	options->pdo_increment = p->value.u32;
-	break;
+        options->pdo_increment = p->value.u32;
+        break;
       default:
         // Handle cia402 generic modparams
         v = lcec_cia402_handle_modparam(slave, p, options);

--- a/src/devices/lcec_class_ain.c
+++ b/src/devices/lcec_class_ain.c
@@ -85,9 +85,7 @@ lcec_class_ain_channels_t *lcec_ain_allocate_channels(int count) {
 /// Most of the defaults are actually coded in
 /// `lcec_ain_register_channel`, so we can safely just memset
 /// everything to 0 here.
-lcec_class_ain_options_t *lcec_ain_options(void) {
-  return LCEC_HAL_ALLOCATE(lcec_class_ain_options_t);
-}
+lcec_class_ain_options_t *lcec_ain_options(void) { return LCEC_HAL_ALLOCATE(lcec_class_ain_options_t); }
 
 /// @brief registers a single analog-input channel and publishes it as a LinuxCNC HAL pin.
 ///

--- a/src/devices/lcec_class_ain.h
+++ b/src/devices/lcec_class_ain.h
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 
 typedef struct {
-  const char *name_prefix;               ///< Prefix for device naming, defaults to "aio".
+  const char *name_prefix;         ///< Prefix for device naming, defaults to "aio".
   int has_sync;                    ///< Device supports the sync_err PDO.
   int valueonly;                   ///< Only read the value from the sensor, do not read over/under range or error PDOs.
   int is_temperature;              ///< Device is a temperature sensor.

--- a/src/devices/lcec_class_aout.c
+++ b/src/devices/lcec_class_aout.c
@@ -61,9 +61,7 @@ lcec_class_aout_channels_t *lcec_aout_allocate_channels(int count) {
 /// Most of the defaults are actually coded in
 /// `lcec_aout_register_channel`, so we can safely just memset
 /// everything to 0 here.
-lcec_class_aout_options_t *lcec_aout_options(void) {
-  return LCEC_HAL_ALLOCATE(lcec_class_aout_options_t);
-}
+lcec_class_aout_options_t *lcec_aout_options(void) { return LCEC_HAL_ALLOCATE(lcec_class_aout_options_t); }
 
 /// @brief registers a single analog-output channel and publishes it as a set of LinuxCNC HAL pins.
 ///

--- a/src/devices/lcec_class_aout.h
+++ b/src/devices/lcec_class_aout.h
@@ -22,7 +22,7 @@
 #include "../lcec.h"
 
 typedef struct {
-  const char *name_prefix;               ///< Prefix for device naming, defaults to "aio".
+  const char *name_prefix;         ///< Prefix for device naming, defaults to "aio".
   int max_value;                   ///< The maximum value returned for "normal" output channels.
   double default_scale;            ///< Default scale for the device.
   double default_offset;           ///< Default value offset for the device.

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -636,9 +636,9 @@ lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t con
 
   mp = LCEC_ALLOCATE_ARRAY(lcec_modparam_desc_t, len * 9 + 1);
 
-  mp[(len-1) * 9] = orig[(len-1)];  // Copy terminator.
+  mp[(len - 1) * 9] = orig[(len - 1)];  // Copy terminator.
 
-  for (l = 0; l<len; l++) {
+  for (l = 0; l < len; l++) {
     mp[l * 9] = orig[l];
     for (int i = 1; i < 9; i++) {
       char *name;

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -55,7 +55,6 @@ typedef struct {
   int digital_in_channels;
   int digital_out_channels;
 
-
   int enable_opmode;  ///< Enable opmode and opmode-display.  They're technically optional in the spec.
   int enable_pp;      ///< If true, enable required PP-mode pins: `-actual-position` and `-target-position`.
   int enable_pv;      ///< If true, enable required PV-mode pins: `-actual-velocity` and `-target-velocity`.
@@ -120,8 +119,8 @@ typedef struct {
 /// the CiA 402 device itself (such as the number of channels), plus
 /// an array of per-channel options.
 typedef struct {
-  int channels;                                     ///< Number of channels;
-  int rxpdolimit, txpdolimit;                       ///< Maximum number of PDO entries allowed per PDO.
+  int channels;                ///< Number of channels;
+  int rxpdolimit, txpdolimit;  ///< Maximum number of PDO entries allowed per PDO.
   int pdo_increment;
   lcec_class_cia402_channel_options_t *channel[8];  ///< Room for 8 channel options.
 } lcec_class_cia402_options_t;

--- a/src/devices/lcec_class_cia402_opt.h
+++ b/src/devices/lcec_class_cia402_opt.h
@@ -575,6 +575,6 @@
                           thing(profile_max_velocity) thing(profile_velocity) thing(pv) thing(target_torque) thing(target_vl)              \
                               thing(torque_demand) thing(torque_profile_type) thing(torque_slope) thing(tq) thing(velocity_demand)         \
                                   thing(velocity_error_time) thing(velocity_error_window) thing(velocity_sensor_selector)                  \
-                                      thing(velocity_threshold_time) thing(velocity_threshold_window) thing(vl) thing(vl_maximum) thing(vl_minimum) thing(positioning_window)                    \
-                                              thing(positioning_time) thing(maximum_slippage) thing(probe_status) thing(position_demand)   \
-                                                  thing(control_effort)
+                                      thing(velocity_threshold_time) thing(velocity_threshold_window) thing(vl) thing(vl_maximum)          \
+                                          thing(vl_minimum) thing(positioning_window) thing(positioning_time) thing(maximum_slippage)      \
+                                              thing(probe_status) thing(position_demand) thing(control_effort)

--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -40,7 +40,7 @@ lcec_class_din_channels_t *lcec_din_allocate_channels(int count) {
 
   channels = LCEC_HAL_ALLOCATE(lcec_class_din_channels_t);
   channels->count = count;
-  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_din_channel_t *,count);
+  channels->channels = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_din_channel_t *, count);
 
   return channels;
 }

--- a/src/devices/lcec_class_dout.h
+++ b/src/devices/lcec_class_dout.h
@@ -24,7 +24,7 @@
 #include "../lcec.h"
 
 typedef struct {
-  const char *name;                  ///< Used for debugging only
+  const char *name;            ///< Used for debugging only
   hal_bit_t *out;              ///< -dout-X pin in LinuxCNC
   hal_bit_t invert;            ///< Is the value inverted?
   unsigned int pdo_os;         ///< Byte offset in PDO data struct
@@ -40,7 +40,8 @@ typedef struct {
 lcec_class_dout_channels_t *lcec_dout_allocate_channels(int count);
 lcec_class_dout_channel_t *lcec_dout_register_channel(struct lcec_slave *slave, int id, uint16_t idx, uint16_t sidx);
 lcec_class_dout_channel_t *lcec_dout_register_channel_named(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, const char *name);
-lcec_class_dout_channel_t *lcec_dout_register_channel_packed(struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, const char *name);
+lcec_class_dout_channel_t *lcec_dout_register_channel_packed(
+    struct lcec_slave *slave, uint16_t idx, uint16_t sidx, int bit, const char *name);
 void lcec_dout_write(struct lcec_slave *slave, lcec_class_dout_channel_t *data);
 void lcec_dout_write_all(struct lcec_slave *slave, lcec_class_dout_channels_t *pins);
 

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -53,8 +53,8 @@ static const lcec_modparam_desc_t lcec_deasda_modparams[] = {
 };
 
 typedef struct {
-  const char *name;      // Mode type name
-  uint16_t value;  // Which value needs to be set in 0x6060:00 to enable this mode
+  const char *name;  // Mode type name
+  uint16_t value;    // Which value needs to be set in 0x6060:00 to enable this mode
 } drive_operationmodes_t;
 
 static const drive_operationmodes_t drive_operationmodes[] = {

--- a/src/devices/lcec_el1918_logic.c
+++ b/src/devices/lcec_el1918_logic.c
@@ -204,7 +204,7 @@ int lcec_el1918_logic_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // alloc hal memory
-  hal_data = LCEC_HAL_ALLOCATE_ARRAY(lcec_el1918_logic_data_t, fsoe_idx* sizeof(lcec_el1918_logic_fsoe_t));
+  hal_data = LCEC_HAL_ALLOCATE_ARRAY(lcec_el1918_logic_data_t, fsoe_idx * sizeof(lcec_el1918_logic_fsoe_t));
   hal_data->fsoe_count = fsoe_idx;
   slave->hal_data = hal_data;
 

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -210,7 +210,8 @@ static const lcec_pindesc_t slave_pins[] = {
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_paramdesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_00_scale), "%s.%s.%s.axis0-enc-scale"},
+static const lcec_paramdesc_t slave_params[] = {
+    {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_00_scale), "%s.%s.%s.axis0-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_01_scale), "%s.%s.%s.axis1-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_02_scale), "%s.%s.%s.axis2-enc-scale"},
     {HAL_FLOAT, HAL_RW, offsetof(lcec_fr4000_data_t, enc_03_scale), "%s.%s.%s.axis3-enc-scale"},

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -96,23 +96,27 @@ typedef struct {
   unsigned int sync_locked_bp;
 } lcec_ph3lm2rm_data_t;
 
-static const lcec_pindesc_t enc_pins[] = {{HAL_BIT, HAL_IO, offsetof(lcec_ph3lm2rm_enc_data_t, latch_ena_pos), "%s.%s.%s.%s-latch-ena-pos"},
+static const lcec_pindesc_t enc_pins[] = {
+    {HAL_BIT, HAL_IO, offsetof(lcec_ph3lm2rm_enc_data_t, latch_ena_pos), "%s.%s.%s.%s-latch-ena-pos"},
     {HAL_BIT, HAL_IO, offsetof(lcec_ph3lm2rm_enc_data_t, latch_ena_neg), "%s.%s.%s.%s-latch-ena-neg"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, error), "%s.%s.%s.%s-error"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_valid), "%s.%s.%s.%s-latch-valid"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_state), "%s.%s.%s.%s-latch-state"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_enc_data_t, latch_state_not), "%s.%s.%s.%s-latch-state-not"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},};
-
-static const lcec_paramdesc_t enc_params[] = {
-  {HAL_FLOAT, HAL_RW, offsetof(lcec_ph3lm2rm_enc_data_t, scale), "%s.%s.%s.%s-scale"},
-  {HAL_TYPE_UNSPECIFIED},
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
-static const lcec_pindesc_t lm_pins[] = {{HAL_U32, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level), "%s.%s.%s.%s-signal-level"},
+static const lcec_paramdesc_t enc_params[] = {
+    {HAL_FLOAT, HAL_RW, offsetof(lcec_ph3lm2rm_enc_data_t, scale), "%s.%s.%s.%s-scale"},
+    {HAL_TYPE_UNSPECIFIED},
+};
+
+static const lcec_pindesc_t lm_pins[] = {
+    {HAL_U32, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level), "%s.%s.%s.%s-signal-level"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_warn), "%s.%s.%s.%s-signal-level-warn"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_err), "%s.%s.%s.%s-signal-level-err"},
-    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},};
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
 
 static const lcec_paramdesc_t lm_params[] = {
     {HAL_U32, HAL_RW, offsetof(lcec_ph3lm2rm_lm_data_t, signal_level_warn_val), "%s.%s.%s.%s-signal-level-warn-val"},

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -159,7 +159,8 @@ static const lcec_pindesc_t slave_pins[] = {{HAL_FLOAT, HAL_IN, offsetof(lcec_st
     {HAL_BIT, HAL_IN, offsetof(lcec_stmds5k_data_t, fast_ramp), "%s.%s.%s.srv-fast-ramp"},
     {HAL_BIT, HAL_IN, offsetof(lcec_stmds5k_data_t, brake), "%s.%s.%s.srv-brake"}, {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL}};
 
-static const lcec_paramdesc_t slave_params[] = {{HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, pos_scale), "%s.%s.%s.srv-pos-scale"},
+static const lcec_paramdesc_t slave_params[] = {
+    {HAL_FLOAT, HAL_RW, offsetof(lcec_stmds5k_data_t, pos_scale), "%s.%s.%s.srv-pos-scale"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, torque_reference), "%s.%s.%s.srv-torque-ref"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, speed_max_rpm), "%s.%s.%s.srv-max-rpm"},
     {HAL_FLOAT, HAL_RO, offsetof(lcec_stmds5k_data_t, speed_max_rpm_sp), "%s.%s.%s.srv-max-rpm-sp"},

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -19,7 +19,6 @@
 /// @file
 /// @brief Header file for LinuxCNC-Ethercat
 
-
 #ifndef _LCEC_H_
 #define _LCEC_H_
 
@@ -86,8 +85,8 @@ extern "C" {
 #define LCEC_FSOE_SIZE(ch_count, data_len) (LCEC_FSOE_CMD_LEN + ch_count * (data_len + LCEC_FSOE_CRC_LEN) + LCEC_FSOE_CONNID_LEN)
 
 #define LCEC_MAX_PDO_REG_COUNT   128  ///< The maximum number of calls to lcec_pdo_init() for a single driver.
-#define LCEC_MAX_PDO_ENTRY_COUNT 128   ///< The maximum number of PDO entries in a PDO in a sync.
-#define LCEC_MAX_PDO_INFO_COUNT  16    ///< The maximum number of PDOs in a sync.
+#define LCEC_MAX_PDO_ENTRY_COUNT 128  ///< The maximum number of PDO entries in a PDO in a sync.
+#define LCEC_MAX_PDO_INFO_COUNT  16   ///< The maximum number of PDOs in a sync.
 #define LCEC_MAX_SYNC_COUNT      4    ///< The maximum number of syncs.
 
 // Memory allocation macros.  These differ from malloc in a couple
@@ -141,7 +140,7 @@ typedef struct {
 
 /// @brief Definition of a device that LinuxCNC-Ethercat supports.
 typedef struct {
-  const char *name;                             ///< The device's name ("EL1008")
+  const char *name;                       ///< The device's name ("EL1008")
   uint32_t vid;                           ///< The EtherCAT vendor ID
   uint32_t pid;                           ///< The EtherCAT product ID
   int is_fsoe_logic;                      ///< Does this device use Safety-over-EtherCAT?
@@ -149,7 +148,7 @@ typedef struct {
   lcec_slave_init_t proc_init;            ///< init function.  Sets up the device.
   const lcec_modparam_desc_t *modparams;  ///< XML modparams, if any
   uint64_t flags;                         ///< Flags, passed through to `proc_init` as `slave->flags`.
-  const char *sourcefile;                       ///< Source filename, autopopulated.
+  const char *sourcefile;                 ///< Source filename, autopopulated.
 } lcec_typelist_t;
 
 /// @brief Linked list for holding device type definitions.
@@ -191,8 +190,8 @@ typedef struct lcec_slave_state {
 } lcec_slave_state_t;
 
 typedef struct lcec_master {
-  lcec_master_t *prev;         ///< Next master.
-  lcec_master_t *next;         ///< Previous master.
+  lcec_master_t *prev;              ///< Next master.
+  lcec_master_t *next;              ///< Previous master.
   int index;                        ///< Index of this mater.
   char name[LCEC_CONF_STR_MAXLEN];  ///< Name of master.
   ec_master_t *master;              ///< EtherCAT master structure.
@@ -265,9 +264,9 @@ typedef struct {
 
 /// @brief EtherCAT slave.
 typedef struct lcec_slave {
-  lcec_slave_t *prev;                   ///< Next slave
-  lcec_slave_t *next;                   ///< Previous slave
-  lcec_master_t *master;                ///< Master for this slave
+  lcec_slave_t *prev;                        ///< Next slave
+  lcec_slave_t *next;                        ///< Previous slave
+  lcec_master_t *master;                     ///< Master for this slave
   int index;                                 ///< Index of this slave.
   char name[LCEC_CONF_STR_MAXLEN];           ///< Slave name.
   uint32_t vid;                              ///< Slave's vendor ID
@@ -309,26 +308,26 @@ typedef struct {
 
 /// @brief HAL pin description.
 typedef struct {
-  hal_type_t type;    ///< HAL type of this pin (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
+  hal_type_t type;      ///< HAL type of this pin (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
   hal_param_dir_t dir;  ///< Direction for this pin (`HAL_IN`, `HAL_OUT`, or `HAL_IO`).
-  int offset;         ///< Offset for this pin's data in `hal_data`.
-  const char *fmt;    ///< Format string for generating pin names via sprintf().
+  int offset;           ///< Offset for this pin's data in `hal_data`.
+  const char *fmt;      ///< Format string for generating pin names via sprintf().
 } lcec_paramdesc_t;
 
 /// @brief Sync manager configuration.
 typedef struct {
-  lcec_slave_t *slave; ///< For debugging messages
+  lcec_slave_t *slave;                            ///< For debugging messages
   int sync_count;                                 ///< Number of syncs.
   ec_sync_info_t *curr_sync;                      ///< Current sync.
   ec_sync_info_t syncs[LCEC_MAX_SYNC_COUNT + 1];  ///< Sync definitions.
 
-  int pdo_info_count;                                ///< Number of PDO infos.
-  ec_pdo_info_t *curr_pdo_info;                      ///< Current PDO info.
-  ec_pdo_info_t pdo_infos[LCEC_MAX_PDO_INFO_COUNT+1];  ///< PDO info definitions.
+  int pdo_info_count;                                    ///< Number of PDO infos.
+  ec_pdo_info_t *curr_pdo_info;                          ///< Current PDO info.
+  ec_pdo_info_t pdo_infos[LCEC_MAX_PDO_INFO_COUNT + 1];  ///< PDO info definitions.
 
-  int pdo_entry_count;                                        ///< Number of PDO entries.
-  ec_pdo_entry_info_t *curr_pdo_entry;                        ///< Current PDO entry.
-  ec_pdo_entry_info_t pdo_entries[LCEC_MAX_PDO_ENTRY_COUNT+1];  ///< PDO entry definitions.
+  int pdo_entry_count;                                            ///< Number of PDO entries.
+  ec_pdo_entry_info_t *curr_pdo_entry;                            ///< Current PDO entry.
+  ec_pdo_entry_info_t pdo_entries[LCEC_MAX_PDO_ENTRY_COUNT + 1];  ///< PDO entry definitions.
 } lcec_syncs_t;
 
 /// @brief Lookup table mapping string to int

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -211,7 +211,7 @@ int main(int argc, char **argv) {
   }
 
   // setup header
-  header = (LCEC_CONF_HEADER_T*)shmem_ptr;
+  header = (LCEC_CONF_HEADER_T *)shmem_ptr;
   shmem_ptr += sizeof(LCEC_CONF_HEADER_T);
   header->magic = LCEC_CONF_SHMEM_MAGIC;
   header->length = state.outputBuf.len;

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -73,10 +73,11 @@ void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mo
   syncs->curr_sync->watchdog_mode = watchdog_mode;
 
   if (syncs->sync_count > LCEC_MAX_SYNC_COUNT) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_sync: WARNING: sync full for slave %s.%s, not adding more.  Expect failure.\n",
-		    syncs->slave->master->name, syncs->slave->name);
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "lcec_syncs_add_sync: WARNING: sync full for slave %s.%s, not adding more.  Expect failure.\n",
+        syncs->slave->master->name, syncs->slave->name);
   } else {
-      (syncs->sync_count)++;
+    (syncs->sync_count)++;
   }
   syncs->syncs[syncs->sync_count].index = 0xff;
 }
@@ -93,10 +94,11 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
   syncs->curr_pdo_info->index = index;
 
   if (syncs->pdo_info_count > LCEC_MAX_PDO_INFO_COUNT) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s, not adding more.  Expect failure.\n",
-		    syncs->slave->master->name, syncs->slave->name);
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s, not adding more.  Expect failure.\n",
+        syncs->slave->master->name, syncs->slave->name);
   } else {
-      (syncs->pdo_info_count)++;
+    (syncs->pdo_info_count)++;
   }
 }
 
@@ -114,8 +116,9 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
   syncs->curr_pdo_entry->bit_length = bit_length;
 
   if (syncs->pdo_entry_count > LCEC_MAX_PDO_ENTRY_COUNT) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_syncs_add_pdo_entry: WARNING: pdo_entries full for slave %s.%s, not adding more.  Expect failure.\n",
-		    syncs->slave->master->name, syncs->slave->name);
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "lcec_syncs_add_pdo_entry: WARNING: pdo_entries full for slave %s.%s, not adding more.  Expect failure.\n",
+        syncs->slave->master->name, syncs->slave->name);
   } else {
     (syncs->pdo_entry_count)++;
   }
@@ -530,7 +533,7 @@ static int lcec_param_newfv_list(void *base, const lcec_paramdesc_t *list, va_li
 
   for (p = list; p->type != HAL_TYPE_UNSPECIFIED; p++) {
     va_copy(ac, ap);
-    err = lcec_param_newfv(p->type, p->dir, ((char*)base + p->offset), p->fmt, ac);
+    err = lcec_param_newfv(p->type, p->dir, ((char *)base + p->offset), p->fmt, ac);
     va_end(ac);
     if (err) {
       return err;

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -394,7 +394,7 @@ int lcec_parse_config(void) {
   }
 
   // check magic, get length and close shmem
-  header = (LCEC_CONF_HEADER_T*)shmem_ptr;
+  header = (LCEC_CONF_HEADER_T *)shmem_ptr;
   if (header->magic != LCEC_CONF_SHMEM_MAGIC) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "lcec_conf is not loaded\n");
     goto fail1;
@@ -532,14 +532,14 @@ int lcec_parse_config(void) {
           generic_pdos = LCEC_ALLOCATE_ARRAY(ec_pdo_info_t, slave_conf->pdoCount);
 
           // alloc sync manager memory
-          generic_sync_managers = LCEC_ALLOCATE_ARRAY(ec_sync_info_t , (slave_conf->syncManagerCount + 1));
+          generic_sync_managers = LCEC_ALLOCATE_ARRAY(ec_sync_info_t, (slave_conf->syncManagerCount + 1));
 
           generic_sync_managers->index = 0xff;
         }
 
         // alloc sdo config memory
         if (slave_conf->sdoConfigLength > 0) {
-          sdo_config = (lcec_slave_sdoconf_t*)lcec_zalloc(slave_conf->sdoConfigLength + sizeof(lcec_slave_sdoconf_t));
+          sdo_config = (lcec_slave_sdoconf_t *)lcec_zalloc(slave_conf->sdoConfigLength + sizeof(lcec_slave_sdoconf_t));
           if (sdo_config == NULL) {
             rtapi_print_msg(
                 RTAPI_MSG_ERR, LCEC_MSG_PFX "Unable to allocate slave %s.%s sdo entry memory\n", master->name, slave_conf->name);
@@ -552,7 +552,7 @@ int lcec_parse_config(void) {
 
         // alloc idn config memory
         if (slave_conf->idnConfigLength > 0) {
-          idn_config = (lcec_slave_idnconf_t*)lcec_zalloc(slave_conf->idnConfigLength + sizeof(lcec_slave_idnconf_t));
+          idn_config = (lcec_slave_idnconf_t *)lcec_zalloc(slave_conf->idnConfigLength + sizeof(lcec_slave_idnconf_t));
           if (idn_config == NULL) {
             rtapi_print_msg(
                 RTAPI_MSG_ERR, LCEC_MSG_PFX "Unable to allocate slave %s.%s idn entry memory\n", master->name, slave_conf->name);
@@ -566,7 +566,7 @@ int lcec_parse_config(void) {
 
         // alloc modparam memory
         if (slave_conf->modParamCount > 0) {
-          modparams = LCEC_ALLOCATE_ARRAY(lcec_slave_modparam_t,  (slave_conf->modParamCount + 1));
+          modparams = LCEC_ALLOCATE_ARRAY(lcec_slave_modparam_t, (slave_conf->modParamCount + 1));
           modparams[slave_conf->modParamCount].id = -1;
         }
 

--- a/src/lcec_malloc.c
+++ b/src/lcec_malloc.c
@@ -19,14 +19,15 @@
 /// @file
 /// @brief Memory allocation helpers for LinuxCNC-Ethercat
 
-#include "lcec.h"
 #include <stdio.h>
 
+#include "lcec.h"
 
 void *lcec_hal_malloc(size_t size, const char *file, const char *func, int line) {
   void *result = hal_malloc(size);
-  if (result==NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "MEMORY ALLOCATION FAILURE, hal_malloc() returned NULL in function %s at %s:%d\n", func, file, line);
+  if (result == NULL) {
+    rtapi_print_msg(
+        RTAPI_MSG_ERR, LCEC_MSG_PFX "MEMORY ALLOCATION FAILURE, hal_malloc() returned NULL in function %s at %s:%d\n", func, file, line);
     exit(1);
   }
   memset(result, 0, size);
@@ -35,7 +36,7 @@ void *lcec_hal_malloc(size_t size, const char *file, const char *func, int line)
 
 void *lcec_malloc(size_t size, const char *file, const char *func, int line) {
   void *result = malloc(size);
-  if (result==NULL) {
+  if (result == NULL) {
     fprintf(stderr, LCEC_MSG_PFX "MEMORY ALLOCATION FAILURE, hal_malloc() returned NULL in function %s at %s:%d\n", func, file, line);
     exit(1);
   }


### PR DESCRIPTION
We've had some drift vs clang-format's output.  I thought I'd re-ran this against the malloc change, but apparently not.

This should *only* include changes from running `clang-format -i` against src/*.[ch] and src/devices/*.[ch]. 