### PR TITLE
fix(Omron G5): Change type names

### DIFF
--- a/src/configgen/drivers/drivers.go
+++ b/src/configgen/drivers/drivers.go
@@ -2774,6 +2774,167 @@ var Drivers=[]EthercatDriver{
     },
   },
   EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000005",
+    Type: "R88D-KN01H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000002",
+    Type: "R88D-KN01L-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000006",
+    Type: "R88D-KN02H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000003",
+    Type: "R88D-KN02L-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000007",
+    Type: "R88D-KN04H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000004",
+    Type: "R88D-KN04L-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000b",
+    Type: "R88D-KN06F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000008",
+    Type: "R88D-KN08H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000c",
+    Type: "R88D-KN10F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000009",
+    Type: "R88D-KN10H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005f",
+    Type: "R88D-KN150F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005a",
+    Type: "R88D-KN150H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000d",
+    Type: "R88D-KN15F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000000a",
+    Type: "R88D-KN15H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005b",
+    Type: "R88D-KN20F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000056",
+    Type: "R88D-KN20H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005c",
+    Type: "R88D-KN30F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000057",
+    Type: "R88D-KN30H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005d",
+    Type: "R88D-KN50F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000058",
+    Type: "R88D-KN50H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x0000005e",
+    Type: "R88D-KN75F-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000059",
+    Type: "R88D-KN75H-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
+    VendorID: "0x00000083",
+    ProductID: "0x00000001",
+    Type: "R88D-KNA5L-ECT",
+    ModParams: []string{
+    },
+  },
+  EthercatDriver{
     VendorID: "0x000000b9",
     ProductID: "0x00001388",
     Type: "StMDS5k",

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -249,6 +249,13 @@ static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave) {
   hal_data = LCEC_HAL_ALLOCATE(lcec_omrg5_data_t);
   slave->hal_data = hal_data;
 
+  // check for deprecated type names
+  if(strstr(slave->type_name, "OmrG5_") != NULL) {
+    char new_type_name[16];
+    strncpy(new_type_name, slave->type_name+6, strlen(slave->type_name));
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "The used type name '%s' is deprectaed. Please change the type name to 'R88D-%s-ECT'\n", slave->type_name, new_type_name);
+  }
+
   // set to cyclic synchronous position mode
   if (lcec_write_sdo8(slave, 0x6060, 0x00, 8) != 0) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s sdo velo mode\n", master->name, slave->name);

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -254,7 +254,7 @@ static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave) {
     char new_type_name[16];
     strncpy(new_type_name, slave->type_name + 6, strlen(slave->type_name));
     rtapi_print_msg(RTAPI_MSG_ERR,
-        LCEC_MSG_PFX "The used type name '%s' is deprectaed. Please change the type name in your XML config to 'R88D-%s-ECT'\n",
+        LCEC_MSG_PFX "The used type name '%s' is deprecated. Please change the type name in your XML config to 'R88D-%s-ECT'\n",
         slave->type_name, new_type_name);
   }
 

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -26,7 +26,8 @@
 
 static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave);
 
-static lcec_typelist_t types[] = {
+// these types are soon to be deprecated because of their unintuitive naming
+static lcec_typelist_t old_types[] = {
     {"OmrG5_KNA5L", LCEC_OMRON_VID, 0x00000001, 0, NULL, lcec_omrg5_init},
     {"OmrG5_KN01L", LCEC_OMRON_VID, 0x00000002, 0, NULL, lcec_omrg5_init},
     {"OmrG5_KN02L", LCEC_OMRON_VID, 0x00000003, 0, NULL, lcec_omrg5_init},
@@ -52,8 +53,36 @@ static lcec_typelist_t types[] = {
     {"OmrG5_KN150F", LCEC_OMRON_VID, 0x0000005F, 0, NULL, lcec_omrg5_init},
     {NULL},
 };
+ADD_TYPES(old_types);
 
+static lcec_typelist_t types[] = {
+    {"R88D-KNA5L-ECT", LCEC_OMRON_VID, 0x00000001, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN01L-ECT", LCEC_OMRON_VID, 0x00000002, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN02L-ECT", LCEC_OMRON_VID, 0x00000003, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN04L-ECT", LCEC_OMRON_VID, 0x00000004, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN01H-ECT", LCEC_OMRON_VID, 0x00000005, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN02H-ECT", LCEC_OMRON_VID, 0x00000006, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN04H-ECT", LCEC_OMRON_VID, 0x00000007, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN08H-ECT", LCEC_OMRON_VID, 0x00000008, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN10H-ECT", LCEC_OMRON_VID, 0x00000009, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN15H-ECT", LCEC_OMRON_VID, 0x0000000A, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN20H-ECT", LCEC_OMRON_VID, 0x00000056, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN30H-ECT", LCEC_OMRON_VID, 0x00000057, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN50H-ECT", LCEC_OMRON_VID, 0x00000058, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN75H-ECT", LCEC_OMRON_VID, 0x00000059, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN150H-ECT", LCEC_OMRON_VID, 0x0000005A, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN06F-ECT", LCEC_OMRON_VID, 0x0000000B, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN10F-ECT", LCEC_OMRON_VID, 0x0000000C, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN15F-ECT", LCEC_OMRON_VID, 0x0000000D, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN20F-ECT", LCEC_OMRON_VID, 0x0000005B, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN30F-ECT", LCEC_OMRON_VID, 0x0000005C, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN50F-ECT", LCEC_OMRON_VID, 0x0000005D, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN75F-ECT", LCEC_OMRON_VID, 0x0000005E, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN150F-ECT", LCEC_OMRON_VID, 0x0000005F, 0, NULL, lcec_omrg5_init},
+    {NULL},
+};
 ADD_TYPES(types);
+
 typedef struct {
   hal_float_t *pos_cmd;
   hal_s32_t *pos_cmd_raw;

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -250,10 +250,12 @@ static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave) {
   slave->hal_data = hal_data;
 
   // check for deprecated type names
-  if(strstr(slave->type_name, "OmrG5_") != NULL) {
+  if (strstr(slave->type_name, "OmrG5_") != NULL) {
     char new_type_name[16];
-    strncpy(new_type_name, slave->type_name+6, strlen(slave->type_name));
-    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "The used type name '%s' is deprectaed. Please change the type name to 'R88D-%s-ECT'\n", slave->type_name, new_type_name);
+    strncpy(new_type_name, slave->type_name + 6, strlen(slave->type_name));
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "The used type name '%s' is deprectaed. Please change the type name in your XML config to 'R88D-%s-ECT'\n",
+        slave->type_name, new_type_name);
   }
 
   // set to cyclic synchronous position mode

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -26,6 +26,34 @@
 
 static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave);
 
+static lcec_typelist_t types[] = {
+    {"R88D-KNA5L-ECT", LCEC_OMRON_VID, 0x00000001, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN01L-ECT", LCEC_OMRON_VID, 0x00000002, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN02L-ECT", LCEC_OMRON_VID, 0x00000003, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN04L-ECT", LCEC_OMRON_VID, 0x00000004, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN01H-ECT", LCEC_OMRON_VID, 0x00000005, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN02H-ECT", LCEC_OMRON_VID, 0x00000006, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN04H-ECT", LCEC_OMRON_VID, 0x00000007, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN08H-ECT", LCEC_OMRON_VID, 0x00000008, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN10H-ECT", LCEC_OMRON_VID, 0x00000009, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN15H-ECT", LCEC_OMRON_VID, 0x0000000A, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN20H-ECT", LCEC_OMRON_VID, 0x00000056, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN30H-ECT", LCEC_OMRON_VID, 0x00000057, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN50H-ECT", LCEC_OMRON_VID, 0x00000058, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN75H-ECT", LCEC_OMRON_VID, 0x00000059, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN150H-ECT", LCEC_OMRON_VID, 0x0000005A, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN06F-ECT", LCEC_OMRON_VID, 0x0000000B, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN10F-ECT", LCEC_OMRON_VID, 0x0000000C, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN15F-ECT", LCEC_OMRON_VID, 0x0000000D, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN20F-ECT", LCEC_OMRON_VID, 0x0000005B, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN30F-ECT", LCEC_OMRON_VID, 0x0000005C, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN50F-ECT", LCEC_OMRON_VID, 0x0000005D, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN75F-ECT", LCEC_OMRON_VID, 0x0000005E, 0, NULL, lcec_omrg5_init},
+    {"R88D-KN150F-ECT", LCEC_OMRON_VID, 0x0000005F, 0, NULL, lcec_omrg5_init},
+    {NULL},
+};
+ADD_TYPES(types);
+
 // these types are soon to be deprecated because of their unintuitive naming
 static lcec_typelist_t old_types[] = {
     {"OmrG5_KNA5L", LCEC_OMRON_VID, 0x00000001, 0, NULL, lcec_omrg5_init},
@@ -54,34 +82,6 @@ static lcec_typelist_t old_types[] = {
     {NULL},
 };
 ADD_TYPES(old_types);
-
-static lcec_typelist_t types[] = {
-    {"R88D-KNA5L-ECT", LCEC_OMRON_VID, 0x00000001, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN01L-ECT", LCEC_OMRON_VID, 0x00000002, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN02L-ECT", LCEC_OMRON_VID, 0x00000003, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN04L-ECT", LCEC_OMRON_VID, 0x00000004, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN01H-ECT", LCEC_OMRON_VID, 0x00000005, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN02H-ECT", LCEC_OMRON_VID, 0x00000006, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN04H-ECT", LCEC_OMRON_VID, 0x00000007, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN08H-ECT", LCEC_OMRON_VID, 0x00000008, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN10H-ECT", LCEC_OMRON_VID, 0x00000009, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN15H-ECT", LCEC_OMRON_VID, 0x0000000A, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN20H-ECT", LCEC_OMRON_VID, 0x00000056, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN30H-ECT", LCEC_OMRON_VID, 0x00000057, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN50H-ECT", LCEC_OMRON_VID, 0x00000058, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN75H-ECT", LCEC_OMRON_VID, 0x00000059, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN150H-ECT", LCEC_OMRON_VID, 0x0000005A, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN06F-ECT", LCEC_OMRON_VID, 0x0000000B, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN10F-ECT", LCEC_OMRON_VID, 0x0000000C, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN15F-ECT", LCEC_OMRON_VID, 0x0000000D, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN20F-ECT", LCEC_OMRON_VID, 0x0000005B, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN30F-ECT", LCEC_OMRON_VID, 0x0000005C, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN50F-ECT", LCEC_OMRON_VID, 0x0000005D, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN75F-ECT", LCEC_OMRON_VID, 0x0000005E, 0, NULL, lcec_omrg5_init},
-    {"R88D-KN150F-ECT", LCEC_OMRON_VID, 0x0000005F, 0, NULL, lcec_omrg5_init},
-    {NULL},
-};
-ADD_TYPES(types);
 
 typedef struct {
   hal_float_t *pos_cmd;

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -277,6 +277,7 @@ typedef struct lcec_slave {
   lcec_master_t *master;                     ///< Master for this slave
   int index;                                 ///< Index of this slave.
   char name[LCEC_CONF_STR_MAXLEN];           ///< Slave name.
+  char type_name[LCEC_CONF_STR_MAXLEN];      ///< Slave type name.
   uint32_t vid;                              ///< Slave's vendor ID
   uint32_t pid;                              ///< Slave's EtherCAT PID/device ID.
   ec_sync_info_t *sync_info;                 ///< Sync Manager configuration.

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -510,6 +510,8 @@ int lcec_parse_config(void) {
         slave->index = slave_conf->index;
         strncpy(slave->name, slave_conf->name, LCEC_CONF_STR_MAXLEN);
         slave->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+        strncpy(slave->type_name, slave_conf->type_name, LCEC_CONF_STR_MAXLEN);
+        slave->type_name[LCEC_CONF_STR_MAXLEN - 1] = 0;
         slave->master = master;
 
         // add slave to list


### PR DESCRIPTION
This changes the very unintuitive type names for the real part names. 

For examle Omrg5_KN04H becomes R88D-KN04H-ECT.

Issue: #441