### PR TITLE
feat(main): Show stack backtrace on failure

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -97,12 +97,12 @@ install-realtime: realtime
 
 lcec.so: lcec_main.o $(lcec-common-objs) liblcecdevices.a
 	$(ECHO) Linking $@
-	$(Q)ld -d -r -o $*.tmp lcec_main.o $(lcec-common-objs)
-	$(Q)objcopy -j .rtapi_export -O binary $*.tmp $*.sym
-	$(Q)(echo '{ global : '; tr -s '\0' < $*.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > $*.ver
-	$(Q)$(CC) -shared -Bsymbolic $(RTLDFLAGS) -Wl,--version-script,$*.ver -o $@ lcec_main.o $(lcec-comon-objs) -lm
-	$(Q)$(CC) -shared -Bsymbolic $(RTLDFLAGS) -Wl,--version-script,$*.ver -o $@ lcec_main.o $(lcec-common-objs) -lm $(RTEXTRA_LDFLAGS)
-	$(Q)chmod -x $@
+	ld -d -r -o $@.tmp lcec_main.o $(lcec-common-objs)
+	objcopy -j .rtapi_export -O binary $@.tmp $@.sym
+	(echo '{ global : '; tr -s '\0' < $@.sym | xargs -r0 printf '%s;\n' | grep .; echo 'local : * ; };') > $@.ver
+#$(CC) -shared -Bsymbolic $(RTLDFLAGS) -Wl,--version-script,$@.ver -o $@ lcec_main.o $(lcec-comon-objs) -lm
+	$(CC) -shared -Bsymbolic $(RTLDFLAGS) -Wl,--version-script,$@.ver -o $@ lcec_main.o $(lcec-common-objs) -lm $(RTEXTRA_LDFLAGS)
+	chmod -x $@
 
 lcec_conf: $(lcec-conf-objs) $(lcec-common-objs) liblcecdevices.a
 	$(CC) -o $@ $(lcec-conf-objs) $(lcec-common-objs) -Wl,-rpath,$(LIBDIR) -L$(LIBDIR) -llinuxcnchal -lexpat -Wl,--whole-archive liblcecdevices.a -Wl,--no-whole-archive -lethercat -lm


### PR DESCRIPTION
This has been bugging me a while; if we crash (which can happen a lot during debugging), then we don't have any sort of stack backtrace or any easy way to know where things crashed.  Yeah, you can attach a debugger or add lots of print statements, but a simple stack backtrace is frequently good enough.  So here we go.

This dumps a stack backtrace using `glibc`'s built-in stack backtrace handler.  It's not perfect, in that it doesn't seem to find the symbols from `lcec.so`, but it's still helpful.  Here's a recent crash of mine:

```
-- STACK TRACE START
0       /usr/lib/linuxcnc/modules/lcec.so(+0xfc7c) [0x7f2612ae6c7c]
1       /lib/x86_64-linux-gnu/libc.so.6(+0x3c050) [0x7f2613541050]
2       /lib/x86_64-linux-gnu/libc.so.6(+0x15543f) [0x7f261365a43f]
3       /lib/x86_64-linux-gnu/libc.so.6(+0x5c4a0) [0x7f26135614a0]
4       /lib/x86_64-linux-gnu/libc.so.6(+0x7e758) [0x7f2613583758]
5       /usr/lib/linuxcnc/modules/lcec.so(+0x1221d) [0x7f2612ae921d]
6       /usr/lib/linuxcnc/modules/lcec.so(+0x12306) [0x7f2612ae9306]
7       /usr/lib/linuxcnc/modules/lcec.so(+0x12429) [0x7f2612ae9429]
8       /usr/lib/linuxcnc/modules/lcec.so(+0x234a0) [0x7f2612afa4a0]
9       /usr/lib/linuxcnc/modules/lcec.so(rtapi_app_main+0x348) [0x7f2612ae7e66]
10      /usr/bin/rtapi_app(+0x10cf7) [0x55bc72fd4cf7]
11      /usr/bin/rtapi_app(+0x1164e) [0x55bc72fd564e]
12      /usr/bin/rtapi_app(main+0x6d5) [0x55bc72fd0415]
13      /lib/x86_64-linux-gnu/libc.so.6(+0x2724a) [0x7f261352c24a]
14      /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7f261352c305]
15      /usr/bin/rtapi_app(_start+0x21) [0x55bc72fd0861]
-- STACK TRACE END
```
It's nice to know which module is crashing, but this is kind of sparse on names.  Fortunately, you can fairly easily turn things like `/usr/lib/linuxcnc/modules/lcec.so(+0x1221d)` into function names by looking them up using objdump.  Just run `objdump --syms /usr/lib/linuxcnc/modules/lcec.so | sort | less` and scan for the last entry before `0x1221d`.  That's this block here:

```
0000000000012198 l     F .text  000000000000005d              lcec_append_pdo_entry_reg
00000000000121f5 l     F .text  00000000000000cb              lcec_pin_newfv
00000000000122c0 l     F .text  000000000000005d              lcec_pin_newfv_list
000000000001231d l     F .text  0000000000000085              lcec_pin_newf
00000000000123a2 l     F .text  000000000000008f              lcec_pin_newf_list
0000000000012431 l     F .text  0000000000000032              lcec_lookupint
```

So, `0x1221d` is somewhere inside of `lcec_pin_newfv`.


This code is pretty obviously not going to run outside of user-mode LinuxCNC, but it should be `#ifdef`ed off.  It should be safe to delete entirely if it causes problems in some other, unknown environment.