### PR TITLE
feat(syncs): Support overflowing PDOs when all PDO entries are in use

### DIFF
--- a/documentation/pdos-and-syncs.md
+++ b/documentation/pdos-and-syncs.md
@@ -162,6 +162,18 @@ exist on this specific device.  So we need to manually handle
 mappings, *and* there are a lot of conditionals to control which
 objects get mapped.
 
+In addition to all of this, this style has an extra feature that can
+be useful in very dynamic environments (like CiA 402 devices) --
+`lcec_syncs_enable_autoflow()` can tell LinuxCNC how many PDOs a
+device supports, and how many PDO entries each PDO supports, and it
+will then automatically start a new PDO when needed because the
+current PDO has run out of free entries.  This lets us use the same
+basic code on devices that allow dozens of PDO entries per PDO, as
+well as devices like the Omron MX2 which only allow *2* PDO entries
+per PDO.  By using `autoflow`, we can transparently map a handful of
+PDO entries into a many PDOs as required without needing to modify any
+higher-level code.
+
 ## Performance
 
 If we don't explicitly set `sync_info`, then the Etherlab EtherCAT

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -36,10 +36,13 @@
 #include "lcec_class_dout.h"
 
 // Constants for modparams.  The basic_cia402 driver only has one:
-#define M_CHANNELS     0
-#define M_RXPDOLIMIT   1
-#define M_TXPDOLIMIT   2
-#define M_PDOINCREMENT 3
+#define M_CHANNELS      0
+#define M_RXPDOLIMIT    1
+#define M_TXPDOLIMIT    2
+#define M_PDOINCREMENT  3
+#define M_PDOAUTOFLOW   4
+#define M_PDOLIMIT      5
+#define M_PDOENTRYLIMIT 6
 
 /// @brief Device-specific modparam settings available via XML.
 static const lcec_modparam_desc_t modparams_perchannel[] = {
@@ -52,6 +55,9 @@ static const lcec_modparam_desc_t modparams_base[] = {
     {"ciaRxPDOEntryLimit", M_RXPDOLIMIT, MODPARAM_TYPE_U32},
     {"ciaTxPDOEntryLimit", M_TXPDOLIMIT, MODPARAM_TYPE_U32},
     {"pdoIncrement", M_PDOINCREMENT, MODPARAM_TYPE_U32},
+    {"pdoAutoflow", M_PDOAUTOFLOW, MODPARAM_TYPE_BIT},
+    {"pdoLimit", M_PDOLIMIT, MODPARAM_TYPE_U32},
+    {"pdoEntryLimit", M_PDOENTRYLIMIT, MODPARAM_TYPE_U32},
     // XXXX, add device-specific modparams here that aren't duplicated for multi-axis devices
     {NULL},
 };
@@ -123,6 +129,15 @@ static int handle_modparams(lcec_slave_t *slave, lcec_class_cia402_options_t *op
         break;
       case M_PDOINCREMENT:
         options->pdo_increment = p->value.u32;
+        break;
+      case M_PDOAUTOFLOW:
+        options->pdo_autoflow = p->value.bit;
+        break;
+      case M_PDOLIMIT:
+        options->pdo_limit = p->value.u32;
+        break;
+      case M_PDOENTRYLIMIT:
+        options->pdo_entry_limit = p->value.u32;
         break;
       default:
         // Handle cia402 generic modparams

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -145,6 +145,9 @@ lcec_class_cia402_options_t *lcec_cia402_options(void) {
   lcec_class_cia402_options_t *opts = LCEC_HAL_ALLOCATE(lcec_class_cia402_options_t);
   opts->channels = 1;
   opts->pdo_increment = 1;
+  opts->pdo_autoflow = 0;
+  opts->pdo_limit = 1 << 10;        // Too high to trigger
+  opts->pdo_entry_limit = 1 << 10;  //  To high to trigger
 
   for (int channel = 0; channel < 8; channel++) {
     opts->channel[channel] = lcec_cia402_channel_options();
@@ -184,6 +187,10 @@ lcec_syncs_t *lcec_cia402_init_sync(lcec_slave_t *slave, lcec_class_cia402_optio
 
   syncs = LCEC_HAL_ALLOCATE(lcec_syncs_t);
   lcec_syncs_init(slave, syncs);
+
+  if (options->pdo_autoflow) {
+    lcec_syncs_enable_autoflow(slave, syncs, options->pdo_limit, options->pdo_entry_limit, options->pdo_increment);
+  }
 
   // SM0 and SM1 aren't generally used.
   lcec_syncs_add_sync(syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -124,6 +124,9 @@ typedef struct {
   int channels;                ///< Number of channels;
   int rxpdolimit, txpdolimit;  ///< Maximum number of PDO entries allowed per PDO.
   int pdo_increment;
+  int pdo_autoflow;
+  int pdo_limit;
+  int pdo_entry_limit;
   lcec_class_cia402_channel_options_t *channel[CIA402_MAX_CHANNELS];  ///< Room for 8 channel options.
 } lcec_class_cia402_options_t;
 

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -333,9 +333,14 @@ typedef struct {
   ec_pdo_info_t *curr_pdo_info;                          ///< Current PDO info.
   ec_pdo_info_t pdo_infos[LCEC_MAX_PDO_INFO_COUNT + 1];  ///< PDO info definitions.
 
-  int pdo_entry_count;                                            ///< Number of PDO entries.
+  int pdo_entry_count;                                            ///< Total number of PDO entries for slave.
   ec_pdo_entry_info_t *curr_pdo_entry;                            ///< Current PDO entry.
   ec_pdo_entry_info_t pdo_entries[LCEC_MAX_PDO_ENTRY_COUNT + 1];  ///< PDO entry definitions.
+
+  int autoflow;         ///< If true, then adding new PDO entries will automatically start a new PDO at `pdo_entry_limit`
+  int pdo_entry_limit;  ///< Device limit on the number of PDO entries per PDO
+  int pdo_limit;        ///< Device limit on the number of PDOs per sync.
+  int pdo_increment;    ///< Number to increment PDO number when overflowing.
 } lcec_syncs_t;
 
 /// @brief Lookup table mapping string to int
@@ -378,6 +383,7 @@ int lcec_param_newf_list(void *base, const lcec_paramdesc_t *list, ...);
 
 void copy_fsoe_data(lcec_slave_t *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
 void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) __attribute__((nonnull));
+void lcec_syncs_enable_autoflow(lcec_slave_t *slave, lcec_syncs_t *syncs, int pdo_limit, int pdo_entry_limit, int pdo_increment);
 void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode);
 void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
 void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);

--- a/tests/scottlaird-lcectest1/cia402-all.xml
+++ b/tests/scottlaird-lcectest1/cia402-all.xml
@@ -140,6 +140,9 @@
     </slave>
     <slave idx="10" type="basic_cia402" vid="0x00000083" pid="0x00000053" name="omron-mx2">
       <!--3G3AX-MX2-ECT EtherCAT Communication Unit for 3G3MX2-->
+      <modParam name="pdoAutoflow" value="true"/>
+      <modParam name="pdoEntryLimit" value="2"/>
+      <modParam name="pdoIncrement" value="1"/>
       <modParam name="ciaRxPDOEntryLimit" value="8"/>
       <modParam name="ciaTxPDOEntryLimit" value="8"/>
       <modParam name="enablePP" value="false"/>
@@ -150,8 +153,8 @@
       <modParam name="enableErrorCode" value="true"/>
       <!-- <modParam name="enableTargetVL" value="true"/> -->
       <!-- <modParam name="enableVLDemand" value="true"/>-->
-      <modParam name="enableVLMaximum" value="true"/>
-      <modParam name="enableVLMinimum" value="true"/>
+      <!-- <modParam name="enableVLMaximum" value="true"/> -->
+      <!-- <modParam name="enableVLMinimum" value="true"/> -->
     </slave>
   </master>
 </masters>


### PR DESCRIPTION
This adds optional support for "autofill"ing PDO entries.  When it is enabled (via a call to `lcec_syncs_enable_autoflow()`), we will check to see if the current PDO is full and automatically create a new PDO as needed to permit mapping PDO entries.

This is needed for the Omron MX2, as it only allows 2 (!) PDO entries per PDO, but seems to support 512 (!) PDOs.  So we set it up with autofill on and tell it to cap PDOs at 2 entries, and it ends up creating a bunch of tiny little 2-entry PDOs.

Issues: #180 #414
