### PR TITLE
feat(cia402): Allow for variable numbers of channels in modParam generation

### DIFF
--- a/src/configgen/drivers/drivers.go
+++ b/src/configgen/drivers/drivers.go
@@ -280,6 +280,8 @@ var Drivers=[]EthercatDriver{
       "<modParam name=\"ch2peakCurrent_amps\" value=\"6.0\"/> ",
       "<!-- Number of stepper pulses per rotation --> ",
       "<modParam name=\"ch1motorResolution_pulses\" value=\"10000\"/> ",
+      "<!-- Number of stepper pulses per rotation --> ",
+      "<modParam name=\"ch2motorResolution_pulses\" value=\"10000\"/> ",
       "<!-- Number of encoder steps per revolution. --> ",
       "<modParam name=\"ch1encoderResolution\" value=\"4000\"/> ",
       "<!-- Number of encoder steps per revolution. --> ",

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -56,8 +56,13 @@ static const lcec_modparam_desc_t modparams_base[] = {
     {NULL},
 };
 
-static const lcec_modparam_doc_t overrides[] = {
-    // XXXX, add overrides here
+static const lcec_modparam_doc_t chan_docs[] = {
+    // XXXX, add documentation for per-channel settings here
+    {NULL},
+};
+
+static const lcec_modparam_doc_t base_docs[] = {
+    // XXXX, add documentation for device-specific settings here
     {NULL},
 };
 
@@ -84,7 +89,7 @@ static lcec_typelist_t types[] = {
         /* modparams implicitly added below */},
     {NULL},
 };
-ADD_TYPES_WITH_CIA402_MODPARAMS(types, modparams_perchannel, modparams_base, overrides)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types, CIA402_MAX_CHANNELS, modparams_perchannel, modparams_base, chan_docs, base_docs)
 
 static void lcec_basic_cia402_read(lcec_slave_t *slave, long period);
 static void lcec_basic_cia402_write(lcec_slave_t *slave, long period);

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -306,24 +306,24 @@ lcec_class_cia402_options_t *lcec_cia402_options(void);
 lcec_class_cia402_channel_options_t *lcec_cia402_channel_options(void);
 void lcec_cia402_rename_multiaxis_channels(lcec_class_cia402_options_t *opt);
 int lcec_cia402_handle_modparam(struct lcec_slave *slave, const lcec_slave_modparam_t *p, lcec_class_cia402_options_t *opt);
-lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t const *orig);
-lcec_modparam_desc_t *lcec_cia402_modparams(
-    lcec_modparam_desc_t const *device_channelized_mps, lcec_modparam_desc_t const *device_base_mps, lcec_modparam_doc_t const *overrides);
+lcec_modparam_desc_t *lcec_cia402_channelized_modparams(lcec_modparam_desc_t const *orig, int count);
+lcec_modparam_desc_t *lcec_cia402_modparams(int channels, lcec_modparam_desc_t const *device_channelized_mps,
+    lcec_modparam_desc_t const *device_base_mps, lcec_modparam_doc_t const *channelized_docs, lcec_modparam_doc_t const *base_docs);
 lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_output_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 int lcec_cia402_add_input_sync(lcec_slave_t *slave, lcec_syncs_t *syncs, lcec_class_cia402_options_t *options);
 lcec_ratio lcec_cia402_decode_ratio_modparam(const char *value, int max_denominator);
 
-#define ADD_TYPES_WITH_CIA402_MODPARAMS(types, chan_mps, base_mps, overrides) \
-  static void AddTypes##types(void) __attribute__((constructor));             \
-  static void AddTypes##types(void) {                                         \
-    const lcec_modparam_desc_t *all_modparams;                                \
-    int i;                                                                    \
-    all_modparams = lcec_cia402_modparams(chan_mps, base_mps, overrides);     \
-    for (i = 0; types[i].name != NULL; i++) {                                 \
-      types[i].modparams = all_modparams;                                     \
-    }                                                                         \
-    lcec_addtypes(types, __FILE__);                                           \
+#define ADD_TYPES_WITH_CIA402_MODPARAMS(types, channels, chan_mps, base_mps, chan_docs, base_docs) \
+  static void AddTypes##types(void) __attribute__((constructor));                                  \
+  static void AddTypes##types(void) {                                                              \
+    const lcec_modparam_desc_t *all_modparams;                                                     \
+    int i;                                                                                         \
+    all_modparams = lcec_cia402_modparams(channels, chan_mps, base_mps, chan_docs, base_docs);     \
+    for (i = 0; types[i].name != NULL; i++) {                                                      \
+      types[i].modparams = all_modparams;                                                          \
+    }                                                                                              \
+    lcec_addtypes(types, __FILE__);                                                                \
   }
 
 // modParam IDs

--- a/src/devices/lcec_leadshine_stepper.c
+++ b/src/devices/lcec_leadshine_stepper.c
@@ -55,17 +55,9 @@ static const lcec_modparam_desc_t modparams_base[] = {
     {NULL},
 };
 
-static const lcec_modparam_doc_t docs1[] = {
+static const lcec_modparam_doc_t docs[] = {
     {"feedRatio", "10000", "Microsteps per rotation"},
     {"encoderRatio", "4000", "Encoder steps per rotation"},
-    {NULL},
-};
-
-static const lcec_modparam_doc_t docs2[] = {
-    {"ch1feedRatio", "10000", "Microsteps per rotation"},
-    {"ch2feedRatio", "10000", "Microsteps per rotation"},
-    {"ch1encoderRatio", "4000", "Encoder steps per rotation"},
-    {"ch2encoderRatio", "4000", "Encoder steps per rotation"},
     {NULL},
 };
 
@@ -113,8 +105,8 @@ static lcec_typelist_t types2[] = {
     {NULL},
 };
 
-ADD_TYPES_WITH_CIA402_MODPARAMS(types1, modparams_perchannel, modparams_base, docs1)
-ADD_TYPES_WITH_CIA402_MODPARAMS(types2, modparams_perchannel, modparams_base, docs2)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types1, 1, modparams_perchannel, modparams_base, docs, NULL)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types2, 2, modparams_perchannel, modparams_base, docs, NULL)
 
 static void lcec_leadshine_stepper_read(lcec_slave_t *slave, long period);
 static void lcec_leadshine_stepper_write(lcec_slave_t *slave, long period);

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -85,53 +85,34 @@ static const lcec_modparam_desc_t modparams_base[] = {
 // We don't want to list *everything* here, because that gets
 // overwhelming, but we do want to include the most common things that
 // users will want to change.
-#define PER_CHANNEL_DOCS(ch)                                                                                              \
-  {#ch "enableCSP", "true", "Enable support for Cyclic Synchronous Position mode."},                                      \
-      {#ch "enableCSV", "false", "Enable support for Cyclic Synchronous Velocity mode."},                                 \
-      {#ch "encoderResolution", "4000", "Number of encoder steps per revolution."},                                       \
-      {#ch "peakCurrent_amps", "6.0", "Maximum stepper Amps."},                                                           \
-      {#ch "output1Func", "alarm", "Output 1 use: general, alarm, brake, in-place."},                                     \
-      {#ch "output2Func", "brake", "Output 2 use: general, alarm, brake, in-place."},                                     \
-      {#ch "input3Func", "cw-limit",                                                                                      \
-          "Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"}, \
-      {#ch "input4Func", "ccw-limit",                                                                                     \
-          "Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"}, \
-      {#ch "input5Func", "home",                                                                                          \
-          "Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"}, \
-  {                                                                                                                       \
-#ch "input6Func", "motor-offline",                                                                                    \
-        "Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"     \
+#define PER_CHANNEL_DOCS                                                                                                              \
+  {"enableCSP", "true", "Enable support for Cyclic Synchronous Position mode."},                                                      \
+      {"enableCSV", "false", "Enable support for Cyclic Synchronous Velocity mode."},                                                 \
+      {"encoderResolution", "4000", "Number of encoder steps per revolution."}, {"peakCurrent_amps", "6.0", "Maximum stepper Amps."}, \
+      {"output1Func", "alarm", "Output 1 use: general, alarm, brake, in-place."},                                                     \
+      {"output2Func", "brake", "Output 2 use: general, alarm, brake, in-place."},                                                     \
+      {"input3Func", "cw-limit",                                                                                                      \
+          "Input 3 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"},             \
+      {"input4Func", "ccw-limit",                                                                                                     \
+          "Input 4 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"},             \
+      {"input5Func", "home",                                                                                                          \
+          "Input 5 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"},             \
+  {                                                                                                                                   \
+    "input6Func", "motor-offline",                                                                                                    \
+        "Input 6 use: general, cw-limit, ccw-limit, home, clear-fault, emergency-stop, motor-offline, probe1, probe2"                 \
   }
 
-/// Default values for single-axis open-loop steppers
+/// Default values for open-loop steppers
 static const lcec_modparam_doc_t docs_open[] = {
-    PER_CHANNEL_DOCS(),
+    PER_CHANNEL_DOCS,
     {"motorResolution_pulses", "10000", "Number of stepper pulses per rotation"},
     {NULL},
 };
 
-/// Default values for dual-axis open-loop steppers
-static const lcec_modparam_doc_t docs_open_x2[] = {
-    PER_CHANNEL_DOCS(ch1),
-    PER_CHANNEL_DOCS(ch2),
-    {"ch1motorResolution_pulses", "10000", "Number of stepper pulses per rotation"},
-    {"ch1motorResolution_pulses", "10000", "Number of stepper pulses per rotation"},
-    {NULL},
-};
-
-/// Default values for single-axis closed-loop steppers
+/// Default values for closed-loop steppers
 static const lcec_modparam_doc_t docs_closed[] = {
-    PER_CHANNEL_DOCS(),
+    PER_CHANNEL_DOCS,
     {"controlMode", "closedloop", "Operation mode: openloop, closedloop, or foc."},
-    {NULL},
-};
-
-/// Default values for dual-axis closed-loop steppers
-static const lcec_modparam_doc_t docs_closed_x2[] = {
-    PER_CHANNEL_DOCS(ch1),
-    PER_CHANNEL_DOCS(ch2),
-    {"ch1controlMode", "closedloop", "Operation mode: openloop, closedloop, or foc."},
-    {"ch2controlMode", "closedloop", "Operation mode: openloop, closedloop, or foc."},
     {NULL},
 };
 
@@ -173,10 +154,10 @@ static lcec_typelist_t types_closed_x2[] = {
     {NULL},
 };
 
-ADD_TYPES_WITH_CIA402_MODPARAMS(types_open, modparams_perchannel, modparams_base, docs_open)
-ADD_TYPES_WITH_CIA402_MODPARAMS(types_open_x2, modparams_perchannel, modparams_base, docs_open_x2)
-ADD_TYPES_WITH_CIA402_MODPARAMS(types_closed, modparams_perchannel, modparams_base, docs_closed)
-ADD_TYPES_WITH_CIA402_MODPARAMS(types_closed_x2, modparams_perchannel, modparams_base, docs_closed_x2)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types_open, 1, modparams_perchannel, modparams_base, docs_open, NULL)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types_open_x2, 2, modparams_perchannel, modparams_base, docs_open, NULL)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types_closed, 1, modparams_perchannel, modparams_base, docs_closed, NULL)
+ADD_TYPES_WITH_CIA402_MODPARAMS(types_closed_x2, 2, modparams_perchannel, modparams_base, docs_closed, NULL)
 
 static void lcec_rtec_read(lcec_slave_t *slave, long period);
 static void lcec_rtec_write(lcec_slave_t *slave, long period);

--- a/src/tests/test_cia402.c
+++ b/src/tests/test_cia402.c
@@ -35,7 +35,7 @@ TESTFUNC(test_cia402_modparam_len) {
   TESTINT(lcec_modparam_desc_len(per_channel_mps), 3);
   TESTINT(lcec_modparam_desc_len(device_mps), 1);
 
-  channelized_mps = lcec_cia402_channelized_modparams(per_channel_mps);
+  channelized_mps = lcec_cia402_channelized_modparams(per_channel_mps, CIA402_MAX_CHANNELS);
   TESTNOTNULL(channelized_mps);
 
   TESTINT(lcec_modparam_desc_len(channelized_mps), 27);
@@ -82,17 +82,64 @@ TESTFUNC(test_cia402_modparam_len) {
   TESTINT(all_mps[16].id, 0x1016);
   TESTINT(all_mps[17].id, 0x1017);
 
+
+  // Test with 1 channel
+  channelized_mps = lcec_cia402_channelized_modparams(per_channel_mps, 1);
+  TESTNOTNULL(channelized_mps);
+
+  TESTINT(lcec_modparam_desc_len(channelized_mps), 3);
+
+  all_mps = lcec_modparam_desc_concat(channelized_mps, device_mps);
+  TESTNOTNULL(all_mps);
+
+  TESTINT(lcec_modparam_desc_len(all_mps), 4);
+  TESTSTRING(all_mps[0].name, "aaa");
+  TESTSTRING(all_mps[1].name, "bbb");
+  TESTSTRING(all_mps[2].name, "ccc");
+  TESTSTRING(all_mps[3].name, "ddd");
+
+  TESTINT(all_mps[0].id, 0x1000);
+  TESTINT(all_mps[1].id, 0x1010);
+  TESTINT(all_mps[2].id, 0x1020);
+  TESTINT(all_mps[3].id, 1);
+
+  // Test with 2 channels
+  channelized_mps = lcec_cia402_channelized_modparams(per_channel_mps, 2);
+  TESTNOTNULL(channelized_mps);
+
+  TESTINT(lcec_modparam_desc_len(channelized_mps), 6);
+
+  all_mps = lcec_modparam_desc_concat(channelized_mps, device_mps);
+  TESTNOTNULL(all_mps);
+
+  TESTINT(lcec_modparam_desc_len(all_mps), 7);
+  TESTSTRING(all_mps[0].name, "ch1aaa");
+  TESTSTRING(all_mps[1].name, "ch2aaa");
+  TESTSTRING(all_mps[2].name, "ch1bbb");
+  TESTSTRING(all_mps[3].name, "ch2bbb");
+  TESTSTRING(all_mps[4].name, "ch1ccc");
+  TESTSTRING(all_mps[5].name, "ch2ccc");
+  TESTSTRING(all_mps[6].name, "ddd");
+
+  TESTINT(all_mps[0].id, 0x1000);
+  TESTINT(all_mps[1].id, 0x1001);
+  TESTINT(all_mps[2].id, 0x1010);
+  TESTINT(all_mps[3].id, 0x1011);
+  TESTINT(all_mps[4].id, 0x1020);
+  TESTINT(all_mps[5].id, 0x1021);
+  TESTINT(all_mps[6].id, 1);
+  
   TESTRESULTS;
 }
 
 TESTFUNC(test_cia402_modparam_defaults) {
   TESTSETUP;
 
-  int a = lcec_modparam_desc_len(lcec_cia402_modparams(NULL, NULL, NULL));
+  int a = lcec_modparam_desc_len(lcec_cia402_modparams(8, NULL, NULL, NULL, NULL));
 
-  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(per_channel_mps, NULL, NULL)), a + 27);
-  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(per_channel_mps, device_mps, NULL)), a + 28);
-  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(per_channel_mps, device_mps, docs_mps)), a + 28);
+  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(8, per_channel_mps, NULL, NULL, NULL)), a + 27);
+  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(8, per_channel_mps, device_mps, NULL, NULL)), a + 28);
+  TESTINT(lcec_modparam_desc_len(lcec_cia402_modparams(8, per_channel_mps, device_mps, NULL, docs_mps)), a + 28);
 
   lcec_modparam_desc_t *all_mps = lcec_modparam_desc_concat(per_channel_mps, device_mps2);
 


### PR DESCRIPTION
There's a moderate amount of magic under the hood with `<modParam>`s for CiA 402 devices.  Since devices can have between 1 and 8 motor channels (axes) per device, we need a way to specify per-channel modParams without needing to duplicate everything 8x.  To do this, we auto-generate an expanded list of modParams in `lcec_cia402_modparams()`, with one per channel.  

Previously, we always generated a full set of per-channel modParams plus the base-named model for all CiA 402 devices.  That is, when there was a per-channel modParam named `foo`, we created a list that included `foo`, `ch1foo`, `ch2foo`, ... `ch8foo`.

That was fine until we started adding documentation for things; once that happened, if we added docs for per-channel modParams then we'd *always* get 9 sets of comments generated, which is user-hostile, and the workarounds were ugly.

This changes the behavior so that we can specify how many axes' worth of modParams we want.  If we request 8, then we get `foo`, `ch1foo`, etc, like before.  If we request 1, then we only get `foo`.  And if we request between 2 and 7, then we get `ch1foo` and `ch2foo`, without `foo`.  This still leaves `basic_cia402` with ugly params, but there's not much that we can do about that.  Device-specific drivers, which should always know how many axes each device support, become slightly less complex now.

One downside is that is now starting to get too many params in modParam-handling fuctions, so we're not *quite* there yet.  This also needs better examples in `basic_cia402`.

Kind of wondering if [designated-initializer args](https://pdimov.github.io/blog/2020/09/07/named-parameters-in-c20/) are too far to go for this.  The linked article is about C++, but it's using a C feature, not a C++ feature.