### PR TITLE
fix(deasda): Add a modparam to disable digital out

### DIFF
--- a/src/configgen/drivers/drivers.go
+++ b/src/configgen/drivers/drivers.go
@@ -256,6 +256,11 @@ var Drivers=[]EthercatDriver{
     ProductID: "0x10305070",
     Type: "DeASDA",
     ModParams: []string{
+      "<!-- Operation mode, CSV or CSP --> ",
+      "<modParam name=\"opmode\" value=\"CSP\"/> ",
+      "<!-- Enable digital output ports --> ",
+      "<modParam name=\"enableDigitalOutput\" value=\"true\"/> ",
+      "",
     },
   },
   EthercatDriver{
@@ -263,6 +268,11 @@ var Drivers=[]EthercatDriver{
     ProductID: "0x00006010",
     Type: "DeASDA3",
     ModParams: []string{
+      "<!-- Operation mode, CSV or CSP --> ",
+      "<modParam name=\"opmode\" value=\"CSP\"/> ",
+      "<!-- Enable digital output ports --> ",
+      "<modParam name=\"enableDigitalOutput\" value=\"true\"/> ",
+      "",
     },
   },
   EthercatDriver{
@@ -270,6 +280,9 @@ var Drivers=[]EthercatDriver{
     ProductID: "0x00006080",
     Type: "DeASDB3",
     ModParams: []string{
+      "<!-- Operation mode, CSV or CSP --> ",
+      "<modParam name=\"opmode\" value=\"CSP\"/> ",
+      "",
     },
   },
   EthercatDriver{


### PR DESCRIPTION
This adds `<modParam name="enableDigitalOut" value="false"/>` for Delta ASDA-series drives.  Some devices don't support digital outs and crash when they're accessed.


Issue #372 
