### PR TITLE
fix: fix minor C++ compile bugs

### DIFF
--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -63,15 +63,18 @@ static const lcec_modparam_doc_t overrides[] = {
 
 static int lcec_basic_cia402_init(int comp_id, lcec_slave_t *slave);
 
-// When extending this, you will need to modify the number of PDOs
-// registered (the `8` here).  For now, the easiest way to do this is
-// to set it to a fairly large number, compile the driver, and attempt
-// to use it.  It will fail with an error, but the error message will
-// give the correct value.
+// XXXX: macros like these are helpful if you're planning on
+// supporting devices with varying numbers of axes and I/O ports in
+// your device.  See lcec_leadshine_stepper.c and lece_rtec.c for
+// examples of use.
 //
-// In the future, we'll probably remove the number entirely and handle
-// it dynamically.  Then this comment can go away.
-//
+//#define AXES(flags)  ((flags >> 60) & 0xf)
+//#define DIN(flags) ((flags >> 56) & 0xf)
+//#define DOUT(flags) ((flags >> 52) & 0xf)
+//#define F_AXES(axes) ((uint64_t)axes << 60)
+//#define F_DIN(din) ((uint64_t)din<<56)
+//#define F_DOUT(dout) ((uint64_t)dout<<52)
+
 // XXXX: remove `basic_cia402` and replace it with your device name,
 // then change the next two parameters to match your device's VID and
 // PID.  Feel free to add multiple devices here if they can share the

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -223,11 +223,7 @@ static int lcec_deasda_init(int comp_id, lcec_slave_t *slave) {
   uint64_t flags;
   flags = slave->flags;
 
-  syncs = hal_malloc(sizeof(lcec_syncs_t));
-  if (syncs == NULL) {
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "hal_malloc() for deasda syncs failed\n");
-    return -1;
-  }
+  syncs = LCEC_HAL_ALLOCATE(lcec_syncs_t);
 
   // Determine Operation Mode (modParam opmode) as this defines everything else
   LCEC_CONF_MODPARAM_VAL_T *pval;

--- a/src/lcec_conf_util.c
+++ b/src/lcec_conf_util.c
@@ -39,15 +39,15 @@ void initOutputBuffer(LCEC_CONF_OUTBUF_T *buf) {
 }
 
 void *addOutputBuffer(LCEC_CONF_OUTBUF_T *buf, size_t len) {
-  void *p = calloc(1, sizeof(LCEC_CONF_OUTBUF_ITEM_T) + len);
+  LCEC_CONF_OUTBUF_T *p = (LCEC_CONF_OUTBUF_T *)calloc(1, sizeof(LCEC_CONF_OUTBUF_ITEM_T) + len);
   if (p == NULL) {
     fprintf(stderr, "%s: ERROR: Couldn't allocate memory for config token\n", modname);
     return NULL;
   }
 
   // setup header
-  LCEC_CONF_OUTBUF_ITEM_T *header = p;
-  p += sizeof(LCEC_CONF_OUTBUF_ITEM_T);
+  LCEC_CONF_OUTBUF_ITEM_T *header = (LCEC_CONF_OUTBUF_ITEM_T *)p;
+  p = (LCEC_CONF_OUTBUF_T *)((char *)p + sizeof(LCEC_CONF_OUTBUF_ITEM_T));
   header->len = len;
   buf->len += len;
 


### PR DESCRIPTION
This fixes a couple minor C++ compilation bugs that have crept in, plus an obsolete comment in `lcec_basic_cia402.c`.

I try to keep this code C++-clean, as C++ compilers are *generally* stricter about type mismatches and catch bugs that are *technically* legal C but still incorrect.

I also use clang's `scan-build` and GCC's `-fanalyzer` from time to time.  They all find bugs.