### PR TITLE
feat(configgen): propagate modparams to lcec_configgen

### DIFF
--- a/documentation/rtec.md
+++ b/documentation/rtec.md
@@ -26,101 +26,131 @@ See the [CiA 402](cia402.md) documentation for additional details
 about how to configure CiA 402 devices in LinuxCNC.  At a minimum, you
 will need to include the `cia402` HAL component.
 
+## Devices
+
+This driver supports all known (as of early 2024) RTelligent EC-series
+EtherCAT stepper drives, including:
+
+- [ECR60](http://www.rtelligent.net/ECR60.html) (one-axis 6A open-loop driver)
+- [ECR60x2](https://www.rtelligentglobal.com/fieldbus-open-loop-stepper-drive-ecr60x2a-product/) (two-axis 6A open-loop driver)
+- [ECR86](http://www.rtelligent.net/ECR86.html) (one-axis 7A open-loop driver)
+- [ECT60](http://www.rtelligent.net/ECT60.html) (one-axis 6A closed-loop driver)
+- [ECT60x2](https://www.rtelligentglobal.com/fieldbus-open-loop-stepper-drive-ect60x2-product/) (two-axis 6A closed-loop driver)
+- [ECT86](http://www.rtelligent.net/ECT86.html) (one-axis 7A closed-loop driver)
+
+Only the ECT60 and ECR60x2 have been tested.
+
+### Caveats
+
+My ECR60x2 (technically an EXR60X2A) has a few EtherCAT shortcomings
+that moderately impact its utility.  First, `ethercat sdos` doesn't
+show anything for the device.  This makes is somewhat tricky to
+develop against, but shouldn't impact its use.  More annoyingly, it
+maps PDOs at 0x16n0 and 0x1An0 instead of 0x160n and 0x1A0n, so a bit
+of special configuration is needed to get the second axis to work.
+Finally, it only appears to support 2 TX PDOs, which means that we've
+had to disable some optional features to save PDO space.
+
+From the docs, it appears that in closed-loop mode, EC* drivers
+measure distances in terms of encoder steps (usually 4000x per
+revolution), and in open-loop mode they measure in terms of
+`motorResolution_pulses` (usually 10000x per revolution).  There does
+not appear to be a way to change these at the drive level, so scaling
+will need to be applied at some point in LinuxCNC to get reasonable
+distance units.
+
 ## Configuration
 
 This driver takes a number of `<modParam>` options that control its
 operation.  There are a number of `rtec`-specific parameters, plus a
 number of additional [`cia402` modParams](cia402.md).
 
-#### `<modParam name="peakCurrent_amps" value="3.0"/>`
+The parameters are listed in their single-axis form; dual-axis devices
+like the ECR60X2 and ECT60X2 have two sets of these parameters, one
+starting with `ch1` and one starting with `ch2`.  For example,
+`ch1peakCurrent_amps` and `ch2peakCurrent_amps`.
 
-Set the maximum current for the motor, in amps.
+<dl>
+<dt>&lt;modParam name="peakCurrent_amps" value="3.0"/&gt</dt>
+<dd>Set the maximum current for the motor, in amps.</dd>
 
-#### `<modParam name="motorResolution_pulses" value="10000"/>`
+<dt>&lt;modParam name="motorResolution_pulses" value="10000"/&gt</dt>
+<dd>Set the number of pulses for a full motor rotation.</dd>
 
-Set the number of pulses for a full motor rotation.
+<dt>&lt;modParam name="standbyTime_ms" value="500"/&gt</dt>
+<dd>Set the standby time, before the drive drops down to standby current.  See below.</dd>
 
-#### `<modParam name="standbyTime_ms" value="500"/>`
+<dt>&lt;modParam name="standbyCurrent_pct" value="50"/&gt</dt>
+<dd>Set the percentage of current used when in standby mode.</dd>
 
-Set the standby time, before the drive drops down to standby current.  See below.
+<dt>&lt;modParam name="output1Func" value="general|alarm|brake|in-place"/&gt</dt>
+<dd>Set the function for output port 1.  See below for options.</dd>
 
-#### `<modParam name="standbyCurrent_pct" value="50"/>`
+<dt>&lt;modParam name="output2Func" value="general|alarm|brake|in-place"/&gt</dt>
+<dd>Set the function for output port 2.  See below for options.</dd>
 
-Set the percentage of current used when in standby mode.
+<dt>&lt;modParam name="output1Polarity" value="nc|no"/&gt</dt>
+<dd>Set the polarity for output port 1, either <tt>nc</tt> for
+normally-closed or <tt>no</tt> for normally open.</dd>
 
-#### `<modParam name="output1Func" value="general|alarm|brake|in-place"/>`
+<dt>&lt;modParam name="output2Polarity" value="nc|no"/&gt</dt>
+<dd>Set the polarity for output port 2, either <tt>nc</tt> for
+normally-closed or <tt>no</tt> for normally open.</dd>
 
-Set the function for output port 1.  See below for options.
+<dt>&lt;modParam name="input3Func" value="general|..."/&gt</dt>
+<dd>Set the function for input port 3.  See below for options.</dd>
 
-#### `<modParam name="output2Func" value="general|alarm|brake|in-place"/>`
+<dt>&lt;modParam name="input4Func" value="general|..."/&gt</dt>
+<dd>Set the function for input port 4.  See below for options.</dd>
 
-Set the function for output port 2.  See below for options.
+<dt>&lt;modParam name="input5Func" value="general|..."/&gt</dt>
+<dd>Set the function for input port 5.  See below for options.</dd>
 
-#### `<modParam name="output1Polarity" value="nc|no"/>`
+<dt>&lt;modParam name="input6Func" value="general|..."/&gt</dt>
+<dd>Set the function for input port 6.  See below for options.</dd>
 
-Set the polarity for output port 1, either `nc` or `no`.
+<dt>&lt;modParam name="input3Polarity" value="nc|no"/&gt</dt>
+<dd>Set the polarity for input port 3, either <tt>nc</tt> for
+normally-closed or <tt>no</tt> for normally open.</dd>
 
-#### `<modParam name="output2Polarity" value="nc|no"/>`
+<dt>&lt;modParam name="input4Polarity" value="nc|no/&gt</dt>
+<dd>Set the polarity for input port 4, either <tt>nc</tt> for
+normally-closed or <tt>no</tt> for normally open.</dd>
 
-Set the polarity for output port 2, either `nc` or `no`.
+<dt>&lt;modParam name="input5Polarity" value="nc|no/&gt</dt>
+<dd>Set the polarity for input port 5, either <tt>nc</tt> for
+normally-closed or <tt>no</tt> for normally open.</dd>
 
-#### `<modParam name="input3Func" value="general|..."/>`
+<dt>&lt;modParam name="input6Polarity" value="nc|no/&gt</dt>
+<dd>Set the polarity for input port 6, either <tt>nc</tt> for
+normally-closed or <tt>no</tt> for normally open.</dd>
 
-Set the function for input port 3.  See below for options.
+<dt>&lt;modParam name="filterTime_us"  value="6400"/&gt</dt>
 
-#### `<modParam name="input4Func" value="general|..."/>`
+<dd>Set the filter time in microseconds.</dd>
 
-Set the function for input port 4.  See below for options.
+<dt>&lt;modParam name="shaftLockTime_us" value="1000"/&gt</dt>
 
-#### `<modParam name="input5Func" value="general|..."/>`
+<dd>Set the shaft lock time in microseconds.</dd>
 
-Set the function for input port 5.  See below for options.
+<dt>&lt;modParam name="motorAutoTune" value="true|false"/&gt</dt>
 
-#### `<modParam name="input6Func" value="general|..."/>`
+<dd>Enable or disable motor autotuning.</dd>
 
-Set the function for input port 6.  See below for options.
+<dt>&lt;modParam name="stepperPhases" value="2"/&gt</dt>
 
-#### `<modParam name="input3Polarity" value="nc|no"/>`
+<dd>Set the number of stepper phases for the motor.</dd>
 
-Set the polarity for input port 3, either `nc` or `no`.
+<dt>&lt;modParam name="controlMode"  value="openloop|closedloop|foc"/&gt</dt>
 
-#### `<modParam name="input4Polarity" value="nc|no/>`
+<dd>Set the control mode for the motor.</dd>
 
-Set the polarity for input port 4, either `nc` or `no`.
+<dt>&lt;modParam name="encoderResolution" value="4000"/&gt</dt>
 
-#### `<modParam name="input5Polarity" value="nc|no/>`
+<dd>The number of encoder pulses per revolution.</dd>
 
-Set the polarity for input port 5, either `nc` or `no`.
-
-#### `<modParam name="input6Polarity" value="nc|no/>`
-
-Set the polarity for input port 6, either `nc` or `no`.
-
-#### `<modParam name="filterTime_us"  value="6400"/>`
-
-Set the filter time in microseconds.
-
-#### `<modParam name="shaftLockTime_us" value="1000"/>`
-
-Set the shaft lock time in microseconds.
-
-#### `<modParam name="motorAutoTune" value="true|false"/>`
-
-Enable or disable motor autotuning.
-
-#### `<modParam name="stepperPhases" value="2"/>`
-
-Set the number of stepper phases for the motor.
-
-#### `<modParam name="controlMode"  value="openloop|closedloop|foc"/>`
-
-Set the control mode for the motor.
-
-#### `<modParam name="encoderResolution" value="4000"/>`
-
-The number of encoder pulses per revolution.
-
-#### `<modParam name="positionErrorLimit" value="4000"/>`
+<dt>&lt;modParam name="positionErrorLimit" value="4000"/&gt</dt>
+</dl>
 
 ## Inputs
 
@@ -131,15 +161,39 @@ use.
 
 The `inputXFunc` (where X is 3, 4, 5, or 6) modParam controls the function of each input.  The available options are:
 
-- `general`
-- `cw-limit`
-- `ccw-limit`
-- `home`
-- `clear-fault`
-- `emergency-stop`
-- `motor-offline`
-- `probe1`
-- `probe2`
+<dl>
+<dt>general</dt>
+<dd>The input is available to be used as a general-purpose input.  Use
+this if you want LinuxCNC to take actions based on the state of the
+input rather than having the stepper drive itself take action.</dd>
+
+<dt>cw-limit</dt>
+<dd>The input is used for the clockwise limit/homing sensor, and is
+automatically used as part of CiA 402 homing mode.</dd>
+
+<dt>ccw-limit</dt>
+<dd>The input is used for the counter-clockwise limit/homing sensor,
+and is automatically used as part of CiA 402 homing mode.</dd> 
+
+<dt>home</dt>
+<dd>The input is used for the home sensor, and is presumably used as
+part of CiA 402 homing mode.</dd> 
+
+<dt>clear-fault</dt>
+<dd>The input is used to clear faults.</dd>
+
+<dt>emergency-stop</dt>
+<dd>The input is used as an emergency stop.</dd>
+
+<dt>motor-offline</dt>
+<dd>The input is used to take the motor offline.</dd>
+
+<dt>probe1<dt>
+<dd>The input is connected to probe #1.</dd>
+
+<dt>probe2<dt>
+<dd>The input is connected to probe #2.</dd>
+</dl>
 
 On my ECT60, the pins come pre-assigned with various functions:
 
@@ -160,10 +214,18 @@ name="input3Polarity" value="nc"/>`.
 
 The single-axis ECR/ECT devices have 2 outputs.  The `output1Func` and `output2Func` modParams control the function of each output.  The available options are:
 
-- `general`
-- `alarm`
-- `brake`
-- `in-place`
+<dl>
+<dt>general</dt>
+<dd>This output is a general-purpose output, available to LinuxCNC.</dd>
+<dt>alarm</dt>
+<dd>This output is triggered automatically when the drive triggers an alarm.</dd>
+<dt> brake</dt>
+<dd>This output is triggered automatically when the drive wishes to
+engage the brake.</dd>
+<dt>in-place</dt>
+<dd>This output is triggered automatically when the motor has reached
+its target position.</dd>
+</dl>
 
 On my ECT60, the pins come pre-assigned as:
 

--- a/scripts/sync-sdos.sh
+++ b/scripts/sync-sdos.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+device="$*"
+
+#
+# This dumps all of the SDO values for one or more devices.  Call it with '-p 2' to show all of the SDOs from slave #2.
+
+function fetch {
+    if echo "$line" | egrep -q '^  0x....:..'; then
+	obj=$(echo "$line" | sed 's/:\(..\), .*/ 0x\1/' )
+	val=$(ethercat $device --type $type upload $obj  2> /dev/null)
+	printf "%-80s   %s\n" "$(echo "$line" | cat -vT)" "$val" 2> /dev/null
+    else
+	echo "$line"
+    fi
+}
+
+echo 'SDO 0x1c32, "SM output parameter"'
+type=uint16 line='  0x1c32:01, rwr-r-, uint16, 16 bit, "Synchronization Type"' fetch
+type=uint32 line='  0x1c32:02, r-r-r-, uint32, 32 bit, "Cycle Time"' fetch
+type=uint16 line='  0x1c32:04, r-r-r-, uint16, 16 bit, "Synchronization Types supported"' fetch
+type=uint32 line='  0x1c32:05, r-r-r-, uint32, 32 bit, "Minimum Cycle Time"' fetch
+type=uint32 line='  0x1c32:06, r-r-r-, uint32, 32 bit, "Calc and Copy Time"' fetch
+type=uint16 line='  0x1c32:08, rwrwrw, uint16, 16 bit, "Get Cycle Time"' fetch
+type=uint32 line='  0x1c32:09, r-r-r-, uint32, 32 bit, "Delay Time"' fetch
+type=uint32 line='  0x1c32:0a, rwrwrw, uint32, 32 bit, "Sync0 Cycle Time"' fetch
+type=uint16 line='  0x1c32:0b, r-r-r-, uint16, 16 bit, "SM-Event Missed"' fetch
+type=uint16 line='  0x1c32:0c, r-r-r-, uint16, 16 bit, "Cycle Time Too Small"' fetch
+type=uint16 line='  0x1c32:0d, ------, type 0000, 16 bit, "Shift Time Too Short"' fetch
+type=uint8 line='  0x1c32:20, r-r-r-, bool, 1 bit, "Sync Error"' fetch
+echo 'SDO 0x1c33, "SM input parameter"'
+type=uint16 line='  0x1c33:01, rwr-r-, uint16, 16 bit, "Synchronization Type"' fetch
+type=uint32 line='  0x1c33:02, r-r-r-, uint32, 32 bit, "Cycle Time"' fetch
+type=uint16 line='  0x1c33:04, r-r-r-, uint16, 16 bit, "Synchronization Types supported"' fetch
+type=uint32 line='  0x1c33:05, r-r-r-, uint32, 32 bit, "Minimum Cycle Time"' fetch
+type=uint32 line='  0x1c33:06, r-r-r-, uint32, 32 bit, "Calc and Copy Time"' fetch
+type=uint16 line='  0x1c33:08, rwrwrw, uint16, 16 bit, "Get Cycle Time"' fetch
+type=uint32 line='  0x1c33:09, r-r-r-, uint32, 32 bit, "Delay Time"' fetch
+type=uint32 line='  0x1c33:0a, rwrwrw, uint32, 32 bit, "Sync0 Cycle Time"' fetch
+type=uint16 line='  0x1c33:0b, r-r-r-, uint16, 16 bit, "SM-Event Missed"' fetch
+type=uint16 line='  0x1c33:0c, r-r-r-, uint16, 16 bit, "Cycle Time Too Small"' fetch
+type=uint16 line='  0x1c33:0d, ------, type 0000, 16 bit, "Shift Time Too Short"' fetch
+type=uint8 line='  0x1c33:20, r-r-r-, bool, 1 bit, "Sync Error"' fetch

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,7 +117,7 @@ lcec_configgen: configgen/*.go configgen/*/*.go
 configgen/devicelist: configgen/devicelist.go
 	(cd configgen ; go build devicelist.go)
 
-configgen/drivers/drivers.go: configgen/devicelist ../documentation/devices/*.yml
+configgen/drivers/drivers.go: configgen/devicelist lcec_devices
 	(cd configgen ; go generate)
 
 # Rule for compiling tests/*.bin files.  We're naming test excutables *.bin so we can use wildcards in .gitignore and `make clean` to match them.

--- a/src/configgen/devicelist.go
+++ b/src/configgen/devicelist.go
@@ -1,34 +1,27 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
-	"bytes"
 	"gopkg.in/yaml.v3"
 	"log"
 	"os"
-	"path/filepath"
+	"os/exec"
 	"sort"
 	"strings"
 )
 
 type DeviceDefinition struct {
-	Device           string `yaml:"Device"`
-	VendorID         string `yaml:"VendorID"`
-	VendorName       string `yaml:"VendorName"`
-	PID              string `yaml:"PID"`
-	Description      string `yaml:"Description"`
-	DocumentationURL string `yaml:"DocumentationURL"`
-	DeviceType       string `yaml:"DeviceType"`
-	Channels         int    `yaml:"Channels"`
-	Notes            string `yaml:"Notes"`
-	SrcFile          string `yaml:"SrcFile"`
-	TestingStatus    string `yaml:"TestingStatus"`
+	Device    string
+	VendorID  string
+	PID       string
+	ModParams []string
 }
 
 var (
-	pathFlag = flag.String("path", "../../documentation/devices/", "Path to *.yml files for device documentation")
-	outputFile = flag.String("output", "configgen/drivers.go", "File to create")
+	devicesFlag = flag.String("devices_path", "../lcec_devices", "Path to lcec_devices tool")
+	outputFile  = flag.String("output", "configgen/drivers.go", "File to create")
 )
 
 func parsefile(filename string) (*DeviceDefinition, error) {
@@ -51,52 +44,56 @@ func main() {
 	flag.Parse()
 
 	entries := []*DeviceDefinition{}
-	otherfiles := 0
 
-	files, err := os.ReadDir(*pathFlag)
+	data, err := exec.Command(*devicesFlag).Output()
 	if err != nil {
-		log.Fatalf("Unable to read directory %q: %v", *pathFlag, err)
+		log.Fatalf("Unable to execute %q: %v", *devicesFlag, err)
 	}
 
-	filenames := []string{}
-	for _, file := range files {
-		if strings.HasSuffix(file.Name(), ".yml") {
-			filenames = append(filenames, file.Name())
-		}
-	}
+	// the output is small enough that this isn't a big deal.
+	lines := strings.Split(string(data), "\n")
 
-	sort.Strings(filenames)
-	for _, name := range filenames {
-		if name[0] != '.' && strings.Contains(name, ".yml") {
-			entry, err := parsefile(filepath.Join(*pathFlag, name))
-			if err != nil {
-				log.Fatalf("Unable to parse file %q: %v", name, err)
+	sort.Strings(lines)
+	for _, line := range lines {
+		pieces := strings.Split(line, "\t")
+		if len(pieces) > 2 {
+			entry := &DeviceDefinition{
+				Device:   pieces[0],
+				VendorID: pieces[1],
+				PID:      pieces[2],
 			}
-			if strings.TrimSpace(entry.Description) != "UNKNOWN" {
-				entries = append(entries, entry)
-			} else {
-				otherfiles++
+			
+			if pieces[4] != "" {
+				entry.ModParams = strings.SplitAfter(pieces[4], "> ")
 			}
+			
+			entries = append(entries, entry)
 		}
 	}
 
 	var sb bytes.Buffer
-	
+
 	sb.WriteString("// Code generated  DO NOT EDIT.\n")
 	sb.WriteString("package configgen\n")
 	sb.WriteString("type EthercatDriver struct {\n")
-	sb.WriteString("	VendorID string\n")
+	sb.WriteString("    VendorID string\n")
 	sb.WriteString("    ProductID string\n")
 	sb.WriteString("    Type string\n")
-	sb.WriteString("}\n");
+	sb.WriteString("    ModParams []string\n")
+	sb.WriteString("}\n")
 
-	sb.WriteString("var Drivers=map[string]EthercatDriver{\n")
+	sb.WriteString("var Drivers=[]EthercatDriver{\n")
 	for _, e := range entries {
-		sb.WriteString(fmt.Sprintf("  %q: EthercatDriver{\n", e.Device))
+		sb.WriteString(fmt.Sprintf("  EthercatDriver{\n"))
 		sb.WriteString(fmt.Sprintf("    VendorID: %q,\n", e.VendorID))
 		sb.WriteString(fmt.Sprintf("    ProductID: %q,\n", e.PID))
 		sb.WriteString(fmt.Sprintf("    Type: %q,\n", e.Device))
-		sb.WriteString("  },\n")
+		sb.WriteString(fmt.Sprintf("    ModParams: []string{\n"))
+		for _, mp := range e.ModParams {
+			sb.WriteString(fmt.Sprintf("      %q,\n", mp))
+		}
+		sb.WriteString(fmt.Sprintf("    },\n"))
+		sb.WriteString(fmt.Sprintf("  },\n"))
 	}
 	sb.WriteString("}\n")
 

--- a/src/configgen/drivers/drivers.go
+++ b/src/configgen/drivers/drivers.go
@@ -1,1239 +1,1975 @@
 // Code generated  DO NOT EDIT.
 package configgen
 type EthercatDriver struct {
-	VendorID string
+    VendorID string
     ProductID string
     Type string
+    ModParams []string
 }
-var Drivers=map[string]EthercatDriver{
-  "AX5101": EthercatDriver{
+var Drivers=[]EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13ed6012",
     Type: "AX5101",
+    ModParams: []string{
+    },
   },
-  "AX5103": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13ef6012",
     Type: "AX5103",
+    ModParams: []string{
+    },
   },
-  "AX5106": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13f26012",
     Type: "AX5106",
+    ModParams: []string{
+    },
   },
-  "AX5112": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13f86012",
     Type: "AX5112",
+    ModParams: []string{
+    },
   },
-  "AX5118": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13fe6012",
     Type: "AX5118",
+    ModParams: []string{
+    },
   },
-  "AX5203": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x14536012",
     Type: "AX5203",
+    ModParams: []string{
+    },
   },
-  "AX5206": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x14566012",
     Type: "AX5206",
+    ModParams: []string{
+    },
   },
-  "AX5805": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x16ad6012",
     Type: "AX5805",
+    ModParams: []string{
+    },
   },
-  "DEMS300": EthercatDriver{
-    VendorID: "0x000001dd",
-    ProductID: "0x10400200",
-    Type: "DEMS300",
-  },
-  "DEASDA": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x000001dd",
     ProductID: "0x10305070",
-    Type: "DEASDA",
+    Type: "DeASDA",
+    ModParams: []string{
+    },
   },
-  "DEASDA3": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x000001dd",
     ProductID: "0x00006010",
-    Type: "DEASDA3",
+    Type: "DeASDA3",
+    ModParams: []string{
+    },
   },
-  "DeASDB3": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x000001dd",
     ProductID: "0x00006080",
     Type: "DeASDB3",
+    ModParams: []string{
+    },
   },
-  "ECR60": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x000001dd",
+    ProductID: "0x10400200",
+    Type: "DeMS300",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000a88",
     ProductID: "0x0a880001",
     Type: "ECR60",
+    ModParams: []string{
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"enableCSV\" value=\"false\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Number of stepper pulses per rotation --> ",
+      "<modParam name=\"motorResolution_pulses\" value=\"10000\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"encoderResolution\" value=\"4000\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output2Func\" value=\"brake\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input5Func\" value=\"home\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input6Func\" value=\"motor-offline\"/> ",
+      "",
+    },
   },
-  "ECR60x2": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000a88",
     ProductID: "0x0a880005",
     Type: "ECR60x2",
+    ModParams: []string{
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"ch1enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"ch2enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"ch1enableCSV\" value=\"false\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"ch2enableCSV\" value=\"false\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"ch1peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"ch2peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Number of stepper pulses per rotation --> ",
+      "<modParam name=\"ch1motorResolution_pulses\" value=\"10000\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"ch1encoderResolution\" value=\"4000\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"ch2encoderResolution\" value=\"4000\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch1output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch2output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch1output2Func\" value=\"brake\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch2output2Func\" value=\"brake\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input5Func\" value=\"home\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input5Func\" value=\"home\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input6Func\" value=\"motor-offline\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input6Func\" value=\"motor-offline\"/> ",
+      "",
+    },
   },
-  "ECR86": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000a88",
     ProductID: "0x0a880003",
     Type: "ECR86",
+    ModParams: []string{
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"enableCSV\" value=\"false\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Number of stepper pulses per rotation --> ",
+      "<modParam name=\"motorResolution_pulses\" value=\"10000\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"encoderResolution\" value=\"4000\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output2Func\" value=\"brake\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input5Func\" value=\"home\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input6Func\" value=\"motor-offline\"/> ",
+      "",
+    },
   },
-  "ECT60": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000a88",
     ProductID: "0x0a880002",
     Type: "ECT60",
+    ModParams: []string{
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"enableCSV\" value=\"false\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Operation mode: openloop, closedloop, or foc. --> ",
+      "<modParam name=\"controlMode\" value=\"closedloop\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"encoderResolution\" value=\"4000\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output2Func\" value=\"brake\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input5Func\" value=\"home\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input6Func\" value=\"motor-offline\"/> ",
+      "",
+    },
   },
-  "ECT60x2": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000a88",
     ProductID: "0x0a880006",
     Type: "ECT60x2",
+    ModParams: []string{
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"ch1enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"ch2enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"ch1enableCSV\" value=\"false\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"ch2enableCSV\" value=\"false\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"ch1peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"ch2peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Operation mode: openloop, closedloop, or foc. --> ",
+      "<modParam name=\"ch1controlMode\" value=\"closedloop\"/> ",
+      "<!-- Operation mode: openloop, closedloop, or foc. --> ",
+      "<modParam name=\"ch2controlMode\" value=\"closedloop\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"ch1encoderResolution\" value=\"4000\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"ch2encoderResolution\" value=\"4000\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch1output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch2output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch1output2Func\" value=\"brake\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"ch2output2Func\" value=\"brake\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input5Func\" value=\"home\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input5Func\" value=\"home\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch1input6Func\" value=\"motor-offline\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"ch2input6Func\" value=\"motor-offline\"/> ",
+      "",
+    },
   },
-  "ECT86": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000a88",
     ProductID: "0x0a880004",
     Type: "ECT86",
+    ModParams: []string{
+      "<!-- Enable support for Cyclic Synchronous Position mode. --> ",
+      "<modParam name=\"enableCSP\" value=\"true\"/> ",
+      "<!-- Enable support for Cyclic Synchronous Velocity mode. --> ",
+      "<modParam name=\"enableCSV\" value=\"false\"/> ",
+      "<!-- Maximum stepper Amps. --> ",
+      "<modParam name=\"peakCurrent_amps\" value=\"6.0\"/> ",
+      "<!-- Operation mode: openloop, closedloop, or foc. --> ",
+      "<modParam name=\"controlMode\" value=\"closedloop\"/> ",
+      "<!-- Number of encoder steps per revolution. --> ",
+      "<modParam name=\"encoderResolution\" value=\"4000\"/> ",
+      "<!-- Output 1 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output1Func\" value=\"alarm\"/> ",
+      "<!-- Output 2 use: general, alarm, brake, in-place. --> ",
+      "<modParam name=\"output2Func\" value=\"brake\"/> ",
+      "<!-- Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input3Func\" value=\"cw-limit\"/> ",
+      "<!-- Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input4Func\" value=\"ccw-limit\"/> ",
+      "<!-- Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input5Func\" value=\"home\"/> ",
+      "<!-- Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2 --> ",
+      "<modParam name=\"input6Func\" value=\"motor-offline\"/> ",
+      "",
+    },
   },
-  "EJ1859": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07432852",
     Type: "EJ1859",
+    ModParams: []string{
+    },
   },
-  "EJ3004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bbc2852",
     Type: "EJ3004",
+    ModParams: []string{
+    },
   },
-  "EJ3202": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c822852",
     Type: "EJ3202",
+    ModParams: []string{
+    },
   },
-  "EJ3214": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c8e2852",
     Type: "EJ3214",
+    ModParams: []string{
+    },
   },
-  "EJ4002": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa22852",
     Type: "EJ4002",
+    ModParams: []string{
+    },
   },
-  "EJ4004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa42852",
     Type: "EJ4004",
+    ModParams: []string{
+    },
   },
-  "EJ4008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa82852",
     Type: "EJ4008",
+    ModParams: []string{
+    },
   },
-  "EJ4018": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fb22852",
     Type: "EJ4018",
+    ModParams: []string{
+    },
   },
-  "EJ4024": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fb82852",
     Type: "EJ4024",
+    ModParams: []string{
+    },
   },
-  "EJ4132": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10242852",
     Type: "EJ4132",
+    ModParams: []string{
+    },
   },
-  "EJ4134": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10262852",
     Type: "EJ4134",
+    ModParams: []string{
+    },
   },
-  "EJ5002": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x138a2852",
     Type: "EJ5002",
+    ModParams: []string{
+    },
   },
-  "EK1100": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x044c2c52",
     Type: "EK1100",
+    ModParams: []string{
+    },
   },
-  "EK1101": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x044d2c52",
     Type: "EK1101",
+    ModParams: []string{
+    },
   },
-  "EK1110": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04562c52",
     Type: "EK1110",
+    ModParams: []string{
+    },
   },
-  "EK1122": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04622c52",
     Type: "EK1122",
+    ModParams: []string{
+    },
   },
-  "EK1814": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07162c52",
     Type: "EK1814",
+    ModParams: []string{
+    },
   },
-  "EK1818": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x071a2c52",
     Type: "EK1818",
+    ModParams: []string{
+    },
   },
-  "EK1828-0010": EthercatDriver{
-    VendorID: "0x00000002",
-    ProductID: "0x07242c52",
-    Type: "EK1828-0010",
-  },
-  "EK1828": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07242c52",
     Type: "EK1828",
+    ModParams: []string{
+    },
   },
-  "EL1002": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x07242c52",
+    Type: "EK1828-0010",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03ea3052",
     Type: "EL1002",
+    ModParams: []string{
+    },
   },
-  "EL1004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03ec3052",
     Type: "EL1004",
+    ModParams: []string{
+    },
   },
-  "EL1008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03f03052",
     Type: "EL1008",
+    ModParams: []string{
+    },
   },
-  "EL1012": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03f43052",
     Type: "EL1012",
+    ModParams: []string{
+    },
   },
-  "EL1014": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03f63052",
     Type: "EL1014",
+    ModParams: []string{
+    },
   },
-  "EL1018": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03fa3052",
     Type: "EL1018",
+    ModParams: []string{
+    },
   },
-  "EL1024": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04003052",
     Type: "EL1024",
+    ModParams: []string{
+    },
   },
-  "EL1034": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x040a3052",
     Type: "EL1034",
+    ModParams: []string{
+    },
   },
-  "EL1084": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x043c3052",
     Type: "EL1084",
+    ModParams: []string{
+    },
   },
-  "EL1088": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04403052",
     Type: "EL1088",
+    ModParams: []string{
+    },
   },
-  "EL1094": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04463052",
     Type: "EL1094",
+    ModParams: []string{
+    },
   },
-  "EL1098": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x044a3052",
     Type: "EL1098",
+    ModParams: []string{
+    },
   },
-  "EL1104": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04503052",
     Type: "EL1104",
+    ModParams: []string{
+    },
   },
-  "EL1114": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x045a3052",
     Type: "EL1114",
+    ModParams: []string{
+    },
   },
-  "EL1124": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04643052",
     Type: "EL1124",
+    ModParams: []string{
+    },
   },
-  "EL1134": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x046e3052",
     Type: "EL1134",
+    ModParams: []string{
+    },
   },
-  "EL1144": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04783052",
     Type: "EL1144",
+    ModParams: []string{
+    },
   },
-  "EL1252": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04e43052",
     Type: "EL1252",
+    ModParams: []string{
+    },
   },
-  "EL1804": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x070c3052",
     Type: "EL1804",
+    ModParams: []string{
+    },
   },
-  "EL1808": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07103052",
     Type: "EL1808",
+    ModParams: []string{
+    },
   },
-  "EL1809": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07113052",
     Type: "EL1809",
+    ModParams: []string{
+    },
   },
-  "EL1819": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x071b3052",
     Type: "EL1819",
+    ModParams: []string{
+    },
   },
-  "EL1852": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x073c3052",
     Type: "EL1852",
+    ModParams: []string{
+    },
   },
-  "EL1859": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07433052",
     Type: "EL1859",
+    ModParams: []string{
+    },
   },
-  "EL1904": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07703052",
     Type: "EL1904",
+    ModParams: []string{
+    },
   },
-  "EL1918_LOGIC": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x077e3052",
     Type: "EL1918_LOGIC",
+    ModParams: []string{
+    },
   },
-  "EL2002": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07d23052",
     Type: "EL2002",
+    ModParams: []string{
+    },
   },
-  "EL2004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07d43052",
     Type: "EL2004",
+    ModParams: []string{
+    },
   },
-  "EL2008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07d83052",
     Type: "EL2008",
+    ModParams: []string{
+    },
   },
-  "EL2022": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07e63052",
     Type: "EL2022",
+    ModParams: []string{
+    },
   },
-  "EL2024": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07e83052",
     Type: "EL2024",
+    ModParams: []string{
+    },
   },
-  "EL2032": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07f03052",
     Type: "EL2032",
+    ModParams: []string{
+    },
   },
-  "EL2034": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07f23052",
     Type: "EL2034",
+    ModParams: []string{
+    },
   },
-  "EL2042": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07fa3052",
     Type: "EL2042",
+    ModParams: []string{
+    },
   },
-  "EL2084": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x08243052",
     Type: "EL2084",
+    ModParams: []string{
+    },
   },
-  "EL2088": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x08283052",
     Type: "EL2088",
+    ModParams: []string{
+    },
   },
-  "EL2124": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x084c3052",
     Type: "EL2124",
+    ModParams: []string{
+    },
   },
-  "EL2202": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x089a3052",
     Type: "EL2202",
+    ModParams: []string{
+    },
   },
-  "EL2521": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x09d93052",
     Type: "EL2521",
+    ModParams: []string{
+    },
   },
-  "EL2612": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0a343052",
     Type: "EL2612",
+    ModParams: []string{
+    },
   },
-  "EL2622": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0a3e3052",
     Type: "EL2622",
+    ModParams: []string{
+    },
   },
-  "EL2624": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0a403052",
     Type: "EL2624",
+    ModParams: []string{
+    },
   },
-  "EL2634": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0a4a3052",
     Type: "EL2634",
+    ModParams: []string{
+    },
   },
-  "EL2652": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0a5c3052",
     Type: "EL2652",
+    ModParams: []string{
+    },
   },
-  "EL2798": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0aee3052",
     Type: "EL2798",
+    ModParams: []string{
+    },
   },
-  "EL2808": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0af83052",
     Type: "EL2808",
+    ModParams: []string{
+    },
   },
-  "EL2809": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0af93052",
     Type: "EL2809",
+    ModParams: []string{
+    },
   },
-  "EL2904": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0b583052",
     Type: "EL2904",
+    ModParams: []string{
+    },
   },
-  "EL3001": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bb93052",
     Type: "EL3001",
+    ModParams: []string{
+    },
   },
-  "EL3002": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bba3052",
     Type: "EL3002",
+    ModParams: []string{
+    },
   },
-  "EL3004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bbc3052",
     Type: "EL3004",
+    ModParams: []string{
+    },
   },
-  "EL3008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bc03052",
     Type: "EL3008",
+    ModParams: []string{
+    },
   },
-  "EL3011": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bc33052",
     Type: "EL3011",
+    ModParams: []string{
+    },
   },
-  "EL3012": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bc43052",
     Type: "EL3012",
+    ModParams: []string{
+    },
   },
-  "EL3014": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bc63052",
     Type: "EL3014",
+    ModParams: []string{
+    },
   },
-  "EL3021": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bcd3052",
     Type: "EL3021",
+    ModParams: []string{
+    },
   },
-  "EL3022": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bce3052",
     Type: "EL3022",
+    ModParams: []string{
+    },
   },
-  "EL3024": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bd03052",
     Type: "EL3024",
+    ModParams: []string{
+    },
   },
-  "EL3041": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0be13052",
     Type: "EL3041",
+    ModParams: []string{
+    },
   },
-  "EL3042": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0be23052",
     Type: "EL3042",
+    ModParams: []string{
+    },
   },
-  "EL3044": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0be43052",
     Type: "EL3044",
+    ModParams: []string{
+    },
   },
-  "EL3048": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0be83052",
     Type: "EL3048",
+    ModParams: []string{
+    },
   },
-  "EL3051": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0beb3052",
     Type: "EL3051",
+    ModParams: []string{
+    },
   },
-  "EL3052": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bec3052",
     Type: "EL3052",
+    ModParams: []string{
+    },
   },
-  "EL3054": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bee3052",
     Type: "EL3054",
+    ModParams: []string{
+    },
   },
-  "EL3058": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bf23052",
     Type: "EL3058",
+    ModParams: []string{
+    },
   },
-  "EL3061": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bf53052",
     Type: "EL3061",
+    ModParams: []string{
+    },
   },
-  "EL3062": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bf63052",
     Type: "EL3062",
+    ModParams: []string{
+    },
   },
-  "EL3064": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bf83052",
     Type: "EL3064",
+    ModParams: []string{
+    },
   },
-  "EL3068": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0bfc3052",
     Type: "EL3068",
+    ModParams: []string{
+    },
   },
-  "EL3101": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c1d3052",
     Type: "EL3101",
+    ModParams: []string{
+    },
   },
-  "EL3102": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c1e3052",
     Type: "EL3102",
+    ModParams: []string{
+    },
   },
-  "EL3104": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c1e3052",
+    Type: "EL3102",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c203052",
     Type: "EL3104",
+    ModParams: []string{
+    },
   },
-  "EL3111": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c273052",
     Type: "EL3111",
+    ModParams: []string{
+    },
   },
-  "EL3112": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c283052",
     Type: "EL3112",
+    ModParams: []string{
+    },
   },
-  "EL3114": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c283052",
+    Type: "EL3112",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c2a3052",
     Type: "EL3114",
+    ModParams: []string{
+    },
   },
-  "EL3121": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c313052",
     Type: "EL3121",
+    ModParams: []string{
+    },
   },
-  "EL3122": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c323052",
     Type: "EL3122",
+    ModParams: []string{
+    },
   },
-  "EL3124": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c323052",
+    Type: "EL3122",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c343052",
     Type: "EL3124",
+    ModParams: []string{
+    },
   },
-  "EL3141": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c453052",
     Type: "EL3141",
+    ModParams: []string{
+    },
   },
-  "EL3142": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c463052",
     Type: "EL3142",
+    ModParams: []string{
+    },
   },
-  "EL3144": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c463052",
+    Type: "EL3142",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c483052",
     Type: "EL3144",
+    ModParams: []string{
+    },
   },
-  "EL3151": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c4f3052",
     Type: "EL3151",
+    ModParams: []string{
+    },
   },
-  "EL3152": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c503052",
     Type: "EL3152",
+    ModParams: []string{
+    },
   },
-  "EL3154": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c503052",
+    Type: "EL3152",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c523052",
     Type: "EL3154",
+    ModParams: []string{
+    },
   },
-  "EL3161": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c593052",
     Type: "EL3161",
+    ModParams: []string{
+    },
   },
-  "EL3162": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c5a3052",
     Type: "EL3162",
+    ModParams: []string{
+    },
   },
-  "EL3164": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x0c5a3052",
+    Type: "EL3162",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c5c3052",
     Type: "EL3164",
+    ModParams: []string{
+    },
   },
-  "EL3182": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c6e3052",
     Type: "EL3182",
+    ModParams: []string{
+    },
   },
-  "EL3201": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c813052",
     Type: "EL3201",
+    ModParams: []string{
+    },
   },
-  "EL3202": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c823052",
     Type: "EL3202",
+    ModParams: []string{
+    },
   },
-  "EL3204": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c843052",
     Type: "EL3204",
+    ModParams: []string{
+    },
   },
-  "EL3208": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c883052",
     Type: "EL3208",
+    ModParams: []string{
+    },
   },
-  "EL3214": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c8e3052",
     Type: "EL3214",
+    ModParams: []string{
+    },
   },
-  "EL3218": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c923052",
     Type: "EL3218",
+    ModParams: []string{
+    },
   },
-  "EL3255": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0cb73052",
     Type: "EL3255",
+    ModParams: []string{
+    },
   },
-  "EL3403": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0d4b3052",
     Type: "EL3403",
+    ModParams: []string{
+    },
   },
-  "EL4001": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa13052",
     Type: "EL4001",
+    ModParams: []string{
+    },
   },
-  "EL4002": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa23052",
     Type: "EL4002",
+    ModParams: []string{
+    },
   },
-  "EL4004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa43052",
     Type: "EL4004",
+    ModParams: []string{
+    },
   },
-  "EL4008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fa83052",
     Type: "EL4008",
+    ModParams: []string{
+    },
   },
-  "EL4011": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fab3052",
     Type: "EL4011",
+    ModParams: []string{
+    },
   },
-  "EL4012": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fac3052",
     Type: "EL4012",
+    ModParams: []string{
+    },
   },
-  "EL4014": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fae3052",
     Type: "EL4014",
+    ModParams: []string{
+    },
   },
-  "EL4018": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fb23052",
     Type: "EL4018",
+    ModParams: []string{
+    },
   },
-  "EL4021": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fb53052",
     Type: "EL4021",
+    ModParams: []string{
+    },
   },
-  "EL4022": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fb63052",
     Type: "EL4022",
+    ModParams: []string{
+    },
   },
-  "EL4024": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fb83052",
     Type: "EL4024",
+    ModParams: []string{
+    },
   },
-  "EL4028": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fbc3052",
     Type: "EL4028",
+    ModParams: []string{
+    },
   },
-  "EL4031": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fbf3052",
     Type: "EL4031",
+    ModParams: []string{
+    },
   },
-  "EL4032": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fc03052",
     Type: "EL4032",
+    ModParams: []string{
+    },
   },
-  "EL4034": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fc23052",
     Type: "EL4034",
+    ModParams: []string{
+    },
   },
-  "EL4038": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0fc63052",
     Type: "EL4038",
+    ModParams: []string{
+    },
   },
-  "EL4102": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10063052",
     Type: "EL4102",
+    ModParams: []string{
+    },
   },
-  "EL4104": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10083052",
     Type: "EL4104",
+    ModParams: []string{
+    },
   },
-  "EL4112": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10103052",
     Type: "EL4112",
+    ModParams: []string{
+    },
   },
-  "EL4114": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10123052",
     Type: "EL4114",
+    ModParams: []string{
+    },
   },
-  "EL4122": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x101a3052",
     Type: "EL4122",
+    ModParams: []string{
+    },
   },
-  "EL4124": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x101c3052",
     Type: "EL4124",
+    ModParams: []string{
+    },
   },
-  "EL4132": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10243052",
     Type: "EL4132",
+    ModParams: []string{
+    },
   },
-  "EL4134": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x10263052",
     Type: "EL4134",
+    ModParams: []string{
+    },
   },
-  "EL5002": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x138a3052",
     Type: "EL5002",
+    ModParams: []string{
+    },
   },
-  "EL5032": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13a83052",
     Type: "EL5032",
+    ModParams: []string{
+    },
   },
-  "EL5101": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13ed3052",
     Type: "EL5101",
+    ModParams: []string{
+    },
   },
-  "EL5102": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x13ee3052",
     Type: "EL5102",
+    ModParams: []string{
+    },
   },
-  "EL5151": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x141f3052",
     Type: "EL5151",
+    ModParams: []string{
+    },
   },
-  "EL5152": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x14203052",
     Type: "EL5152",
+    ModParams: []string{
+    },
   },
-  "EL6090": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x17ca3052",
     Type: "EL6090",
+    ModParams: []string{
+    },
   },
-  "EL6900": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1af43052",
     Type: "EL6900",
+    ModParams: []string{
+    },
   },
-  "EL7031": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1b773052",
     Type: "EL7031",
+    ModParams: []string{
+    },
   },
-  "EL7041-0052": EthercatDriver{
-    VendorID: "0x00000002",
-    ProductID: "0x1b813052",
-    Type: "EL7041-0052",
-  },
-  "EL7041-1000": EthercatDriver{
-    VendorID: "0x00000002",
-    ProductID: "0x1b813052",
-    Type: "EL7041-1000",
-  },
-  "EL7041": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1b813052",
     Type: "EL7041",
+    ModParams: []string{
+    },
   },
-  "EL7201_9014": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EL7041-0052",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EL7041-1000",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000002",
+    ProductID: "0x1b813052",
+    Type: "EL7041_1000",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1c213052",
     Type: "EL7201_9014",
+    ModParams: []string{
+    },
   },
-  "EL7211": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1c2b3052",
     Type: "EL7211",
+    ModParams: []string{
+    },
   },
-  "EL7221": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1c353052",
     Type: "EL7221",
+    ModParams: []string{
+    },
   },
-  "EL7342": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1cae3052",
     Type: "EL7342",
+    ModParams: []string{
+    },
   },
-  "EL7411": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1cf33052",
     Type: "EL7411",
+    ModParams: []string{
+    },
   },
-  "EL9505": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x25213052",
     Type: "EL9505",
+    ModParams: []string{
+    },
   },
-  "EL9508": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x25243052",
     Type: "EL9508",
+    ModParams: []string{
+    },
   },
-  "EL9510": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x25263052",
     Type: "EL9510",
+    ModParams: []string{
+    },
   },
-  "EL9512": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x25283052",
     Type: "EL9512",
+    ModParams: []string{
+    },
   },
-  "EL9515": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x252b3052",
     Type: "EL9515",
+    ModParams: []string{
+    },
   },
-  "EL9576": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x25683052",
     Type: "EL9576",
+    ModParams: []string{
+    },
   },
-  "EM3701": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0e753452",
     Type: "EM3701",
+    ModParams: []string{
+    },
   },
-  "EM3702": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0e763452",
     Type: "EM3702",
+    ModParams: []string{
+    },
   },
-  "EM3712": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0e803452",
     Type: "EM3712",
+    ModParams: []string{
+    },
   },
-  "EM7004": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1b5c3452",
     Type: "EM7004",
+    ModParams: []string{
+    },
   },
-  "EP1008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03f04052",
     Type: "EP1008",
+    ModParams: []string{
+    },
   },
-  "EP1018": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x03fa4052",
     Type: "EP1018",
+    ModParams: []string{
+    },
   },
-  "EP1122": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x04624052",
     Type: "EP1122",
+    ModParams: []string{
+    },
   },
-  "EP1819": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x071b4052",
     Type: "EP1819",
+    ModParams: []string{
+    },
   },
-  "EP2008": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07d84052",
     Type: "EP2008",
+    ModParams: []string{
+    },
   },
-  "EP2028": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x07ec4052",
     Type: "EP2028",
+    ModParams: []string{
+    },
   },
-  "EP2308": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x09044052",
     Type: "EP2308",
+    ModParams: []string{
+    },
   },
-  "EP2316": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x090c4052",
     Type: "EP2316",
+    ModParams: []string{
+    },
   },
-  "EP2318": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x090e4052",
     Type: "EP2318",
+    ModParams: []string{
+    },
   },
-  "EP2328": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x09184052",
     Type: "EP2328",
+    ModParams: []string{
+    },
   },
-  "EP2338": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x09224052",
     Type: "EP2338",
+    ModParams: []string{
+    },
   },
-  "EP2339": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x09234052",
     Type: "EP2339",
+    ModParams: []string{
+    },
   },
-  "EP2349": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x092d4052",
     Type: "EP2349",
+    ModParams: []string{
+    },
   },
-  "EP2809": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0af94052",
     Type: "EP2809",
+    ModParams: []string{
+    },
   },
-  "EP3174": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c664052",
     Type: "EP3174",
+    ModParams: []string{
+    },
   },
-  "EP3184": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c704052",
     Type: "EP3184",
+    ModParams: []string{
+    },
   },
-  "EP3204": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x0c844052",
     Type: "EP3204",
+    ModParams: []string{
+    },
   },
-  "EP4174": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x104e4052",
     Type: "EP4174",
+    ModParams: []string{
+    },
   },
-  "EP7041": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x1b813052",
     Type: "EP7041",
+    ModParams: []string{
+    },
   },
-  "EPP2308": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x64765649",
     Type: "EPP2308",
+    ModParams: []string{
+    },
   },
-  "EPP2316": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x090c4052",
     Type: "EPP2316",
+    ModParams: []string{
+    },
   },
-  "EPP2318": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x647656e9",
     Type: "EPP2318",
+    ModParams: []string{
+    },
   },
-  "EPP2328": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x64765789",
     Type: "EPP2328",
+    ModParams: []string{
+    },
   },
-  "EPP2334": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x647657e9",
     Type: "EPP2334",
+    ModParams: []string{
+    },
   },
-  "EPP2338": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x64765829",
     Type: "EPP2338",
+    ModParams: []string{
+    },
   },
-  "EPP2339": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x64765839",
     Type: "EPP2339",
+    ModParams: []string{
+    },
   },
-  "EPP2349": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x647658d9",
     Type: "EPP2349",
+    ModParams: []string{
+    },
   },
-  "EPX3158": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x9809ab69",
     Type: "EPX3158",
+    ModParams: []string{
+    },
   },
-  "EQ2339": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000002",
     ProductID: "0x092d4052",
     Type: "EQ2339",
+    ModParams: []string{
+    },
   },
-  "EX260-SEC1": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000114",
     ProductID: "0x01000001",
     Type: "EX260-SEC1",
+    ModParams: []string{
+    },
   },
-  "EX260-SEC2": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000114",
     ProductID: "0x01000002",
     Type: "EX260-SEC2",
+    ModParams: []string{
+    },
   },
-  "EX260-SEC3": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000114",
     ProductID: "0x01000003",
     Type: "EX260-SEC3",
+    ModParams: []string{
+    },
   },
-  "EX260-SEC4": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000114",
     ProductID: "0x01000004",
     Type: "EX260-SEC4",
+    ModParams: []string{
+    },
   },
-  "EasyIO": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x0000079a",
     ProductID: "0x0debacca",
     Type: "EasyIO",
+    ModParams: []string{
+    },
   },
-  "EPOCAT": EthercatDriver{
-    VendorID: "0x0000079A",
-    ProductID: "0x00decade",
-    Type: "EPOCAT",
+  EthercatDriver{
+    VendorID: "0x0000079a",
+    ProductID: "0x04decade",
+    Type: "EpoCAT",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN01H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000005",
     Type: "OmrG5_KN01H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN01L": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000002",
     Type: "OmrG5_KN01L",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN02H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000006",
     Type: "OmrG5_KN02H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN02L": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000003",
     Type: "OmrG5_KN02L",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN04H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000007",
     Type: "OmrG5_KN04H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN04L": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000004",
     Type: "OmrG5_KN04L",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN06F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000000b",
     Type: "OmrG5_KN06F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN08H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000008",
     Type: "OmrG5_KN08H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN10F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000000c",
     Type: "OmrG5_KN10F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN10H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000009",
     Type: "OmrG5_KN10H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN150F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000005f",
     Type: "OmrG5_KN150F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN150H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000005a",
     Type: "OmrG5_KN150H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN15F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000000d",
     Type: "OmrG5_KN15F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN15H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000000a",
     Type: "OmrG5_KN15H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN20F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000005b",
     Type: "OmrG5_KN20F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN20H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000056",
     Type: "OmrG5_KN20H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN30F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000005c",
     Type: "OmrG5_KN30F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN30H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000057",
     Type: "OmrG5_KN30H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN50F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000005d",
     Type: "OmrG5_KN50F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN50H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000058",
     Type: "OmrG5_KN50H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN75F": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x0000005e",
     Type: "OmrG5_KN75F",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KN75H": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000059",
     Type: "OmrG5_KN75H",
+    ModParams: []string{
+    },
   },
-  "OmrG5_KNA5L": EthercatDriver{
+  EthercatDriver{
     VendorID: "0x00000083",
     ProductID: "0x00000001",
     Type: "OmrG5_KNA5L",
+    ModParams: []string{
+    },
   },
-  "STMDS5K": EthercatDriver{
+  EthercatDriver{
+    VendorID: "0x00000907",
+    ProductID: "0x10000001",
+    Type: "Ph3LM2RM",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x000000b9",
     ProductID: "0x00001388",
-    Type: "STMDS5K",
+    Type: "StMDS5k",
+    ModParams: []string{
+    },
   },
-  "basic_cia402": EthercatDriver{
+  EthercatDriver{
     VendorID: "0xffffffff",
     ProductID: "0xffffffff",
     Type: "basic_cia402",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000000",
+    ProductID: "0x00000000",
+    Type: "generic",
+    ModParams: []string{
+    },
   },
 }

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -42,12 +42,22 @@
 #define M_PDOINCREMENT 3
 
 /// @brief Device-specific modparam settings available via XML.
-static const lcec_modparam_desc_t modparams_lcec_basic_cia402[] = {
+static const lcec_modparam_desc_t modparams_perchannel[] = {
+    // XXXX, add per-channel device-specific modparams here.
+    {NULL},
+};
+
+static const lcec_modparam_desc_t modparams_base[] = {
     {"ciaChannels", M_CHANNELS, MODPARAM_TYPE_U32},
     {"ciaRxPDOEntryLimit", M_RXPDOLIMIT, MODPARAM_TYPE_U32},
     {"ciaTxPDOEntryLimit", M_TXPDOLIMIT, MODPARAM_TYPE_U32},
     {"pdoIncrement", M_PDOINCREMENT, MODPARAM_TYPE_U32},
-    // XXXX, add device-specific modparams here.
+    // XXXX, add device-specific modparams here that aren't duplicated for multi-axis devices
+    {NULL},
+};
+
+static const lcec_modparam_doc_t overrides[] = {
+    // XXXX, add overrides here
     {NULL},
 };
 
@@ -71,7 +81,7 @@ static lcec_typelist_t types[] = {
         /* modparams implicitly added below */},
     {NULL},
 };
-ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_lcec_basic_cia402)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_perchannel, modparams_base, overrides)
 
 static void lcec_basic_cia402_read(lcec_slave_t *slave, long period);
 static void lcec_basic_cia402_write(lcec_slave_t *slave, long period);

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -550,9 +550,7 @@ void lcec_cia402_write(lcec_slave_t *slave, lcec_class_cia402_channel_t *data) {
 /// @param channels An `lcec_class_cia402_channel_t *`, as returned by lcec_cia402_register_channel.
 void lcec_cia402_write_all(lcec_slave_t *slave, lcec_class_cia402_channels_t *channels) {
   for (int i = 0; i < channels->count; i++) {
-    lcec_class_cia402_channel_t *channel = channels->channels[i];
-
-    lcec_cia402_write(slave, channel);
+    lcec_cia402_write(slave, channels->channels[i]);
   }
 }
 
@@ -657,12 +655,18 @@ lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t con
 /// @brief Merge per-device modParams and channelized generic CiA 402
 /// modParams into a single list.
 ///
-/// @param device_mps a `lcec_modparam_desc_t[]` containing all of the
+/// @param device_channelized_mps a `lcec_modparam_desc_t[]` containing all of the per-channel
 /// device-specific `<modParam>`settings.
-lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_mps) {
-  const lcec_modparam_desc_t *channelized_mps = lcec_cia402_channelized_modparams(per_channel_modparams);
+/// @param device_base_mps a `lcec_modparam_desc_t[]` containing device-specific `<modParam>` settings that should *not* be duplicated per
+/// channel.
+/// @param docs a `lcec_modparam_doc_t[]` that will override the settings of `default_value` and `comment` on existing MPs.
+lcec_modparam_desc_t *lcec_cia402_modparams(
+    lcec_modparam_desc_t const *device_channelized_mps, lcec_modparam_desc_t const *device_base_mps, lcec_modparam_doc_t const *docs) {
+  const lcec_modparam_desc_t *pre_channelized_mps = lcec_modparam_desc_concat(per_channel_modparams, device_channelized_mps);
+  const lcec_modparam_desc_t *channelized_mps = lcec_cia402_channelized_modparams(pre_channelized_mps);
+  const lcec_modparam_desc_t *all_mps = lcec_modparam_desc_concat(channelized_mps, device_base_mps);
 
-  return lcec_modparam_desc_concat(device_mps, channelized_mps);
+  return lcec_modparam_desc_merge_docs(all_mps, docs);
 }
 
 /// @brief Handle a single modparam entry

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -305,22 +305,23 @@ lcec_class_cia402_channel_options_t *lcec_cia402_channel_options(void);
 void lcec_cia402_rename_multiaxis_channels(lcec_class_cia402_options_t *opt);
 int lcec_cia402_handle_modparam(struct lcec_slave *slave, const lcec_slave_modparam_t *p, lcec_class_cia402_options_t *opt);
 lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t const *orig);
-lcec_modparam_desc_t *lcec_cia402_modparams(lcec_modparam_desc_t const *device_mps);
+lcec_modparam_desc_t *lcec_cia402_modparams(
+    lcec_modparam_desc_t const *device_channelized_mps, lcec_modparam_desc_t const *device_base_mps, lcec_modparam_doc_t const *overrides);
 lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_output_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_input_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, int max_denominator);
 
-#define ADD_TYPES_WITH_CIA402_MODPARAMS(types, mps)        \
-  static void AddTypes(void) __attribute__((constructor)); \
-  static void AddTypes(void) {                             \
-    const lcec_modparam_desc_t *all_modparams;             \
-    int i;                                                 \
-    all_modparams = lcec_cia402_modparams(mps);            \
-    for (i = 0; types[i].name != NULL; i++) {              \
-      types[i].modparams = all_modparams;                  \
-    }                                                      \
-    lcec_addtypes(types, __FILE__);                        \
+#define ADD_TYPES_WITH_CIA402_MODPARAMS(types, chan_mps, base_mps, overrides) \
+  static void AddTypes##types(void) __attribute__((constructor));             \
+  static void AddTypes##types(void) {                                         \
+    const lcec_modparam_desc_t *all_modparams;                                \
+    int i;                                                                    \
+    all_modparams = lcec_cia402_modparams(chan_mps, base_mps, overrides);     \
+    for (i = 0; types[i].name != NULL; i++) {                                 \
+      types[i].modparams = all_modparams;                                     \
+    }                                                                         \
+    lcec_addtypes(types, __FILE__);                                           \
   }
 
 // modParam IDs

--- a/src/devices/lcec_class_cia402_opt.h
+++ b/src/devices/lcec_class_cia402_opt.h
@@ -496,85 +496,86 @@
 
 // This is the list of read PDOs.  These all need to be initialized,
 // mapped, and read.
-#define FOR_ALL_READ_PDOS_DO(thing) \
-  thing(actual_current);            \
-  thing(actual_following_error);    \
-  thing(actual_position);           \
-  thing(actual_torque);             \
-  thing(actual_velocity);           \
-  thing(actual_velocity_sensor);    \
-  thing(actual_vl);                 \
-  thing(actual_voltage);            \
-  thing(control_effort);            \
-  thing(error_code);                \
-  thing(opmode_display);            \
-  thing(position_demand);           \
-  thing(probe_status);              \
-  thing(torque_demand);             \
-  thing(velocity_demand);           \
-  thing(vl_demand);
+#define FOR_ALL_READ_PDOS_DO(action) \
+  action(actual_current);            \
+  action(actual_following_error);    \
+  action(actual_position);           \
+  action(actual_torque);             \
+  action(actual_velocity);           \
+  action(actual_velocity_sensor);    \
+  action(actual_vl);                 \
+  action(actual_voltage);            \
+  action(control_effort);            \
+  action(error_code);                \
+  action(opmode_display);            \
+  action(position_demand);           \
+  action(probe_status);              \
+  action(torque_demand);             \
+  action(velocity_demand);           \
+  action(vl_demand);
 
 // This is the list of write SDOs.  These need to be initialized, mapped, and written.
-#define FOR_ALL_WRITE_PDOS_DO(thing) \
-  thing(opmode);                     \
-  thing(profile_velocity);           \
-  thing(target_position);            \
-  thing(target_torque);              \
-  thing(target_velocity);            \
-  thing(target_vl);
+#define FOR_ALL_WRITE_PDOS_DO(action) \
+  action(opmode);                     \
+  action(profile_velocity);           \
+  action(target_position);            \
+  action(target_torque);              \
+  action(target_velocity);            \
+  action(target_vl);
 
 // This is the list of write *SDOs*.  These need to be initialized differently and written, but not mapped.
-#define FOR_ALL_WRITE_SDOS_DO(thing) \
-  thing(following_error_timeout);    \
-  thing(following_error_window);     \
-  thing(home_accel);                 \
-  thing(home_method);                \
-  thing(home_velocity_fast);         \
-  thing(home_velocity_slow);         \
-  thing(interpolation_time_period);  \
-  thing(maximum_acceleration);       \
-  thing(maximum_current);            \
-  thing(maximum_deceleration);       \
-  thing(maximum_motor_rpm);          \
-  thing(maximum_slippage);           \
-  thing(maximum_torque);             \
-  thing(motion_profile);             \
-  thing(motor_rated_current);        \
-  thing(motor_rated_torque);         \
-  thing(polarity);                   \
-  thing(positioning_time);           \
-  thing(positioning_window);         \
-  thing(profile_accel);              \
-  thing(profile_decel);              \
-  thing(profile_end_velocity);       \
-  thing(profile_max_velocity);       \
-  thing(torque_profile_type);        \
-  thing(torque_slope);               \
-  thing(velocity_error_time);        \
-  thing(velocity_error_window);      \
-  thing(velocity_sensor_selector);   \
-  thing(velocity_threshold_time);    \
-  thing(velocity_threshold_window);  \
-  thing(vl_maximum);                 \
-  thing(vl_minimum);
+#define FOR_ALL_WRITE_SDOS_DO(action) \
+  action(following_error_timeout);    \
+  action(following_error_window);     \
+  action(home_accel);                 \
+  action(home_method);                \
+  action(home_velocity_fast);         \
+  action(home_velocity_slow);         \
+  action(interpolation_time_period);  \
+  action(maximum_acceleration);       \
+  action(maximum_current);            \
+  action(maximum_deceleration);       \
+  action(maximum_motor_rpm);          \
+  action(maximum_slippage);           \
+  action(maximum_torque);             \
+  action(motion_profile);             \
+  action(motor_rated_current);        \
+  action(motor_rated_torque);         \
+  action(polarity);                   \
+  action(positioning_time);           \
+  action(positioning_window);         \
+  action(profile_accel);              \
+  action(profile_decel);              \
+  action(profile_end_velocity);       \
+  action(profile_max_velocity);       \
+  action(torque_profile_type);        \
+  action(torque_slope);               \
+  action(velocity_error_time);        \
+  action(velocity_error_window);      \
+  action(velocity_sensor_selector);   \
+  action(velocity_threshold_time);    \
+  action(velocity_threshold_window);  \
+  action(vl_maximum);                 \
+  action(vl_minimum);
 
 // This is the list of CiA 402 modes:
-#define FOR_ALL_CIA402_MODES_DO(thing) thing(pp) thing(pv) thing(csp) thing(csv) thing(cst) thing(hm) thing(ip) thing(tq) thing(vl)
+#define FOR_ALL_CIA402_MODES_DO(action) \
+  action(pp) action(pv) action(csp) action(csv) action(cst) action(hm) action(ip) action(tq) action(vl)
 
 // This is all items that have entries in `enabled`.  It is neither a
 // proper superset not proper subset of the above entries.
 //
 // Also, `clang-format` *really* doesn't know what to do with this.
-#define FOR_ALL_OPTS_DO(thing)                                                                                                      \
-  thing(actual_current) thing(actual_following_error) thing(actual_torque) thing(actual_velocity_sensor) thing(actual_vl)           \
-      thing(actual_voltage) thing(csp) thing(cst) thing(csv) thing(digital_input) thing(digital_output) thing(error_code)           \
-          thing(following_error_timeout) thing(following_error_window) thing(hm) thing(home_accel) thing(interpolation_time_period) \
-              thing(ip) thing(maximum_acceleration) thing(maximum_current) thing(maximum_deceleration) thing(maximum_motor_rpm)     \
-                  thing(maximum_torque) thing(motion_profile) thing(motor_rated_current) thing(motor_rated_torque) thing(opmode)    \
-                      thing(polarity) thing(pp) thing(profile_accel) thing(profile_decel) thing(profile_end_velocity)               \
-                          thing(profile_max_velocity) thing(profile_velocity) thing(pv) thing(target_torque) thing(target_vl)       \
-                              thing(torque_demand) thing(torque_profile_type) thing(torque_slope) thing(tq) thing(velocity_demand)  \
-                                  thing(velocity_error_time) thing(velocity_error_window) thing(velocity_sensor_selector)           \
-                                      thing(velocity_threshold_time) thing(velocity_threshold_window) thing(vl) thing(vl_demand)    \
-                                          thing(vl_maximum) thing(vl_minimum) thing(positioning_window) thing(positioning_time)     \
-                                              thing(maximum_slippage) thing(probe_status) thing(position_demand) thing(control_effort)
+#define FOR_ALL_OPTS_DO(action)                                                                                                          \
+  action(actual_current) action(actual_following_error) action(actual_torque) action(actual_velocity_sensor) action(actual_vl)           \
+      action(actual_voltage) action(csp) action(cst) action(csv) action(digital_input) action(digital_output) action(error_code)         \
+          action(following_error_timeout) action(following_error_window) action(hm) action(home_accel) action(interpolation_time_period) \
+              action(ip) action(maximum_acceleration) action(maximum_current) action(maximum_deceleration) action(maximum_motor_rpm)     \
+                  action(maximum_torque) action(motion_profile) action(motor_rated_current) action(motor_rated_torque) action(opmode)    \
+                      action(polarity) action(pp) action(profile_accel) action(profile_decel) action(profile_end_velocity)               \
+                          action(profile_max_velocity) action(profile_velocity) action(pv) action(target_torque) action(target_vl)       \
+                              action(torque_demand) action(torque_profile_type) action(torque_slope) action(tq) action(velocity_demand)  \
+                                  action(velocity_error_time) action(velocity_error_window) action(velocity_sensor_selector)             \
+                                      action(velocity_threshold_time) action(velocity_threshold_window) action(vl) action(vl_demand)     \
+                                          action(vl_maximum) action(vl_minimum) action(positioning_window) action(positioning_time)      \
+                                              action(maximum_slippage) action(probe_status) action(position_demand) action(control_effort)

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -55,9 +55,9 @@ extern "C" {
 // init macro; this will make GCC run calls to AddTypes() before
 // main() is called.  This is used to register new slave types
 // dynamically without needing a giant list in lcec_main.c.
-#define ADD_TYPES(types)                                   \
-  static void AddTypes(void) __attribute__((constructor)); \
-  static void AddTypes(void) { lcec_addtypes(types, __FILE__); }
+#define ADD_TYPES(types)                                          \
+  static void AddTypes##types(void) __attribute__((constructor)); \
+  static void AddTypes##types(void) { lcec_addtypes(types, __FILE__); }
 
 // vendor ids, please keep sorted.
 #define LCEC_BECKHOFF_VID   0x00000002
@@ -133,10 +133,18 @@ typedef enum {
 } lcec_modparam_type_t;
 
 typedef struct {
-  const char *name;           ///< the name that appears in the XML.
-  int id;                     ///< Numeric ID, should be unique per device driver.
-  lcec_modparam_type_t type;  ///< The type (bit, int, float, string) of this modParam.
+  const char *name;            ///< the name that appears in the XML.
+  int id;                      ///< Numeric ID, should be unique per device driver.
+  lcec_modparam_type_t type;   ///< The type (bit, int, float, string) of this modParam.
+  const char *config_value;    ///< The default value (as a string), for use in lcec_configgen.
+  const char *config_comment;  ///< A comment to added to the output in lcec_configgen.
 } lcec_modparam_desc_t;
+
+typedef struct {
+  const char *name;            ///< the name that appears in the XML.
+  const char *config_value;    ///< The default value (as a string), for use in lcec_configgen.
+  const char *config_comment;  ///< A comment to added to the output in lcec_configgen.
+} lcec_modparam_doc_t;
 
 /// @brief Definition of a device that LinuxCNC-Ethercat supports.
 typedef struct {
@@ -384,8 +392,9 @@ double lcec_lookupdouble(const lcec_lookuptable_double_t *table, const char *key
 double lcec_lookupdouble_i(const lcec_lookuptable_double_t *table, const char *key, double default_value) __attribute__((nonnull));
 
 LCEC_CONF_MODPARAM_VAL_T *lcec_modparam_get(lcec_slave_t *slave, int id) __attribute__((nonnull));
-int lcec_modparam_desc_len(const lcec_modparam_desc_t *mp) __attribute__((nonnull));
-lcec_modparam_desc_t *lcec_modparam_desc_concat(lcec_modparam_desc_t const *a, lcec_modparam_desc_t const *b) __attribute__((nonnull));
+int lcec_modparam_desc_len(const lcec_modparam_desc_t *mp);
+lcec_modparam_desc_t *lcec_modparam_desc_concat(lcec_modparam_desc_t const *a, lcec_modparam_desc_t const *b);
+lcec_modparam_desc_t *lcec_modparam_desc_merge_docs(lcec_modparam_desc_t const *a, lcec_modparam_doc_t const *b);
 
 lcec_pdo_entry_reg_t *lcec_allocate_pdo_entry_reg(int size);
 int lcec_pdo_init(lcec_slave_t *slave, uint16_t idx, uint16_t sidx, unsigned int *os, unsigned int *bp);

--- a/src/lcec_devices.c
+++ b/src/lcec_devices.c
@@ -38,6 +38,11 @@ extern lcec_typelinkedlist_t *typeslist;
 
 int main(int argc, char **argv) {
   for (lcec_typelinkedlist_t *t = typeslist; t != NULL; t = t->next) {
-    printf("%s\t0x%08x\t0x%08x\t%s\n", t->type->name, t->type->vid, t->type->pid, t->type->sourcefile);
+    printf("%s\t0x%08x\t0x%08x\t%s\t", t->type->name, t->type->vid, t->type->pid, t->type->sourcefile);
+    for (const lcec_modparam_desc_t *m = t->type->modparams; m && m->name != NULL; m++) {
+      if (m->config_comment) printf("<!-- %s --> ", m->config_comment);
+      if (m->config_value) printf("<modParam name=\"%s\" value=\"%s\"/> ", m->name, m->config_value);
+    }
+    printf("\n");
   }
 }

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -543,9 +543,9 @@ int lcec_parse_config(void) {
           if (sdo_config == NULL) {
             rtapi_print_msg(
                 RTAPI_MSG_ERR, LCEC_MSG_PFX "Unable to allocate slave %s.%s sdo entry memory\n", master->name, slave_conf->name);
-            lcec_free(generic_pdo_entries);
-            lcec_free(generic_pdos);
-            lcec_free(generic_sync_managers);
+            //lcec_free(generic_pdo_entries);
+            //lcec_free(generic_pdos);
+            //lcec_free(generic_sync_managers);
             goto fail2;
           }
         }
@@ -556,10 +556,10 @@ int lcec_parse_config(void) {
           if (idn_config == NULL) {
             rtapi_print_msg(
                 RTAPI_MSG_ERR, LCEC_MSG_PFX "Unable to allocate slave %s.%s idn entry memory\n", master->name, slave_conf->name);
-            lcec_free(generic_pdo_entries);
-            lcec_free(generic_pdos);
-            lcec_free(generic_sync_managers);
-            lcec_free(sdo_config);
+            //lcec_free(generic_pdo_entries);
+	    //lcec_free(generic_pdos);
+            //lcec_free(generic_sync_managers);
+            //lcec_free(sdo_config);
             goto fail2;
           }
         }
@@ -923,7 +923,7 @@ void lcec_clear_config(void) {
         slave->proc_cleanup(slave);
       }
 
-      // free slave
+      /*      // free slave
       if (slave->modparams != NULL) {
         lcec_free(slave->modparams);
       }
@@ -949,6 +949,7 @@ void lcec_clear_config(void) {
         lcec_free(slave->wd_conf);
       }
       lcec_free(slave);
+      */
       slave = prev_slave;
     }
 

--- a/src/lcec_modparam.c
+++ b/src/lcec_modparam.c
@@ -25,6 +25,20 @@
 int lcec_modparam_desc_len(const lcec_modparam_desc_t *mp) {
   int l;
 
+  if (mp == NULL) return 0;
+
+  for (l = 0; mp[l].name != NULL; l++)
+    ;
+
+  return l;
+}
+
+/// @brief Cound the number of entries in a `lcec_modparam_doc_t[]`.
+int lcec_modparam_doc_len(const lcec_modparam_doc_t *mp) {
+  int l;
+
+  if (mp == NULL) return 0;
+
   for (l = 0; mp[l].name != NULL; l++)
     ;
 
@@ -47,6 +61,45 @@ lcec_modparam_desc_t *lcec_modparam_desc_concat(lcec_modparam_desc_t const *a, l
     c[a_len + i] = b[i];
   }
   c[a_len + b_len] = a[a_len];  // Copy terminator
+
+  return c;
+}
+
+/// @brief Merge the docs and config values for entries in a with values from b.
+lcec_modparam_desc_t *lcec_modparam_desc_merge_docs(lcec_modparam_desc_t const *a, lcec_modparam_doc_t const *b) {
+  int a_len, b_len, i, j;
+  lcec_modparam_desc_t const *aa;
+  lcec_modparam_doc_t const *bb;
+  lcec_modparam_desc_t *c, *cc;
+
+  a_len = lcec_modparam_desc_len(a);
+  b_len = lcec_modparam_doc_len(b);
+
+  // Duplicate a into c
+  c = LCEC_ALLOCATE_ARRAY(lcec_modparam_desc_t, a_len + 1);
+
+  for (j = 0; j < a_len; j++) {
+    aa = a + j;
+    cc = c + j;
+    cc->name = aa->name;
+    cc->id = aa->id;
+    cc->type = aa->type;
+    if (aa->config_value) cc->config_value = aa->config_value;
+    if (aa->config_comment) cc->config_comment = aa->config_comment;
+  }
+
+  for (i = 0; i < b_len; i++) {
+    bb = b + i;
+    if (bb->config_value || bb->config_comment) {
+      for (j = 0; j < a_len; j++) {
+        cc = c + j;
+        if (strcmp(cc->name, bb->name) == 0) {
+          if (bb->config_value) cc->config_value = bb->config_value;
+          if (bb->config_comment) cc->config_comment = bb->config_comment;
+        }
+      }
+    }
+  }
 
   return c;
 }

--- a/src/tests/test_cia402.c
+++ b/src/tests/test_cia402.c
@@ -18,7 +18,17 @@ static const lcec_modparam_desc_t device_mps[] = {
     {NULL},
 };
 
-TESTFUNC(test_modparm_len) {
+static const lcec_modparam_desc_t device_mps2[] = {
+    {"eee", 0x100, MODPARAM_TYPE_S32, "42"},
+    {NULL},
+};
+
+static const lcec_modparam_doc_t docs_mps[] = {
+    {"aaa", "12"},
+    {NULL},
+};
+
+TESTFUNC(test_cia402_modparam_len) {
   TESTSETUP;
   lcec_modparam_desc_t *channelized_mps;
 
@@ -75,10 +85,37 @@ TESTFUNC(test_modparm_len) {
   TESTRESULTS;
 }
 
-TESTFUNC(test_modparam_ratio) {
+TESTFUNC(test_cia402_modparam_defaults) {
   TESTSETUP;
 
-  int max_denom = 1<<15;
+  int a = lcec_modparam_desc_len(lcec_cia402_modparams(NULL, NULL, NULL));
+
+  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(per_channel_mps, NULL, NULL)), a + 27);
+  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(per_channel_mps, device_mps, NULL)), a + 28);
+  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(per_channel_mps, device_mps, docs_mps)), a + 28);
+
+  lcec_modparam_desc_t *all_mps = lcec_modparam_desc_concat(per_channel_mps, device_mps2);
+
+  TESTINT(lcec_modparam_desc_len(all_mps), 4);
+  TESTSTRING(all_mps[3].config_value, "42");
+
+  TESTRESULTS;
+}
+
+TESTFUNC(test_cia402_modparam_docs) {
+  TESTSETUP;
+  lcec_modparam_desc_t *merged_mps = lcec_modparam_desc_merge_docs(per_channel_mps, docs_mps);
+
+  TESTINT(lcec_modparam_desc_len(merged_mps), 3);
+  TESTSTRING(merged_mps[0].config_value, "12");
+
+  TESTRESULTS;
+}
+
+TESTFUNC(test_cia402_modparam_ratio) {
+  TESTSETUP;
+
+  int max_denom = 1 << 15;
 
   lcec_ratio ratio;
   ratio = lcec_cia402_decode_ratio_modparam("1/2", max_denom);

--- a/src/tests/test_modparam.c
+++ b/src/tests/test_modparam.c
@@ -21,12 +21,22 @@ static const lcec_modparam_desc_t mp_0[] = {
     {NULL},
 };
 
-TESTFUNC(test_modparm_len) {
+TESTFUNC(test_modparam_len) {
   TESTSETUP;
 
   TESTINT(lcec_modparam_desc_len(mp_3), 3);
   TESTINT(lcec_modparam_desc_len(mp_1), 1);
   TESTINT(lcec_modparam_desc_len(mp_0), 0);
+  TESTINT(lcec_modparam_desc_len(NULL), 0);
+
+  TESTRESULTS;
+}
+
+TESTFUNC(test_modparam_concat) {
+  TESTSETUP;
+  TESTINT(lcec_modparam_desc_len(lcec_modparam_desc_concat(mp_1, mp_3)), 4);
+  TESTINT(lcec_modparam_desc_len(lcec_modparam_desc_concat(mp_1, mp_0)), 1);
+  TESTINT(lcec_modparam_desc_len(lcec_modparam_desc_concat(mp_1, NULL)), 1);
 
   TESTRESULTS;
 }

--- a/tests/scottlaird-lcectest1/cia402-all.hal
+++ b/tests/scottlaird-lcectest1/cia402-all.hal
@@ -61,7 +61,6 @@ net rtdrv-drv-act-velo lcec.0.rt-ect60.srv-actual-velocity => cia402.3.drv-actua
 net rtdrv-controlword cia402.3.controlword => lcec.0.rt-ect60.srv-cia-controlword
 net rtdrv-modes-of-operation cia402.3.opmode => lcec.0.rt-ect60.srv-opmode
 net rtdrv-drv-target-pos cia402.3.drv-target-position => lcec.0.rt-ect60.srv-target-position
-net rtdrv-drv-target-velo cia402.3.drv-target-velocity => lcec.0.rt-ect60.srv-target-velocity
 net 2-home-index <= joint.2.index-enable => cia402.3.home
 net 2-enable <= joint.2.amp-enable-out => cia402.3.enable
 net 2-amp-fault => joint.2.amp-fault-in <= cia402.3.drv-fault
@@ -84,7 +83,6 @@ net rtecr1-drv-act-velo lcec.0.rt-ecr60x2.srv-1-actual-velocity => cia402.4.drv-
 net rtecr1-controlword cia402.4.controlword => lcec.0.rt-ecr60x2.srv-1-cia-controlword
 net rtecr1-modes-of-operation cia402.4.opmode => lcec.0.rt-ecr60x2.srv-1-opmode
 net rtecr1-drv-target-pos cia402.4.drv-target-position => lcec.0.rt-ecr60x2.srv-1-target-position
-net rtecr1-drv-target-velo cia402.4.drv-target-velocity => lcec.0.rt-ecr60x2.srv-1-target-velocity
 net 1-home-index <= joint.1.index-enable => cia402.4.home
 net 1-enable <= joint.1.amp-enable-out => cia402.4.enable
 net 1-amp-fault => joint.1.amp-fault-in <= cia402.4.drv-fault


### PR DESCRIPTION
This adds two fields to `lcec_modparam_desc_t`, the structure that describes `<modParam>` options in LCEC.  These are both optional, and are used for communicating with `lcec_configgen` or other configuration systems.

The first field, `config_value`, shows a default value for the modParam.  This should (but does not have to) match the default of the system.  Any modParam that has `config_value` set will appear in `lcec_configgen`'s output; see below for an example.

The second field, `config_comment` provides a comment to go with the modParam.

This PR modifies `lcec_rtec`'s `enableCSP`'s `config_value` to `true` and sets its `config_comment` to `Enable support for Cyclic Synchronous Position mode.`.  When `lcec_configgen` runs and finds a RTEC device, then it'll produce output like this:

```
    <slave idx="27" type="ECT60" name="D28">
      <!-- Enable support for Cyclic Synchronous Position mode. -->
      <modParam name="enableCSP" value="true"/>
 
      ...
    </slave>
```

This support is completely generic in `lcec_configgen`, it knows nothing about individual drivers (except for `basic_cia402`, sort of).  Ths list of modparams and comments has been added to the output of `lcec_devices`, which was already used to extract a list of all devices supported by the current build.  This is then piped into `lcec_configgen` at build time automatically by `make`.

As usual, there are a few weird bits here, mostly around CiA 402 and multi-axis devices.  This PR alters the way that CiA 402 drivers communicate modParams and extends it to add an "docs" field as well as splitting the list of per-driver modParams up into a per-axis and a per-device section.  The per-axis modParams are expanded from `foo` into `[foo, ch1foo, ch2foo, ch3foo, ch4foo, ch5foo, ch6foo, ch7foo, ch8foo]`, even for devices that only support 1 axis.  The per-device modParams are not expanded this way, and end up copied as-is into the final modParam list.  Any modParams added to the `docs` list are matched against existing modParams (by comparing names only), and then the `config_value` and `config_comment` fields are copied over the existing values.

This allows drivers to add config data to modParams defined in `lcec_class_cia402`.

Unfortunately, adding config data *directly* to per-channel modParams currently results in a terrible UX, as it ends up emitting all 9 `foo`, `ch1foo`, ... `ch8foo` params.  To work around this, I'm explicitly only adding config data to specific channel's data in `lcec_rtec.c`.  This results in output like this for 2-axis devices:

```
    <slave idx="28" type="ECR60x2" name="D29">
      <!-- Enable support for Cyclic Synchronous Position mode. -->
      <modParam name="ch1enableCSP" value="true"/>

      <!-- Enable support for Cyclic Synchronous Position mode. -->
      <modParam name="ch2enableCSP" value="true"/>

      ....
</slave>
```

It's a bit ugly, but the output is about as good as it can get.


Note, there's still one shortcoming in this code; we still don't handle device-specific, per-channel modparams correctly in lcec_rtec.  Setting `foo` or `ch1foo` works, but `ch2foo` is still broken.  It's very slightly less broken with this PR.