### PR TITLE
chore: fix CI environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
     # Build LinuxCNC itself.  The result is cached, probably too aggressively.
     build-linuxcnc:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: cache linuxcnc
               id: cache-linuxcnc
@@ -77,7 +77,7 @@ jobs:
 
     # Build Ethercat Master, caching the result.
     build-ethercatmaster:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: cache Ethercat Master
               id: cache-ethercatmaster
@@ -109,7 +109,7 @@ jobs:
         needs:
             - build-linuxcnc
             - build-ethercatmaster
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Dump GitHub context
               env:


### PR DESCRIPTION
Upgrade CI jobs from Ubuntu 20.04 to 22.04; this seems to fix the GCC build problem that was breaking CI checks.