### PR TITLE
Synchronize DC and LinuxCNC servo-thread explicit option and documentation

### DIFF
--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -23,7 +23,7 @@ The basic structure of `ethercat.xml` looks like this:
 
 ```xml
 <masters>
-  <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000" syncServoThreadToRefClock="true">
+  <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000" syncToRefClock="true">
     <slave .../>
 	...
   </master>
@@ -59,7 +59,7 @@ and some of which are required:
 - `refClockSyncCycles="<time>"`: (required) how frequently LinuxCNC-Ethercat
   resyncs distributed clocks across EtherCAT slaves.  Negative values
   have something to do with distributed clocks.  TODO: explain.
-- `syncServoThreadToRefClock="true|false"`: (optional, defaults to `false`)
+- `syncToRefClock="true|false"`: (optional, defaults to `false`)
   Setting this to `true` will adjust the time of LinuxCNC's servo-thread
   to be synchronized with the DC reference clock. This is normally
   wanted when at least one slave uses DC synchronization.

--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -57,17 +57,19 @@ and some of which are required:
   does not match the servo thread time, then an error will be
   reported, eventually.
 - `refClockSyncCycles="<time>"`: (required) how frequently LinuxCNC-Ethercat
-  resyncs distributed clocks across EtherCAT slaves.  Negative values
-  have something to do with distributed clocks.  TODO: explain.
-- `syncToRefClock="true|false"`: (optional, defaults to `false`)
-  Setting this to `true` will adjust the time of LinuxCNC's servo-thread
-  to be synchronized with the DC reference clock. This is normally
-  wanted when at least one slave uses DC synchronization.
+  resyncs distributed clocks across EtherCAT slaves.  
+- `syncToRefClock="true|false"`: (optional) enables or disables synchronization
+  of LinuxCNC's servo thread to the DC reference clock. When set to "true", 
+  the two clocks are kept synchronized, "false" disables the feature. 
+  If the option is not specified, a negative `refClockSyncCycles` value 
+  enables this feature for backward compatibility.
+  Enabling this feature is normally desirable when at least one slave is using
+  DC synchronization.
 
 Generally, for "normal" systems, this will look like 
 
 ```xml
-  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000" syncToRefClock="true">
 ```
 
 ## Slave Configuration

--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -23,7 +23,7 @@ The basic structure of `ethercat.xml` looks like this:
 
 ```xml
 <masters>
-  <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000">
+  <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000" syncServoThreadToRefClock="true">
     <slave .../>
 	...
   </master>
@@ -59,12 +59,41 @@ and some of which are required:
 - `refClockSyncCycles="<time>"`: (required) how frequently LinuxCNC-Ethercat
   resyncs distributed clocks across EtherCAT slaves.  Negative values
   have something to do with distributed clocks.  TODO: explain.
+- `syncServoThreadToRefClock="true|false"`: (optional, defaults to `false`)
+  Setting this to `true` will adjust the time of LinuxCNC's servo-thread
+  to be synchronized with the DC reference clock. This is normally
+  wanted when at least one slave uses DC synchronization. More info below.
 
 Generally, for "normal" systems, this will look like 
 
 ```xml
   <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
 ```
+
+### `syncServoThreadToRefClock`
+
+This option enables or disables synchronisation of LinuxCNC'c servo thread
+to the DC reference clock. It's unavoidable that LinuxCNC's timer and
+the DC timer run at slightly different speeds. This is known to
+cause interference in sending PDO, manifesting itself in reoccuring noise
+from servo and stepper motors. Setting this option to "true" keeps
+the two clocks in sync.
+
+Synchronization is done with a bang-bang controller. Two hal parameters
+and three hal pins can be used to control the bang-bang controller.
+
+Hal parameters
+- `pll-step="<n>" RW`. The adjustment step in nanoseconds. Default 0.1% of appTimePeriod.
+- `pll-max-error="<n>" RW`. Max allowed time difference between the servo thread and
+  the reference clock in nanonseconds before a reset. Default one appTimePeriod.
+  
+Hal pins
+- `pll-err="<n>" OUT`. The current time difference between the servo thread
+  and the reference clock in nanoseconds.
+- `pll-out="<n>" OUT`. Current output correction, will always be +/-pll-step.
+- `pll-reset-count="<n>" OUT`. Number of times pll-err has been larger
+  than pll-max-error. 
+
 
 ## Slave Configuration
 

--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -62,38 +62,13 @@ and some of which are required:
 - `syncServoThreadToRefClock="true|false"`: (optional, defaults to `false`)
   Setting this to `true` will adjust the time of LinuxCNC's servo-thread
   to be synchronized with the DC reference clock. This is normally
-  wanted when at least one slave uses DC synchronization. More info below.
+  wanted when at least one slave uses DC synchronization.
 
 Generally, for "normal" systems, this will look like 
 
 ```xml
   <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
 ```
-
-### `syncServoThreadToRefClock`
-
-This option enables or disables synchronisation of LinuxCNC'c servo thread
-to the DC reference clock. It's unavoidable that LinuxCNC's timer and
-the DC timer run at slightly different speeds. This is known to
-cause interference in sending PDO, manifesting itself in reoccuring noise
-from servo and stepper motors. Setting this option to "true" keeps
-the two clocks in sync.
-
-Synchronization is done with a bang-bang controller. Two hal parameters
-and three hal pins can be used to control the bang-bang controller.
-
-Hal parameters
-- `pll-step="<n>" RW`. The adjustment step in nanoseconds. Default 0.1% of appTimePeriod.
-- `pll-max-error="<n>" RW`. Max allowed time difference between the servo thread and
-  the reference clock in nanonseconds before a reset. Default one appTimePeriod.
-  
-Hal pins
-- `pll-err="<n>" OUT`. The current time difference between the servo thread
-  and the reference clock in nanoseconds.
-- `pll-out="<n>" OUT`. Current output correction, will always be +/-pll-step.
-- `pll-reset-count="<n>" OUT`. Number of times pll-err has been larger
-  than pll-max-error. 
-
 
 ## Slave Configuration
 

--- a/documentation/distributed-clocks.md
+++ b/documentation/distributed-clocks.md
@@ -62,7 +62,7 @@ servo thread time to the distributed clock time.
 This option enables or disables synchronization of LinuxCNC's servo thread
 to the DC reference clock. If this option is set to "true", the two clocks
 are kept synchronized, "false" disables the feature. If the option is not
-specified, a negative `refClockSync` value enables this feature for
+specified, a negative `refClockSyncCycles` value enables this feature for
 backward compatibility.
 
 Synchronization is done with a bang-bang controller. Two hal parameters
@@ -71,7 +71,7 @@ and three hal pins are available.
 Hal parameters
 - `pll-step="<n>" RW`. The adjustment step in nanoseconds. Default 0.1% of appTimePeriod.
 - `pll-max-error="<n>" RW`. Max allowed time difference between the servo thread and
-  the reference clock in nanonseconds before a reset. Default one appTimePeriod.
+  the reference clock in nanoseconds before a reset. Default one appTimePeriod.
 
 Hal pins
 - `pll-err="<n>" OUT`. The current time difference between the servo thread

--- a/documentation/distributed-clocks.md
+++ b/documentation/distributed-clocks.md
@@ -36,11 +36,12 @@ in the future and expect all motors to start their next segment
 precisely on cue, all in sync with each other.
 
 To close the time chain, the LinuxCNC servo thread must be
-synchronized with the DC time. It is inevitable that the distributed clock
-and  the LinuxCNC real-time clock run at different speeds. It is the job
-of the EtherCAT master to slightly adjust the servo thread's timer.
+synchronized with the distributed clock time. It is inevitable
+that the distributed clock and the LinuxCNC real-time clock
+run at different speeds. The lcec module can adjust the
+servo thread's time to the distributed clock reference time.
 Unsynchronized distributed clock and servo thread clock are known to
-lead to unpleasant noise from the drives. Users report "gravel noises",
+lead to unpleasant noises from the drives. Users report "gravel noises",
 "friction noises", and rapid peaks in torque and acceleration.
 This only affects drives that use distributed clock synchronization.
 
@@ -60,7 +61,9 @@ servo thread time to the distributed clock time.
 
 This option enables or disables synchronization of LinuxCNC's servo thread
 to the DC reference clock. If this option is set to "true", the two clocks
-are kept synchronized. Default is "false".
+are kept synchronized, "false" disables the feature. If the option is not
+specified, a negative `refClockSync` value enables this feature for
+backward compatibility.
 
 Synchronization is done with a bang-bang controller. Two hal parameters
 and three hal pins are available.
@@ -78,7 +81,7 @@ Hal pins
   than pll-max-error.
 
 `pll-err` varies up and down. `pll-reset-count`should be kept low.
-If `pll-reset-count` continue to increase, the difference in speed between
+If `pll-reset-count` increases, the difference in speed between
 the clocks is large. Increasing `pll-step` might help. `pll-step` is limited
 to 1% of appTimePeriod.
 

--- a/documentation/distributed-clocks.md
+++ b/documentation/distributed-clocks.md
@@ -47,17 +47,17 @@ This only affects drives that use distributed clock synchronization.
 
 ## Master settings
 
-The `syncServoThreadToRefClock` option controls synchronization of LinuxCNC's
+The `syncToRefClock` option controls synchronization of LinuxCNC's
 servo thread time to the distributed clock time.
 
 ```xml
- <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000" syncServoThreadToRefClock="true">
+ <master idx="0" appTimePeriod="2000000" refClockSyncCycles="1000" syncToRefClock="true">
   ....
  </master>
 
 ```
 
-### `syncServoThreadToRefClock`
+### `syncToRefClock`
 
 This option enables or disables synchronization of LinuxCNC's servo thread
 to the DC reference clock. If this option is set to "true", the two clocks

--- a/examples/generic-complex/ethercat-conf.xml
+++ b/examples/generic-complex/ethercat-conf.xml
@@ -1,5 +1,5 @@
 <masters>
-  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="5">
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="5" syncServoThreadToRefClock="true">
     <slave idx="0" type="EK1100"/>
     <slave idx="1" type="EL1809"/>
     <slave idx="2" type="EL1809"/>

--- a/examples/generic-complex/ethercat-conf.xml
+++ b/examples/generic-complex/ethercat-conf.xml
@@ -1,5 +1,5 @@
 <masters>
-  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="5" syncServoThreadToRefClock="true">
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="5" syncToRefClock="true">
     <slave idx="0" type="EK1100"/>
     <slave idx="1" type="EL1809"/>
     <slave idx="2" type="EL1809"/>

--- a/examples/omrg5/omrg5.xml
+++ b/examples/omrg5/omrg5.xml
@@ -1,5 +1,5 @@
 <masters>
-	<master idx="0" appTimePeriod="1000000" refClockSyncCycles="1" syncServoThreadToRefClock="true">
+	<master idx="0" appTimePeriod="1000000" refClockSyncCycles="1" syncToRefClock="true">
 		<slave idx="0" type="R88D-KN04H-ECT">
 			<dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
 			<watchdog divider="2498" intervals="1000"/>

--- a/examples/omrg5/omrg5.xml
+++ b/examples/omrg5/omrg5.xml
@@ -1,5 +1,5 @@
 <masters>
-	<master idx="0" appTimePeriod="1000000" refClockSyncCycles="1">
+	<master idx="0" appTimePeriod="1000000" refClockSyncCycles="1" syncServoThreadToRefClock="true">
 		<slave idx="0" type="R88D-KN04H-ECT">
 			<dcConf assignActivate="300" sync0Cycle="*1" sync0Shift="0"/>
 			<watchdog divider="2498" intervals="1000"/>

--- a/examples/swm-fm45a/ethercat-conf.xml
+++ b/examples/swm-fm45a/ethercat-conf.xml
@@ -1,5 +1,5 @@
 <masters>
-  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000">
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000" syncServoThreadToRefClock="true">
     <slave idx="0" type="EK1100" name="D1"/>
     <slave idx="1" type="EL1008" name="D2"/>
     <slave idx="2" type="EL1008" name="D3"/>

--- a/examples/swm-fm45a/ethercat-conf.xml
+++ b/examples/swm-fm45a/ethercat-conf.xml
@@ -1,5 +1,5 @@
 <masters>
-  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000" syncServoThreadToRefClock="true">
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="1000" syncToRefClock="true">
     <slave idx="0" type="EK1100" name="D1"/>
     <slave idx="1" type="EL1008" name="D2"/>
     <slave idx="2" type="EL1008" name="D3"/>

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -216,7 +216,7 @@ typedef struct lcec_master {
   long period_last;
   int sync_ref_cnt;
   int sync_ref_cycles;
-  int sync_servothread_to_ref_clock;
+  int sync_to_ref_clock;
   long long state_update_timer;
   ec_master_state_t ms;
 #ifdef RTAPI_TASK_PLL_SUPPORT

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -216,6 +216,7 @@ typedef struct lcec_master {
   long period_last;
   int sync_ref_cnt;
   int sync_ref_cycles;
+  int sync_servothread_to_ref_clock;
   long long state_update_timer;
   ec_master_state_t ms;
 #ifdef RTAPI_TASK_PLL_SUPPORT

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -282,9 +282,9 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
       continue;
     }
 
-    // parse syncServoThreadToRefClock
-    if (strcmp(name, "syncServoThreadToRefClock") == 0) {
-      p->syncServoThreadToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1; // -1 = Need to know if option was given
+    // parse syncToRefClock
+    if (strcmp(name, "syncToRefClock") == 0) {
+      p->syncToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1; // -1 = Need to know if option was given
       continue; // TODO: A general function that can handle four states: yes, no, not given, wrong. Recognize yes/on/true/1/enabled as true
     }
  
@@ -295,12 +295,12 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
   }
 
   // Backwards compatibility with negative refClockSyncCycles meaning activate DC-servoThread sync
-  if (p->syncServoThreadToRefClock == 0) { // Option not given
-    p->syncServoThreadToRefClock = (p->refClockSyncCycles < 0) ? 1 : 0;
-  } else { // option syncServoThreadToRefClock takes precedent over sign of refClockSyncCycles
-    p->syncServoThreadToRefClock == (p->syncServoThreadToRefClock == -1) ? 0 : 1; // Restore normal true/false
+  if (p->syncToRefClock == 0) { // Option not given
+    p->syncToRefClock = (p->refClockSyncCycles < 0) ? 1 : 0;
+  } else { // option syncToRefClock takes precedent over sign of refClockSyncCycles
+    p->syncToRefClock == (p->syncToRefClock == -1) ? 0 : 1; // Restore normal true/false
     p->refClockSyncCycles = abs(p->refClockSyncCycles);
-    fprintf(stderr, "%s: INFO: %s servo-thread with DC reference clock\n", modname, p->syncServoThreadToRefClock ? "Synchronising" : "Not synchronising");
+    fprintf(stderr, "%s: INFO: %s servo-thread with DC reference clock\n", modname, p->syncToRefClock ? "Synchronising" : "Not synchronising");
   }
   
   // set default name

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -285,7 +285,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
     // parse syncServoThreadToRefClock
     if (strcmp(name, "syncServoThreadToRefClock") == 0) {
       p->syncServoThreadToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1; // -1 = Need to know if option was given
-      continue;
+      continue; // TODO: A general function that can handle four states: yes, no, not given, wrong. Recognize yes/on/true/1/enabled as true
     }
  
     // handle error

--- a/src/lcec_conf.h
+++ b/src/lcec_conf.h
@@ -73,6 +73,7 @@ typedef struct {
   int index;
   uint32_t appTimePeriod;
   int refClockSyncCycles;
+  int syncServoThreadToRefClock;
   char name[LCEC_CONF_STR_MAXLEN];
 } LCEC_CONF_MASTER_T;
 

--- a/src/lcec_conf.h
+++ b/src/lcec_conf.h
@@ -73,7 +73,7 @@ typedef struct {
   int index;
   uint32_t appTimePeriod;
   int refClockSyncCycles;
-  int syncServoThreadToRefClock;
+  int syncToRefClock;
   char name[LCEC_CONF_STR_MAXLEN];
 } LCEC_CONF_MASTER_T;
 

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -273,12 +273,12 @@ int rtapi_app_main(void) {
     ecrt_master_application_time(master->master, master->app_time_base);
 #ifdef RTAPI_TASK_PLL_SUPPORT
     master->dc_time_valid_last = 0;
-    if (!master->sync_servothread_to_ref_clock) {
+    if (!master->sync_to_ref_clock) {
       master->app_time_base -= rtapi_get_time();
     }
 #else
     master->app_time_base -= rtapi_get_time();
-    if (master->sync_servothread_to_ref_clock) {
+    if (master->sync_to_ref_clock) {
       rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "unable to sync master %s cycle to reference clock, RTAPI_TASK_PLL_SUPPORT not present\n",
           master->name);
     }
@@ -466,7 +466,7 @@ int lcec_parse_config(void) {
         master->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
         master->app_time_period = master_conf->appTimePeriod;
         master->sync_ref_cycles = master_conf->refClockSyncCycles;
-	master->sync_servothread_to_ref_clock = master_conf->syncServoThreadToRefClock;
+	master->sync_to_ref_clock = master_conf->syncToRefClock;
 	
         // add master to list
         LCEC_LIST_APPEND(first_master, last_master, master);
@@ -1150,7 +1150,7 @@ void lcec_write_master(void *arg, long period) {
   // update application time
   now = rtapi_get_time();
 #ifdef RTAPI_TASK_PLL_SUPPORT
-  if (!master->sync_servothread_to_ref_clock) {
+  if (!master->sync_to_ref_clock) {
     app_time = master->app_time_base + now;
   } else {
     master->dc_ref += period;
@@ -1163,7 +1163,7 @@ void lcec_write_master(void *arg, long period) {
   ecrt_master_application_time(master->master, app_time);
 
   // sync ref clock to master
-  if (!master->sync_servothread_to_ref_clock) {
+  if (!master->sync_to_ref_clock) {
     if (master->sync_ref_cnt == 0) {
       master->sync_ref_cnt = master->sync_ref_cycles;
       ecrt_master_sync_reference_clock(master->master);
@@ -1174,7 +1174,7 @@ void lcec_write_master(void *arg, long period) {
 #ifdef RTAPI_TASK_PLL_SUPPORT
   // sync master to ref clock
   dc_time = 0;
-  if (master->sync_servothread_to_ref_clock) {
+  if (master->sync_to_ref_clock) {
     // get reference clock time to synchronize master cycle
     dc_time_valid = (ecrt_master_reference_clock_time(master->master, &dc_time) == 0);
   } else {

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -273,12 +273,12 @@ int rtapi_app_main(void) {
     ecrt_master_application_time(master->master, master->app_time_base);
 #ifdef RTAPI_TASK_PLL_SUPPORT
     master->dc_time_valid_last = 0;
-    if (master->sync_ref_cycles >= 0) {
+    if (!master->sync_servothread_to_ref_clock) {
       master->app_time_base -= rtapi_get_time();
     }
 #else
     master->app_time_base -= rtapi_get_time();
-    if (master->sync_ref_cycles < 0) {
+    if (master->sync_servothread_to_ref_clock) {
       rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "unable to sync master %s cycle to reference clock, RTAPI_TASK_PLL_SUPPORT not present\n",
           master->name);
     }
@@ -466,7 +466,8 @@ int lcec_parse_config(void) {
         master->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
         master->app_time_period = master_conf->appTimePeriod;
         master->sync_ref_cycles = master_conf->refClockSyncCycles;
-
+	master->sync_servothread_to_ref_clock = master_conf->syncServoThreadToRefClock;
+	
         // add master to list
         LCEC_LIST_APPEND(first_master, last_master, master);
         break;
@@ -1149,7 +1150,7 @@ void lcec_write_master(void *arg, long period) {
   // update application time
   now = rtapi_get_time();
 #ifdef RTAPI_TASK_PLL_SUPPORT
-  if (master->sync_ref_cycles >= 0) {
+  if (!master->sync_servothread_to_ref_clock) {
     app_time = master->app_time_base + now;
   } else {
     master->dc_ref += period;
@@ -1162,7 +1163,7 @@ void lcec_write_master(void *arg, long period) {
   ecrt_master_application_time(master->master, app_time);
 
   // sync ref clock to master
-  if (master->sync_ref_cycles > 0) {
+  if (!master->sync_servothread_to_ref_clock) {
     if (master->sync_ref_cnt == 0) {
       master->sync_ref_cnt = master->sync_ref_cycles;
       ecrt_master_sync_reference_clock(master->master);
@@ -1173,7 +1174,7 @@ void lcec_write_master(void *arg, long period) {
 #ifdef RTAPI_TASK_PLL_SUPPORT
   // sync master to ref clock
   dc_time = 0;
-  if (master->sync_ref_cycles < 0) {
+  if (master->sync_servothread_to_ref_clock) {
     // get reference clock time to synchronize master cycle
     dc_time_valid = (ecrt_master_reference_clock_time(master->master, &dc_time) == 0);
   } else {


### PR DESCRIPTION
This PR adds an explicit master configuration option `syncServoPeriodToRefClock="true|false"`,
reference documentation for configuration and detailed description in distributed-clocks.md.
The option is also added to three of the examples.

The actual functionality to synchronize LinuxCNC's servo thread with DC is already in the code.
It is activated by using a negative value of the `refClockSyncCycles`. This wasn't described anywhere.
There are many users in the linuxcnc forum that encounter the consequences of this unsynchronization,
myself included. Gravel sound, friction sound, acceleration and torque peaks can be seen from 
drives synced by DC. This is caused by interference between the different speed clocks.

This option is so important it deserves an own option. 
Having it as part of the refClockSyncCycles, which is synchronization between slaves,
changes the meaning too much. It's synchronization yes, but between LinuxCNC and reference clock.

Feel free to fix my written language.
