### PR TITLE
feat(rtec): Re-sync RTelligent stepper driver with core CiA 402 code and add features

### DIFF
--- a/documentation/rtec.md
+++ b/documentation/rtec.md
@@ -13,7 +13,6 @@ In your XML file, you should have an entry somewhat like this:
   <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000">
     ...
     <slave idx="1" type="ECT60" name="x-axis">
-      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
       <modParam name="peakCurrent_amps" value="1.0"/>
       <modParam name="controlMode" value="closedloop"/>
       <modParam name="homeOffset" value="1"/>

--- a/tests/scottlaird-lcectest1/cia402-all.hal
+++ b/tests/scottlaird-lcectest1/cia402-all.hal
@@ -77,14 +77,14 @@ net 2-pos-fb => joint.2.motor-pos-fb <= cia402.3.pos-fb
 #net rtect-drv-target-pos cia402.2.drv-target-position => lcec.0.rt-ect60.srv-target-position
 #net rtect-drv-target-velo cia402.2.drv-target-velocity => lcec.0.rt-ect60.srv-target-velocity
 
-net rtecr1-statusword lcec.0.rt-ecr60x2.srv-2-cia-statusword => cia402.4.statusword
-net rtecr1-opmode-display lcec.0.rt-ecr60x2.srv-2-opmode-display => cia402.4.opmode-display
-net rtecr1-drv-act-pos lcec.0.rt-ecr60x2.srv-2-actual-position => cia402.4.drv-actual-position
-net rtecr1-drv-act-velo lcec.0.rt-ecr60x2.srv-2-actual-velocity => cia402.4.drv-actual-velocity
-net rtecr1-controlword cia402.4.controlword => lcec.0.rt-ecr60x2.srv-2-cia-controlword
-net rtecr1-modes-of-operation cia402.4.opmode => lcec.0.rt-ecr60x2.srv-2-opmode
-net rtecr1-drv-target-pos cia402.4.drv-target-position => lcec.0.rt-ecr60x2.srv-2-target-position
-net rtecr1-drv-target-velo cia402.4.drv-target-velocity => lcec.0.rt-ecr60x2.srv-2-target-velocity
+net rtecr1-statusword lcec.0.rt-ecr60x2.srv-1-cia-statusword => cia402.4.statusword
+net rtecr1-opmode-display lcec.0.rt-ecr60x2.srv-1-opmode-display => cia402.4.opmode-display
+net rtecr1-drv-act-pos lcec.0.rt-ecr60x2.srv-1-actual-position => cia402.4.drv-actual-position
+net rtecr1-drv-act-velo lcec.0.rt-ecr60x2.srv-1-actual-velocity => cia402.4.drv-actual-velocity
+net rtecr1-controlword cia402.4.controlword => lcec.0.rt-ecr60x2.srv-1-cia-controlword
+net rtecr1-modes-of-operation cia402.4.opmode => lcec.0.rt-ecr60x2.srv-1-opmode
+net rtecr1-drv-target-pos cia402.4.drv-target-position => lcec.0.rt-ecr60x2.srv-1-target-position
+net rtecr1-drv-target-velo cia402.4.drv-target-velocity => lcec.0.rt-ecr60x2.srv-1-target-velocity
 net 1-home-index <= joint.1.index-enable => cia402.4.home
 net 1-enable <= joint.1.amp-enable-out => cia402.4.enable
 net 1-amp-fault => joint.1.amp-fault-in <= cia402.4.drv-fault

--- a/tests/scottlaird-lcectest1/cia402-all.xml
+++ b/tests/scottlaird-lcectest1/cia402-all.xml
@@ -182,28 +182,12 @@
 	  <pdoEntry idx="606C" subIdx="00" bitLen="32" halPin="srv-actual-velocity" halType="s32"/>
 	</pdo>
       </syncManager>
-    </slave> -->
-    <slave idx="27" type="basic_cia402" vid="0x00000a88" pid="0x0a880002" name="rt-ect60">
-      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
-      <modParam name="ciaRxPDOEntryLimit" value="16"/>
-      <modParam name="ciaTxPDOEntryLimit" value="16"/>
-      <modParam name="enablePP" value="true"/>
-      <modParam name="enablePV" value="true"/>
-      <modParam name="enableTQ" value="true"/>
-      <modParam name="enableHM" value="true"/>
-      <modParam name="enableCSP" value="true"/>
-      <modParam name="enableCSV" value="true"/>
-      <modParam name="enableDigitalInput" value="true"/>
-      <modParam name="digitalInChannels" value="16"/>
-      <modParam name="enableDigitalOutput" value="true"/>
-      <modParam name="digitalOutChannels" value="16"/>
-      <modParam name="enableErrorCode" value="true"/>
-      <modParam name="enableHomeAccel" value="true"/>
-      <modParam name="enableInterpolationTimePeriod" value="true"/>
-      <modParam name="enableProfileAccel" value="true"/>
-      <modParam name="enableProfileDecel" value="true"/>
-      <modParam name="enableProfileVelocity" value="true"/>
+      </slave> -->
+
+    <slave idx="27" type="ECT60" name="rt-ect60">
+      <!-- <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/> -->
     </slave>
+    
     <slave idx="28" type="basic_cia402" vid="0x00000a88" pid="0x0a880005" name="rt-ecr60x2">
       <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
       <modParam name="ciaChannels" value="2"/>

--- a/tests/scottlaird-lcectest1/cia402-all.xml
+++ b/tests/scottlaird-lcectest1/cia402-all.xml
@@ -163,7 +163,7 @@
 	    <complexEntry bitLen="1" halPin="CW-limit" halType="bit"/>
 	    <complexEntry bitLen="1" halPin="CCW-limit" halType="bit"/>
 	    <complexEntry bitLen="1" halPin="in-home" halType="bit"/>
-	    <complexEntry bitLen="13"/>
+	    <complexEntry bitLen="13"/> 
 	    <complexEntry bitLen="1" halPin="in-1" halType="bit"/>
 	    <complexEntry bitLen="1" halPin="in-2" halType="bit"/>
 	    <complexEntry bitLen="1" halPin="in-3" halType="bit"/>
@@ -184,33 +184,9 @@
       </syncManager>
       </slave> -->
 
-    <slave idx="27" type="ECT60" name="rt-ect60">
-      <!-- <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/> -->
-    </slave>
-    
-    <slave idx="28" type="basic_cia402" vid="0x00000a88" pid="0x0a880005" name="rt-ecr60x2">
-      <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
-      <modParam name="ciaChannels" value="2"/>
-      <modParam name="pdoIncrement" value="16"/>
-      <modParam name="ciaRxPDOEntryLimit" value="16"/>
-      <modParam name="ciaTxPDOEntryLimit" value="16"/>
-      <modParam name="ch1enablePP" value="true"/>
-      <modParam name="ch1enablePV" value="true"/>
-      <modParam name="ch1enableCSP" value="true"/>
-      <modParam name="ch1enableCSV" value="true"/>
-      <modParam name="ch1enableErrorCode" value="true"/>
-      <modParam name="ch1enableProfileAccel" value="true"/>
-      <modParam name="ch1enableProfileDecel" value="true"/>
-      <modParam name="ch1enableProfileVelocity" value="true"/>
-      <modParam name="ch2enablePP" value="true"/>
-      <modParam name="ch2enablePV" value="true"/>
-      <modParam name="ch2enableCSP" value="true"/>
-      <modParam name="ch2enableCSV" value="true"/>
-      <modParam name="ch2enableErrorCode" value="true"/>
-      <modParam name="ch2enableProfileAccel" value="true"/>
-      <modParam name="ch2enableProfileDecel" value="true"/>
-      <modParam name="ch2enableProfileVelocity" value="true"/>
-    </slave>
+    <slave idx="27" type="ECT60" name="rt-ect60"/>
+    <slave idx="28" type="ECR60x2" name="rt-ecr60x2"/>
+
     <slave idx="29" type="basic_cia402" vid="0x00000a88" pid="0x0a880042" name="rt-drv400">
       <!--DRV400E(COE)-->
       <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>


### PR DESCRIPTION
This starts bringing the `rtec` driver up to date WRT the current `basic_cia402` driver.

With this patch, both the ECT60 and ECR60x2 seem to be working, although I haven't done extensive testing.

This also adds a default `dcConf` config for these devices, equal to:

```
     <dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
 ```

Thanks to that, this *should* be enough to work:

```
    <slave idx="27" type="ECT60" name="rt-ect60"/>
```

By default, these map all of the PDO entries needed for CSP support.  This can be changed via a bunch of  `enable` modParams, but I'd like something a bit more user-friendly if possible.

Issue #180