### PR TITLE
feat(el2522): Add support for Beckhoff EL2522

### DIFF
--- a/documentation/devices/EL2522.yml
+++ b/documentation/devices/EL2522.yml
@@ -1,0 +1,11 @@
+---
+Device: EL2522
+VendorID: "0x00000002"
+VendorName: Beckhoff Automation GmbH & Co. KG
+PID: "0x09da3052"
+Description: Beckhoff EL2522 2Ch. Pulse Train Output
+DocumentationURL: http://www.beckhoff.com/EL2522
+DeviceType: Digital Output
+Notes: ""
+SrcFile: src/devices/lcec_el2522.c
+TestingStatus: ""

--- a/examples/el2522/Plasma.hal
+++ b/examples/el2522/Plasma.hal
@@ -1,0 +1,77 @@
+#========================================================
+# HAL File Ethercat EL2522 2 Axis Plasma Table
+# Nathan Hofmeyer 2026-05-22
+# Based on Marc Roth EL2521 example
+#========================================================
+
+#--------------------------------------------------------
+#  Load hal components
+#--------------------------------------------------------
+loadusr -W lcec_conf ethercat.xml
+loadrt lcec
+
+loadrt [KINS]KINEMATICS
+loadrt [EMCMOT]EMCMOT base_period_nsec=[EMCMOT]BASE_PERIOD servo_period_nsec=[EMCMOT]SERVO_PERIOD num_joints=[KINS]JOINTS num_spindles=[TRAJ]SPINDLES
+
+#--------------------------------------------------------
+#  Add functions to the servo thread
+#--------------------------------------------------------
+
+addf lcec.read-all            servo-thread
+addf motion-command-handler   servo-thread
+addf motion-controller        servo-thread
+addf lcec.write-all           servo-thread
+
+#========================================================
+#  GLOBAL I/O (E-STOP, machine enable, etc.)
+#========================================================
+setp iocontrol.0.emc-enable-in 1
+
+#========================================================
+#  X AXIS  (JOINT 0) EL2522 Channel 1
+#========================================================
+
+#  Scaling (steps / position unit)
+setp lcec.Master.XY-Axes.ch1.pos-scale  1000
+
+#--------------------------
+#  Position command / feedback wiring
+#--------------------------
+net x-pos-cmd      	<= joint.0.motor-pos-cmd     			
+net x-pos-cmd 		=> lcec.Master.XY-Axes.ch1.pos-cmd
+
+net x-pos-fb       	<= lcec.Master.XY-Axes.ch1.pos-fb     	
+net x-pos-fb 		=> joint.0.motor-pos-fb
+
+#--------------------------
+#  Enable chain
+#--------------------------
+net x-amp-enable   	<= joint.0.amp-enable-out    			 
+net x-amp-enable	=> lcec.Master.XY-Axes.ch1.enable
+
+#========================================================
+#  Y AXIS  (JOINT 1) EL2522 Channel 2
+#========================================================
+
+#  Scaling (steps / position unit)
+setp lcec.Master.XY-Axes.ch2.pos-scale  1000
+
+#--------------------------
+#  Position command / feedback wiring
+#--------------------------
+net y-pos-cmd      	<= joint.1.motor-pos-cmd     			
+net y-pos-cmd 		=> lcec.Master.XY-Axes.ch2.pos-cmd
+
+net y-pos-fb       	<= lcec.Master.XY-Axes.ch2.pos-fb     	
+net y-pos-fb 		=> joint.1.motor-pos-fb
+
+#--------------------------
+#  Enable chain
+#--------------------------
+net y-amp-enable   	<= joint.1.amp-enable-out    			 
+net y-amp-enable	=> lcec.Master.XY-Axes.ch2.enable
+
+
+
+
+

--- a/examples/el2522/Plasma.ini
+++ b/examples/el2522/Plasma.ini
@@ -1,0 +1,106 @@
+#========================================================
+# ini File Ethercat EL2522 2 Axis Plasma Table
+# Nathan Hofmeyer 2026-05-22
+# Based on Marc Roth EL2521 example
+#========================================================
+
+[EMC]
+MACHINE = Plasma
+DEBUG = 0
+VERSION = 1.1
+
+[DISPLAY]
+DISPLAY = axis
+POSITION_OFFSET = RELATIVE
+POSITION_FEEDBACK = ACTUAL
+ARCDIVISION = 64
+GRIDS = 10mm 20mm 50mm 100mm 1in 2in 5in 10in
+MAX_FEED_OVERRIDE = 1.2
+DEFAULT_LINEAR_VELOCITY = 2.50
+MIN_LINEAR_VELOCITY = 0
+MAX_LINEAR_VELOCITY = 25.00
+CYCLE_TIME = 0.100
+INTRO_GRAPHIC = linuxcnc.gif
+INTRO_TIME = 5
+PROGRAM_PREFIX = /home/cnc/linuxcnc/nc_files
+INCREMENTS = 10mm 1mm .1mm .01mm .001mm
+
+[KINS]
+JOINTS = 2
+KINEMATICS = trivkins coordinates=XY
+
+[FILTER]
+PROGRAM_EXTENSION = .ngc,.nc,.tap GCode File (*.ngc, *.nc, *.tap)
+
+[TASK]
+TASK = milltask
+CYCLE_TIME = 0.010
+
+[RS274NGC]
+PARAMETER_FILE = linuxcnc.var
+RS274NGC_STARTUP_CODE = G21 G40 G49 G80 G90 G92.1 G94 G97 M52P1
+SUBROUTINE_PATH = ./:../../nc_files
+USER_M_PATH = ./:../../nc_files
+
+
+[EMCMOT]
+EMCMOT = motmod
+COMM_TIMEOUT = 1.0
+BASE_PERIOD = 0
+SERVO_PERIOD = 1000000
+
+[HAL]
+HALUI = halui
+HALFILE = Plasma.hal
+
+[TRAJ]
+SPINDLES = 2
+COORDINATES =  XY
+LINEAR_UNITS = mm
+ANGULAR_UNITS = degree
+DEFAULT_LINEAR_VELOCITY = 2.50
+MAX_LINEAR_VELOCITY = 25.00
+
+
+[EMCIO]
+EMCIO = io
+CYCLE_TIME = 0.100
+TOOL_TABLE = tool.tbl
+
+#*** AXIS_X *******************************
+[AXIS_X]
+MAX_VELOCITY = 50.0
+MAX_ACCELERATION = 1500.0
+OFFSET_AV_RATIO = 0.5
+MIN_LIMIT = -0.001
+MAX_LIMIT = 900.0
+
+[JOINT_0]
+TYPE = LINEAR
+HOME = 0.0
+MIN_LIMIT = -0.001
+MAX_LIMIT = 900.0
+MAX_VELOCITY = 25.0
+MAX_ACCELERATION = 750.0
+FERROR = 2
+MIN_FERROR = 2
+HOME_OFFSET = 0.0
+
+#*** AXIS_Y *******************************
+[AXIS_Y]
+MAX_VELOCITY = 50.0
+MAX_ACCELERATION = 1500.0
+OFFSET_AV_RATIO = 0.5
+MIN_LIMIT = -0.001
+MAX_LIMIT = 900.0
+
+[JOINT_1]
+TYPE = LINEAR
+HOME = 0.0
+MIN_LIMIT = -0.001
+MAX_LIMIT = 900.0
+MAX_VELOCITY = 25.0
+MAX_ACCELERATION = 750.0
+FERROR = 2
+MIN_FERROR = 2
+HOME_OFFSET = 0.0

--- a/examples/el2522/README
+++ b/examples/el2522/README
@@ -1,1 +1,16 @@
 Example using EL2522 2-Channel output for a XY plasma table. Based on Marc Roth's EL2521 example.
+
+Note: The driver sets the EL2522 to Continuous Position mode (similar to CiA402 CSP),
+which is appropriate for connection to a external CNC controller (e.g. LinuxCNC).
+This mode expects the motion planning to be handled by the CNC controller,
+while the EL2522 is only responsible to execute the step pulses.
+
+A simplifed interface to the EL2522 is provided via HAL pins and parameters, as described below
+
+Pins:
+- "enable" pin maps onto EL2522 "Automatic Direction" bit. This must be asserted to enable step output
+- "pos_cmd" pin maps onto EL2522 "Target counter value," with scaling applied
+- "pos_fb" pin maps onto EL2522 "Counter value" value," with scaling applied
+- "count" pin provides the number of steps executed at run-time for monitoring and debugging purposes.
+Parameters:
+- "pos_scale" parameter provides scaling from HAL position units (e.g. mm) to EL2522 step counts.

--- a/examples/el2522/README
+++ b/examples/el2522/README
@@ -1,0 +1,1 @@
+Example using EL2522 2-Channel output for a XY plasma table. Based on Marc Roth's EL2521 example.

--- a/examples/el2522/ethercat.xml
+++ b/examples/el2522/ethercat.xml
@@ -1,0 +1,15 @@
+<masters>
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="-1" name="Master">
+    <slave idx="0" type="EK1100" name="Coupler"/>
+    <slave idx="1" type="EL2522" name="XY-Axes">
+      <!-- FrequencyModulation = CW/CCW pulses -->
+      <modParam name="ch1OutputMode" value="FrequencyModulation"/>
+      <!-- FrequencyLimit = maximum steps/s -->
+      <modParam name="ch1FrequencyLimit" value="2000000"/>
+      <modParam name="ch2OutputMode" value="FrequencyModulation"/>
+      <modParam name="ch2FrequencyLimit" value="2000000"/>
+      <!-- EL2522 requires assignActivate 7xx -->
+      <dcConf assignActivate="700" sync0Cycle="*1" sync0Shift="0"/>
+    </slave>
+  </master>
+</masters>

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -21,26 +21,31 @@
 ///        Supports continuous positioning mode (similar to CiA402 CSP mode)
 
 #include <ecrt.h>
+#include <math.h>
+#include <stdbool.h>
 
 #include "../lcec.h"
 #include "hal.h"
-#include "math.h"
 
 static int lcec_el2522_init(int comp_id, lcec_slave_t *slave);
 static void lcec_el2522_read(lcec_slave_t *slave, long period);
 static void lcec_el2522_write(lcec_slave_t *slave, long period);
 
-#define LCEC_EL2522_CHANNEL_COUNT      2
-#define LCEC_EL2522_POS_SCALE_DEFAULT  1.0
-#define LCEC_EL2522_MODPARAM_OUTMODE   0
-#define LCEC_EL2522_MODPARAM_FREQLIMIT 2
+#define LCEC_EL2522_CHANNEL_COUNT           2
+#define LCEC_EL2522_POS_SCALE_DEFAULT     1.0
+#define LCEC_EL2522_MODPARAM_OUTMODE_BASE   0
+#define LCEC_EL2522_MODPARAM_OUTMODE_CH1    0
+#define LCEC_EL2522_MODPARAM_OUTMODE_CH2    1
+#define LCEC_EL2522_MODPARAM_FREQLIMIT_BASE 2
+#define LCEC_EL2522_MODPARAM_FREQLIMIT_CH1  2
+#define LCEC_EL2522_MODPARAM_FREQLIMIT_CH2  3
 
 static const lcec_modparam_desc_t modparams_base[] = {
-  {"ch1OutputMode", LCEC_EL2522_MODPARAM_OUTMODE, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
-  {"ch1FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
-  {"ch2OutputMode", LCEC_EL2522_MODPARAM_OUTMODE + 1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
-  {"ch2FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT + 1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
-    {NULL},
+  {"ch1OutputMode", LCEC_EL2522_MODPARAM_OUTMODE_CH1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch1FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT_CH1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
+  {"ch2OutputMode", LCEC_EL2522_MODPARAM_OUTMODE_CH2 + 1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch2FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT_CH2 + 1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
+  {NULL},
 };
 
 static const lcec_lookuptable_int_t lcec_el2522_outmode_table[] = {
@@ -78,7 +83,6 @@ typedef struct {
   unsigned int enable_pdo_os;
   unsigned int enable_pdo_bp;
 
-  // Internal variables
   uint32_t last_count;
   double last_pos_scale;
   double pos_scale_recip;
@@ -87,6 +91,7 @@ typedef struct {
 
 typedef struct {
   lcec_el2522_channel_t channels[LCEC_EL2522_CHANNEL_COUNT];
+  bool last_operational;
 } lcec_el2522_data_t;
 
 static const lcec_pindesc_t slave_pins[] = {
@@ -190,9 +195,10 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
   lcec_master_t *master = slave->master;
   lcec_el2522_data_t *hal_data = LCEC_HAL_ALLOCATE(lcec_el2522_data_t);
   slave->hal_data = hal_data;
-
+  hal_data->last_operational = false;
+  
   for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
-    LCEC_CONF_MODPARAM_VAL_T *pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_OUTMODE + i);
+    LCEC_CONF_MODPARAM_VAL_T *pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_OUTMODE_BASE + i);
     if (pval != NULL) {
       int operating_mode = lcec_lookupint_i(lcec_el2522_outmode_table, pval->str, 0x00);
       if ((err = lcec_write_sdo8(slave, 0x8000 + (0x10 * i), 0x0E, operating_mode)) != 0) {
@@ -200,7 +206,7 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
       }
     }
 
-    pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_FREQLIMIT + i);
+    pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_FREQLIMIT_BASE + i);
     if (pval != NULL) {
       if ((err = lcec_write_sdo32(slave, 0x8000 + (i * 0x10), 0x12, pval->u32)) != 0) {
         return err;
@@ -243,6 +249,7 @@ static void lcec_el2522_read(lcec_slave_t *slave, long period) {
 
   // wait for slave to be operational
   if (!slave->state.operational) {
+    hal_data->last_operational = false;
     return;
   }
 
@@ -250,12 +257,18 @@ static void lcec_el2522_read(lcec_slave_t *slave, long period) {
     lcec_el2522_channel_t *channel = &hal_data->channels[i];
 
     const uint32_t raw_count = EC_READ_U32(&pd[channel->count_pdo_os]);
-    const int32_t diff = (int32_t)(raw_count - channel->last_count);
+    int32_t diff = (int32_t)(raw_count - channel->last_count);
     channel->last_count = raw_count;
+
+    // Avoid discontinuity on first read after safeop->op.
+    if (!hal_data->last_operational) {
+      diff = 0;
+    }
 
     *(channel->count) += diff;
     *(channel->pos_fb) += ((double)diff) * channel->pos_scale_recip;
   }
+  hal_data->last_operational = true;
 }
 
 static void lcec_el2522_write(lcec_slave_t *slave, long period) {
@@ -266,8 +279,7 @@ static void lcec_el2522_write(lcec_slave_t *slave, long period) {
   for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
     lcec_el2522_channel_t *channel = &hal_data->channels[i];
 
-    // check for change in scale value, and relcalculate step offset
-    // to avoid position discontinuities.
+    // Check for scale change, and adjust offset to avoid position discontinuity
     if (channel->pos_scale != channel->last_pos_scale) {
       if ((channel->pos_scale < 1e-20) && (channel->pos_scale > -1e-20)) {
         rtapi_print_msg(

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -1,0 +1,288 @@
+//
+//    Copyright (C) 2026 Nathan Hofmeyer
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+/// @file  lcec_el2522.c
+/// @brief Driver for Beckhoff EL2522 2-channel pulse train output module
+///        Supports continuous positioning mode (similar to CiA402 CSP mode)
+
+#include <ecrt.h>
+
+#include "../lcec.h"
+#include "hal.h"
+#include "math.h"
+
+static int lcec_el2522_init(int comp_id, lcec_slave_t *slave);
+static void lcec_el2522_read(lcec_slave_t *slave, long period);
+static void lcec_el2522_write(lcec_slave_t *slave, long period);
+
+#define LCEC_EL2522_CHANNEL_COUNT      2
+#define LCEC_EL2522_POS_SCALE_DEFAULT  1.0
+#define LCEC_EL2522_MODPARAM_OUTMODE   0
+#define LCEC_EL2522_MODPARAM_FREQLIMIT 2
+
+static const lcec_modparam_desc_t modparams_base[] = {
+  {"ch1OutputMode", LCEC_EL2522_MODPARAM_OUTMODE, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch1FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
+  {"ch2OutputMode", LCEC_EL2522_MODPARAM_OUTMODE + 1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch2FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT + 1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
+    {NULL},
+};
+
+static const lcec_lookuptable_int_t lcec_el2522_outmode_table[] = {
+    {"FrequencyModulation", 0x00},
+    {"PulseDirection", 0x01},
+    {"IncrementalEncoder", 0x02},
+    {NULL, 0},
+};
+
+static lcec_typelist_t lcec_el2522_types[] = {
+    {.name = "EL2522",
+        .vid = LCEC_BECKHOFF_VID,
+        .pid = 0x09da3052,
+        .is_fsoe_logic = 0,
+        .proc_preinit = NULL,
+        .proc_init = lcec_el2522_init,
+        .modparams = modparams_base},
+    {NULL},
+};
+ADD_TYPES(lcec_el2522_types);
+
+typedef struct {
+  // HAL pins
+  hal_float_t *pos_fb;   // pin: position feedback (position units)
+  hal_float_t *pos_cmd;  // pin: position command (position units)
+  hal_bit_t *enable;     // pin: enable command
+  hal_s32_t *count;      // pin: raw count output (steps), useful for commissioning
+
+  // HAL parameters
+  hal_float_t pos_scale;  // param: pos scaling factor (steps/unit)
+
+  // PDO offsets and bit positions
+  unsigned int target_pdo_os;
+  unsigned int count_pdo_os;
+  unsigned int enable_pdo_os;
+  unsigned int enable_pdo_bp;
+
+  // Internal variables
+  uint32_t last_count;
+  double last_pos_scale;
+  double pos_scale_recip;
+  double step_offset;
+} lcec_el2522_channel_t;
+
+typedef struct {
+  lcec_el2522_channel_t channels[LCEC_EL2522_CHANNEL_COUNT];
+} lcec_el2522_data_t;
+
+static const lcec_pindesc_t slave_pins[] = {
+    {HAL_FLOAT, HAL_IN, offsetof(lcec_el2522_channel_t, pos_cmd), "%s.%s.%s.ch%d.pos-cmd"},
+    {HAL_FLOAT, HAL_OUT, offsetof(lcec_el2522_channel_t, pos_fb), "%s.%s.%s.ch%d.pos-fb"},
+    {HAL_S32, HAL_OUT, offsetof(lcec_el2522_channel_t, count), "%s.%s.%s.ch%d.count"},
+    {HAL_BIT, HAL_IN, offsetof(lcec_el2522_channel_t, enable), "%s.%s.%s.ch%d.enable"},
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
+
+static const lcec_paramdesc_t slave_params[] = {
+    {HAL_FLOAT, HAL_RW, offsetof(lcec_el2522_channel_t, pos_scale), "%s.%s.%s.ch%d.pos-scale"},
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
+
+static ec_pdo_entry_info_t el2522_1601_pdo_entries[] = {
+    {0x0000, 0x00, 3},
+    {0x7000, 0x04, 1},  // Automatic direction, used as 'enable'
+    {0x7000, 0x05, 1},  // Forward
+    {0x7000, 0x06, 1},  // Reverse
+    {0x0000, 0x00, 10},
+    {0x7000, 0x12, 32}, // Target counter value
+};
+
+static ec_pdo_entry_info_t el2522_1606_pdo_entries[] = {
+    {0x0000, 0x00, 3},
+    {0x7010, 0x04, 1},  // Automatic direction, used as 'enable'
+    {0x7010, 0x05, 1},  // Forward
+    {0x7010, 0x06, 1},  // Reverse
+    {0x0000, 0x00, 10},
+    {0x7010, 0x12, 32}, // Target counter value
+};
+
+static ec_pdo_entry_info_t el2522_160B_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x7020, 0x03, 1},  // Set Counter
+    {0x0000, 0x00, 12},
+    {0x7020, 0x10, 1},  // Reserved
+    {0x7020, 0x11, 32}, // Set counter Value
+};
+
+static ec_pdo_entry_info_t el2522_160D_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x7030, 0x03, 1},  // Set Counter
+    {0x0000, 0x00, 12},
+    {0x7030, 0x10, 1},  // Reserved
+    {0x7030, 0x11, 32}, // Set Counter Value
+};
+
+static ec_pdo_entry_info_t el2522_1A03_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x6020, 0x03, 1},  // Set counter done
+    {0x6020, 0x04, 1},  // Counter underflow
+    {0x6020, 0x05, 1},  // Counter overflow
+    {0x0000, 0x00, 8},
+    {0x6020, 0x0E, 1},  // Sync error
+    {0x6020, 0x0F, 1},  // TxPDO State
+    {0x6020, 0x10, 1},  // TxPDO Toggle
+    {0x6020, 0x11, 32}, // Counter value
+};
+
+static ec_pdo_entry_info_t el2522_1A05_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x6030, 0x03, 1},  // Set counter done
+    {0x6030, 0x04, 1},  // Counter underflow
+    {0x6030, 0x05, 1},  // Counter overflow
+    {0x0000, 0x00, 8},
+    {0x6030, 0x0E, 1},  // Sync error
+    {0x6030, 0x0F, 1},  // TxPDO State
+    {0x6030, 0x10, 1},  // TxPDO Toggle
+    {0x6030, 0x11, 32}, // Counter value
+};
+
+static ec_pdo_info_t lcec_el2522_pdos_out[] = {
+    {0x1601, 6, el2522_1601_pdo_entries}, // Control Position Ch.1
+    {0x1606, 6, el2522_1606_pdo_entries}, // Control Position Ch.2
+    {0x160B, 5, el2522_160B_pdo_entries}, // Control Ch.1 (Set Counter)
+    {0x160D, 5, el2522_160D_pdo_entries}, // Control Ch.2 (Set Counter)
+};
+
+static ec_pdo_info_t lcec_el2522_pdos_in[] = {
+    {0x1A03, 9, el2522_1A03_pdo_entries}, // Status Ch.1 (Counter value + flags)
+    {0x1A05, 9, el2522_1A05_pdo_entries}, // Status Ch.2 (Counter value + flags)
+};
+
+static ec_sync_info_t lcec_el2522_syncs[] = {
+    {0, EC_DIR_OUTPUT, 0, NULL},
+    {1, EC_DIR_INPUT, 0, NULL},
+    {2, EC_DIR_OUTPUT, 4, lcec_el2522_pdos_out},
+    {3, EC_DIR_INPUT, 2, lcec_el2522_pdos_in},
+    {0xff},
+};
+
+static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
+  int err = 0;
+
+  slave->proc_read = lcec_el2522_read;
+  slave->proc_write = lcec_el2522_write;
+  slave->sync_info = lcec_el2522_syncs;
+
+  lcec_master_t *master = slave->master;
+  lcec_el2522_data_t *hal_data = LCEC_HAL_ALLOCATE(lcec_el2522_data_t);
+  slave->hal_data = hal_data;
+
+  for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
+    LCEC_CONF_MODPARAM_VAL_T *pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_OUTMODE + i);
+    if (pval != NULL) {
+      int operating_mode = lcec_lookupint_i(lcec_el2522_outmode_table, pval->str, 0x00);
+      if ((err = lcec_write_sdo8(slave, 0x8000 + (0x10 * i), 0x0E, operating_mode)) != 0) {
+        return err;
+      }
+    }
+
+    pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_FREQLIMIT + i);
+    if (pval != NULL) {
+      if ((err = lcec_write_sdo32(slave, 0x8000 + (i * 0x10), 0x12, pval->u32)) != 0) {
+        return err;
+      }
+    }
+
+    lcec_el2522_channel_t *channel = &hal_data->channels[i];
+    if ((err = lcec_pdo_init(slave, 0x6020 + (i * 0x10), 0x11, &channel->count_pdo_os, NULL)) != 0) {
+      return err;
+    }
+    if ((err = lcec_pdo_init(slave, 0x7000 + (i * 0x10), 0x04, &channel->enable_pdo_os, &channel->enable_pdo_bp)) != 0) {
+      return err;
+    }
+    if ((err = lcec_pdo_init(slave, 0x7000 + (i * 0x10), 0x12, &channel->target_pdo_os, NULL)) != 0) {
+      return err;
+    }
+
+    // register pins and params
+    if ((err = lcec_pin_newf_list(channel, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i + 1)) != 0) {
+      return err;
+    }
+    if ((err = lcec_param_newf_list(channel, slave_params, LCEC_MODULE_NAME, master->name, slave->name, i + 1)) != 0) {
+      return err;
+    }
+
+    channel->pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+    channel->pos_scale_recip = 1.0 / LCEC_EL2522_POS_SCALE_DEFAULT;
+    channel->last_pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+    channel->last_count = 0;
+    channel->step_offset = 0.0;
+  }
+
+  return err;
+}
+
+static void lcec_el2522_read(lcec_slave_t *slave, long period) {
+  lcec_master_t *master = slave->master;
+  lcec_el2522_data_t *hal_data = (lcec_el2522_data_t *)slave->hal_data;
+  uint8_t *pd = master->process_data;
+
+  // wait for slave to be operational
+  if (!slave->state.operational) {
+    return;
+  }
+
+  for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
+    lcec_el2522_channel_t *channel = &hal_data->channels[i];
+
+    const uint32_t raw_count = EC_READ_U32(&pd[channel->count_pdo_os]);
+    const int32_t diff = (int32_t)(raw_count - channel->last_count);
+    channel->last_count = raw_count;
+
+    *(channel->count) += diff;
+    *(channel->pos_fb) += ((double)diff) * channel->pos_scale_recip;
+  }
+}
+
+static void lcec_el2522_write(lcec_slave_t *slave, long period) {
+  lcec_master_t *master = slave->master;
+  lcec_el2522_data_t *hal_data = (lcec_el2522_data_t *)slave->hal_data;
+  uint8_t *pd = master->process_data;
+
+  for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
+    lcec_el2522_channel_t *channel = &hal_data->channels[i];
+
+    // check for change in scale value, and relcalculate step offset
+    // to avoid position discontinuities.
+    if (channel->pos_scale != channel->last_pos_scale) {
+      if ((channel->pos_scale < 1e-20) && (channel->pos_scale > -1e-20)) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, "Requested pos-scale for %s.%s.ch%i is too small, dropping\n", slave->master->name, slave->name, i+1);
+        channel->pos_scale = channel->last_pos_scale;
+      } else {
+        channel->last_pos_scale = channel->pos_scale;
+        channel->step_offset = *(channel->count) - *(channel->pos_fb) * channel->pos_scale;
+        channel->pos_scale_recip = 1.0 / channel->pos_scale;
+      }
+    }
+
+    // explicit conversion casts used here to ensure correct handling for negative double values
+    const uint32_t target = (uint32_t)((int32_t)round(*(channel->pos_cmd) * channel->pos_scale + channel->step_offset));
+    EC_WRITE_U32(&pd[channel->target_pdo_os], target);
+    EC_WRITE_BIT(&pd[channel->enable_pdo_os], channel->enable_pdo_bp, *(channel->enable));
+  }
+}

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -43,8 +43,8 @@ static void lcec_el2522_write(lcec_slave_t *slave, long period);
 static const lcec_modparam_desc_t modparams_base[] = {
   {"ch1OutputMode", LCEC_EL2522_MODPARAM_OUTMODE_CH1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
   {"ch1FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT_CH1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
-  {"ch2OutputMode", LCEC_EL2522_MODPARAM_OUTMODE_CH2 + 1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
-  {"ch2FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT_CH2 + 1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
+  {"ch2OutputMode", LCEC_EL2522_MODPARAM_OUTMODE_CH2, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch2FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT_CH2, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
   {NULL},
 };
 

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -18,6 +18,7 @@
 
 /// @file  lcec_el2522.c
 /// @brief Driver for Beckhoff EL2522 2-channel pulse train output module
+///        Supports continuous positioning mode (similar to CiA402 CSP mode)
 
 #include <ecrt.h>
 
@@ -25,34 +26,20 @@
 #include "hal.h"
 #include "math.h"
 
-// ****************************************************************************
-// Known limitations:
-// - Step count positions are limited to int32_t min/max values as the el2522 internal counter
-//   is 32 bits wide and is currently used directly as the position feedback (after scaling).
-//   This is sufficient for most linear axes, (at 1um/step, max travel would be +/- 2.1km),
-//   but it could be limiting for continuous rotary axes or axes with extremely
-//   high step resolutions.
-//   If this is a problem, possible to change impl to use a 64-bit internal counter
-//   and only use the el2522 counter feedback as an incremental update.
-// ****************************************************************************
-
 static int lcec_el2522_init(int comp_id, lcec_slave_t *slave);
 static void lcec_el2522_read(lcec_slave_t *slave, long period);
 static void lcec_el2522_write(lcec_slave_t *slave, long period);
 
-#define LCEC_EL2522_CHANNEL_COUNT     2
-#define LCEC_EL2522_POS_SCALE_DEFAULT 1.0
-#define LCEC_EL2522_MODPARAM_OUTMODE  0
-#define LCEC_EL2522_MODPARAM_FREQLIMIT   2
-
-#define LCEC_EL2522_MODPARAM_CH(ch)                                                                       \
-  {"ch" #ch "OutputMode", LCEC_EL2522_MODPARAM_OUTMODE + ch, MODPARAM_TYPE_STRING, "FrequencyModulation", \
-      "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},                              \
-      {"ch" #ch "FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT + ch, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"}
+#define LCEC_EL2522_CHANNEL_COUNT      2
+#define LCEC_EL2522_POS_SCALE_DEFAULT  1.0
+#define LCEC_EL2522_MODPARAM_OUTMODE   0
+#define LCEC_EL2522_MODPARAM_FREQLIMIT 2
 
 static const lcec_modparam_desc_t modparams_base[] = {
-    LCEC_EL2522_MODPARAM_CH(0),
-    LCEC_EL2522_MODPARAM_CH(1),
+  {"ch1OutputMode", LCEC_EL2522_MODPARAM_OUTMODE, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch1FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
+  {"ch2OutputMode", LCEC_EL2522_MODPARAM_OUTMODE + 1, MODPARAM_TYPE_STRING, "FrequencyModulation", "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},
+  {"ch2FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT + 1, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"},
     {NULL},
 };
 
@@ -70,9 +57,7 @@ static lcec_typelist_t lcec_el2522_types[] = {
         .is_fsoe_logic = 0,
         .proc_preinit = NULL,
         .proc_init = lcec_el2522_init,
-        .modparams = modparams_base,
-        .flags = 0,
-        .sourcefile = NULL},
+        .modparams = modparams_base},
     {NULL},
 };
 ADD_TYPES(lcec_el2522_types);
@@ -105,16 +90,93 @@ typedef struct {
 } lcec_el2522_data_t;
 
 static const lcec_pindesc_t slave_pins[] = {
-    {HAL_FLOAT, HAL_IN, offsetof(lcec_el2522_channel_t, pos_cmd), "%s.%s.%s.pos-%d-cmd"},
-    {HAL_FLOAT, HAL_OUT, offsetof(lcec_el2522_channel_t, pos_fb), "%s.%s.%s.pos-%d-fb"},
-    {HAL_S32, HAL_OUT, offsetof(lcec_el2522_channel_t, count), "%s.%s.%s.count-%d"},
-    {HAL_BIT, HAL_IN, offsetof(lcec_el2522_channel_t, enable), "%s.%s.%s.enable-%d"},
+    {HAL_FLOAT, HAL_IN, offsetof(lcec_el2522_channel_t, pos_cmd), "%s.%s.%s.ch%d.pos-cmd"},
+    {HAL_FLOAT, HAL_OUT, offsetof(lcec_el2522_channel_t, pos_fb), "%s.%s.%s.ch%d.pos-fb"},
+    {HAL_S32, HAL_OUT, offsetof(lcec_el2522_channel_t, count), "%s.%s.%s.ch%d.count"},
+    {HAL_BIT, HAL_IN, offsetof(lcec_el2522_channel_t, enable), "%s.%s.%s.ch%d.enable"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
 static const lcec_paramdesc_t slave_params[] = {
-    {HAL_FLOAT, HAL_RW, offsetof(lcec_el2522_channel_t, pos_scale), "%s.%s.%s.pos-%d-scale"},
+    {HAL_FLOAT, HAL_RW, offsetof(lcec_el2522_channel_t, pos_scale), "%s.%s.%s.ch%d.pos-scale"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
+
+static ec_pdo_entry_info_t el2522_1601_pdo_entries[] = {
+    {0x0000, 0x00, 3},
+    {0x7000, 0x04, 1},  // Automatic direction, used as 'enable'
+    {0x7000, 0x05, 1},  // Forward
+    {0x7000, 0x06, 1},  // Reverse
+    {0x0000, 0x00, 10},
+    {0x7000, 0x12, 32}, // Target counter value
+};
+
+static ec_pdo_entry_info_t el2522_1606_pdo_entries[] = {
+    {0x0000, 0x00, 3},
+    {0x7010, 0x04, 1},  // Automatic direction, used as 'enable'
+    {0x7010, 0x05, 1},  // Forward
+    {0x7010, 0x06, 1},  // Reverse
+    {0x0000, 0x00, 10},
+    {0x7010, 0x12, 32}, // Target counter value
+};
+static ec_pdo_entry_info_t el2522_160B_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x7020, 0x03, 1},  // Set Counter
+    {0x0000, 0x00, 12},
+    {0x7020, 0x10, 1},  // Reserved
+    {0x7020, 0x11, 32}, // Set counter Value
+};
+
+static ec_pdo_entry_info_t el2522_160D_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x7030, 0x03, 1},  // Set Counter
+    {0x0000, 0x00, 12},
+    {0x7030, 0x10, 1},  // Reserved
+    {0x7030, 0x11, 32}, // Set Counter Value
+};
+
+static ec_pdo_entry_info_t el2522_1A03_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x6020, 0x03, 1},  // Set counter done
+    {0x6020, 0x04, 1},  // Counter underflow
+    {0x6020, 0x05, 1},  // Counter overflow
+    {0x0000, 0x00, 8},
+    {0x6020, 0x0E, 1},  // Sync error
+    {0x6020, 0x0F, 1},  // TxPDO State
+    {0x6020, 0x10, 1},  // TxPDO Toggle
+    {0x6020, 0x11, 32}, // Counter value
+};
+
+static ec_pdo_entry_info_t el2522_1A05_pdo_entries[] = {
+    {0x0000, 0x00, 2},
+    {0x6030, 0x03, 1},  // Set counter done
+    {0x6030, 0x04, 1},  // Counter underflow
+    {0x6030, 0x05, 1},  // Counter overflow
+    {0x0000, 0x00, 8},
+    {0x6030, 0x0E, 1},  // Sync error
+    {0x6030, 0x0F, 1},  // TxPDO State
+    {0x6030, 0x10, 1},  // TxPDO Toggle
+    {0x6030, 0x11, 32}, // Counter value
+};
+
+static ec_pdo_info_t lcec_el2522_pdos_out[] = {
+    {0x1601, 6, el2522_1601_pdo_entries}, // Control Position Ch.1
+    {0x1606, 6, el2522_1606_pdo_entries}, // Control Position Ch.2
+    {0x160B, 5, el2522_160B_pdo_entries}, // Control Ch.1 (Set Counter)
+    {0x160D, 5, el2522_160D_pdo_entries}, // Control Ch.2 (Set Counter)
+};
+
+static ec_pdo_info_t lcec_el2522_pdos_in[] = {
+    {0x1A03, 9, el2522_1A03_pdo_entries}, // Status Ch.1 (Counter value + flags)
+    {0x1A05, 9, el2522_1A05_pdo_entries}, // Status Ch.2 (Counter value + flags)
+};
+
+static ec_sync_info_t lcec_el2522_syncs[] = {
+    {0, EC_DIR_OUTPUT, 0, NULL},
+    {1, EC_DIR_INPUT, 0, NULL},
+    {2, EC_DIR_OUTPUT, 4, lcec_el2522_pdos_out},
+    {3, EC_DIR_INPUT, 2, lcec_el2522_pdos_in},
+    {0xff},
 };
 
 static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
@@ -122,46 +184,12 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
 
   slave->proc_read = lcec_el2522_read;
   slave->proc_write = lcec_el2522_write;
+  slave->sync_info = lcec_el2522_syncs;
 
   lcec_master_t *master = slave->master;
   lcec_el2522_data_t *hal_data = LCEC_HAL_ALLOCATE(lcec_el2522_data_t);
   slave->hal_data = hal_data;
 
-  // RxPDO assignment
-  if ((err = lcec_write_sdo8(slave, 0x1C12, 0x00, 0x00)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x01, 0x1601)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x02, 0x1606)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x03, 0x160B)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x04, 0x160D)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo8(slave, 0x1C12, 0x00, 0x04)) != 0) {
-    return err;
-  }
-
-  // TxPDO Assign
-  if ((err = lcec_write_sdo8(slave, 0x1C13, 0x00, 0x00)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo16(slave, 0x1C13, 0x01, 0x1A03)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo16(slave, 0x1C13, 0x02, 0x1A05)) != 0) {
-    return err;
-  }
-  if ((err = lcec_write_sdo8(slave, 0x1C13, 0x00, 0x02)) != 0) {
-    return err;
-  }
-
-  // Channel PDO, modparams and defaults
   for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
     LCEC_CONF_MODPARAM_VAL_T *pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_OUTMODE + i);
     if (pval != NULL) {
@@ -173,7 +201,7 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
 
     pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_FREQLIMIT + i);
     if (pval != NULL) {
-      if ((err = lcec_write_sdo32(slave, 0x8000 + (0x10 * i), 0x12, pval->u32)) != 0) {
+      if ((err = lcec_write_sdo32(slave, 0x8000 + (i * 0x10), 0x12, pval->u32)) != 0) {
         return err;
       }
     }
@@ -190,10 +218,10 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // register pins and params
-    if ((err = lcec_pin_newf_list(channel, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {
+    if ((err = lcec_pin_newf_list(channel, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i+1)) != 0) {
       return err;
     }
-    if ((err = lcec_param_newf_list(channel, slave_params, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {
+    if ((err = lcec_param_newf_list(channel, slave_params, LCEC_MODULE_NAME, master->name, slave->name, i+1)) != 0) {
       return err;
     }
 
@@ -242,12 +270,12 @@ static void lcec_el2522_write(lcec_slave_t *slave, long period) {
     if (channel->pos_scale != channel->last_pos_scale) {
       if ((channel->pos_scale < 1e-20) && (channel->pos_scale > -1e-20)) {
         rtapi_print_msg(
-            RTAPI_MSG_ERR, "pos-scale for slave %s.%s.%i is too small, resetting to default\n", slave->master->name, slave->name, i);
-        channel->pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+            RTAPI_MSG_ERR, "Requested pos-scale for %s.%s.ch%i is too small, dropping\n", slave->master->name, slave->name, i+1);
+      } else {
+        channel->last_pos_scale = channel->pos_scale;
+        channel->step_offset = *(channel->count) - *(channel->pos_fb) * channel->pos_scale;
+        channel->pos_scale_recip = 1.0 / channel->pos_scale;
       }
-      channel->step_offset = *(channel->count) - *(channel->pos_fb) * channel->pos_scale;
-      channel->pos_scale_recip = 1.0 / channel->pos_scale;
-      channel->last_pos_scale = channel->pos_scale;
     }
 
     // explicit conversion casts used here to ensure correct handling for negative double values

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -1,0 +1,258 @@
+//
+//    Copyright (C) 2026 Nathan Hofmeyer
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+/// @file  lcec_el2522.c
+/// @brief Driver for Beckhoff EL2522 2-channel pulse train output module
+
+#include <ecrt.h>
+
+#include "../lcec.h"
+#include "hal.h"
+#include "math.h"
+
+// ****************************************************************************
+// Known limitations:
+// - Step count positions are limited to int32_t min/max values as the el2522 internal counter
+//   is 32 bits wide and is currently used directly as the position feedback (after scaling).
+//   This is sufficient for most linear axes, (at 1um/step, max travel would be +/- 2.1km),
+//   but it could be limiting for continuous rotary axes or axes with extremely
+//   high step resolutions.
+//   If this is a problem, possible to change impl to use a 64-bit internal counter
+//   and only use the el2522 counter feedback as an incremental update.
+// ****************************************************************************
+
+static int lcec_el2522_init(int comp_id, lcec_slave_t *slave);
+static void lcec_el2522_read(lcec_slave_t *slave, long period);
+static void lcec_el2522_write(lcec_slave_t *slave, long period);
+
+#define LCEC_EL2522_CHANNEL_COUNT     2
+#define LCEC_EL2522_POS_SCALE_DEFAULT 1.0
+#define LCEC_EL2522_MODPARAM_OUTMODE  0
+#define LCEC_EL2522_MODPARAM_FREQLIMIT   2
+
+#define LCEC_EL2522_MODPARAM_CH(ch)                                                                       \
+  {"ch" #ch "OutputMode", LCEC_EL2522_MODPARAM_OUTMODE + ch, MODPARAM_TYPE_STRING, "FrequencyModulation", \
+      "Output mode: FrequencyModulation|PulseDirection|IncrementalEncoder"},                              \
+      {"ch" #ch "FrequencyLimit", LCEC_EL2522_MODPARAM_FREQLIMIT + ch, MODPARAM_TYPE_U32, "50000", "Maximum output frequency in Hz"}
+
+static const lcec_modparam_desc_t modparams_base[] = {
+    LCEC_EL2522_MODPARAM_CH(0),
+    LCEC_EL2522_MODPARAM_CH(1),
+    {NULL},
+};
+
+static const lcec_lookuptable_int_t lcec_el2522_outmode_table[] = {
+    {"FrequencyModulation", 0x00},
+    {"PulseDirection", 0x01},
+    {"IncrementalEncoder", 0x02},
+    {NULL, 0},
+};
+
+static lcec_typelist_t lcec_el2522_types[] = {
+    {.name = "EL2522",
+        .vid = LCEC_BECKHOFF_VID,
+        .pid = 0x09da3052,
+        .is_fsoe_logic = 0,
+        .proc_preinit = NULL,
+        .proc_init = lcec_el2522_init,
+        .modparams = modparams_base,
+        .flags = 0,
+        .sourcefile = NULL},
+    {NULL},
+};
+ADD_TYPES(lcec_el2522_types);
+
+typedef struct {
+  // HAL pins
+  hal_float_t *pos_fb;   // pin: position feedback (position units)
+  hal_float_t *pos_cmd;  // pin: position command (position units)
+  hal_bit_t *enable;     // pin: enable command
+  hal_s32_t *count;      // pin: raw count output (steps), useful for commissioning
+
+  // HAL parameters
+  hal_float_t pos_scale;  // param: pos scaling factor (steps/unit)
+
+  // PDO offsets and bit positions
+  unsigned int target_pdo_os;
+  unsigned int count_pdo_os;
+  unsigned int enable_pdo_os;
+  unsigned int enable_pdo_bp;
+
+  // Internal variables
+  uint32_t last_count;
+  double last_pos_scale;
+  double pos_scale_recip;
+  double step_offset;
+} lcec_el2522_channel_t;
+
+typedef struct {
+  lcec_el2522_channel_t channels[LCEC_EL2522_CHANNEL_COUNT];
+} lcec_el2522_data_t;
+
+static const lcec_pindesc_t slave_pins[] = {
+    {HAL_FLOAT, HAL_IN, offsetof(lcec_el2522_channel_t, pos_cmd), "%s.%s.%s.pos-%d-cmd"},
+    {HAL_FLOAT, HAL_OUT, offsetof(lcec_el2522_channel_t, pos_fb), "%s.%s.%s.pos-%d-fb"},
+    {HAL_S32, HAL_OUT, offsetof(lcec_el2522_channel_t, count), "%s.%s.%s.count-%d"},
+    {HAL_BIT, HAL_IN, offsetof(lcec_el2522_channel_t, enable), "%s.%s.%s.enable-%d"},
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
+
+static const lcec_paramdesc_t slave_params[] = {
+    {HAL_FLOAT, HAL_RW, offsetof(lcec_el2522_channel_t, pos_scale), "%s.%s.%s.pos-%d-scale"},
+    {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
+};
+
+static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
+  int err = 0;
+
+  slave->proc_read = lcec_el2522_read;
+  slave->proc_write = lcec_el2522_write;
+
+  lcec_master_t *master = slave->master;
+  lcec_el2522_data_t *hal_data = LCEC_HAL_ALLOCATE(lcec_el2522_data_t);
+  slave->hal_data = hal_data;
+
+  // RxPDO assignment
+  if ((err = lcec_write_sdo8(slave, 0x1C12, 0x00, 0x00)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x01, 0x1601)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x02, 0x1606)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x03, 0x160B)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo16(slave, 0x1C12, 0x04, 0x160D)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo8(slave, 0x1C12, 0x00, 0x04)) != 0) {
+    return err;
+  }
+
+  // TxPDO Assign
+  if ((err = lcec_write_sdo8(slave, 0x1C13, 0x00, 0x00)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo16(slave, 0x1C13, 0x01, 0x1A03)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo16(slave, 0x1C13, 0x02, 0x1A05)) != 0) {
+    return err;
+  }
+  if ((err = lcec_write_sdo8(slave, 0x1C13, 0x00, 0x02)) != 0) {
+    return err;
+  }
+
+  // Channel PDO, modparams and defaults
+  for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
+    LCEC_CONF_MODPARAM_VAL_T *pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_OUTMODE + i);
+    if (pval != NULL) {
+      int operating_mode = lcec_lookupint_i(lcec_el2522_outmode_table, pval->str, 0x00);
+      if ((err = lcec_write_sdo8(slave, 0x8000 + (0x10 * i), 0x0E, operating_mode)) != 0) {
+        return err;
+      }
+    }
+
+    pval = lcec_modparam_get(slave, LCEC_EL2522_MODPARAM_FREQLIMIT + i);
+    if (pval != NULL) {
+      if ((err = lcec_write_sdo32(slave, 0x8000 + (0x10 * i), 0x12, pval->u32)) != 0) {
+        return err;
+      }
+    }
+
+    lcec_el2522_channel_t *channel = &hal_data->channels[i];
+    if ((err = lcec_pdo_init(slave, 0x6020 + (i * 0x10), 0x11, &channel->count_pdo_os, NULL)) != 0) {
+      return err;
+    }
+    if ((err = lcec_pdo_init(slave, 0x7000 + (i * 0x10), 0x04, &channel->enable_pdo_os, &channel->enable_pdo_bp)) != 0) {
+      return err;
+    }
+    if ((err = lcec_pdo_init(slave, 0x7000 + (i * 0x10), 0x12, &channel->target_pdo_os, NULL)) != 0) {
+      return err;
+    }
+
+    // register pins and params
+    if ((err = lcec_pin_newf_list(channel, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {
+      return err;
+    }
+    if ((err = lcec_param_newf_list(channel, slave_params, LCEC_MODULE_NAME, master->name, slave->name, i)) != 0) {
+      return err;
+    }
+
+    channel->pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+    channel->pos_scale_recip = 1.0 / LCEC_EL2522_POS_SCALE_DEFAULT;
+    channel->last_pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+    channel->last_count = 0;
+    channel->step_offset = 0.0;
+  }
+
+  return err;
+}
+
+static void lcec_el2522_read(lcec_slave_t *slave, long period) {
+  lcec_master_t *master = slave->master;
+  lcec_el2522_data_t *hal_data = (lcec_el2522_data_t *)slave->hal_data;
+  uint8_t *pd = master->process_data;
+
+  // wait for slave to be operational
+  if (!slave->state.operational) {
+    return;
+  }
+
+  for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
+    lcec_el2522_channel_t *channel = &hal_data->channels[i];
+
+    const uint32_t raw_count = EC_READ_U32(&pd[channel->count_pdo_os]);
+    const int32_t diff = (int32_t)(raw_count - channel->last_count);
+    channel->last_count = raw_count;
+
+    *(channel->count) += diff;
+    *(channel->pos_fb) += ((double)diff) * channel->pos_scale_recip;
+  }
+}
+
+static void lcec_el2522_write(lcec_slave_t *slave, long period) {
+  lcec_master_t *master = slave->master;
+  lcec_el2522_data_t *hal_data = (lcec_el2522_data_t *)slave->hal_data;
+  uint8_t *pd = master->process_data;
+
+  for (int i = 0; i < LCEC_EL2522_CHANNEL_COUNT; i++) {
+    lcec_el2522_channel_t *channel = &hal_data->channels[i];
+
+    // check for change in scale value, and relcalculate step offset
+    // to avoid position discontinuities.
+    if (channel->pos_scale != channel->last_pos_scale) {
+      if ((channel->pos_scale < 1e-20) && (channel->pos_scale > -1e-20)) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, "pos-scale for slave %s.%s.%i is too small, resetting to default\n", slave->master->name, slave->name, i);
+        channel->pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+      }
+      channel->step_offset = *(channel->count) - *(channel->pos_fb) * channel->pos_scale;
+      channel->pos_scale_recip = 1.0 / channel->pos_scale;
+      channel->last_pos_scale = channel->pos_scale;
+    }
+
+    // explicit conversion casts used here to ensure correct handling for negative double values
+    const uint32_t target = (uint32_t)((int32_t)round(*(channel->pos_cmd) * channel->pos_scale + channel->step_offset));
+    EC_WRITE_U32(&pd[channel->target_pdo_os], target);
+    EC_WRITE_BIT(&pd[channel->enable_pdo_os], channel->enable_pdo_bp, *(channel->enable));
+  }
+}

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -219,10 +219,10 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // register pins and params
-    if ((err = lcec_pin_newf_list(channel, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i+1)) != 0) {
+    if ((err = lcec_pin_newf_list(channel, slave_pins, LCEC_MODULE_NAME, master->name, slave->name, i + 1)) != 0) {
       return err;
     }
-    if ((err = lcec_param_newf_list(channel, slave_params, LCEC_MODULE_NAME, master->name, slave->name, i+1)) != 0) {
+    if ((err = lcec_param_newf_list(channel, slave_params, LCEC_MODULE_NAME, master->name, slave->name, i + 1)) != 0) {
       return err;
     }
 

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -119,6 +119,7 @@ static ec_pdo_entry_info_t el2522_1606_pdo_entries[] = {
     {0x0000, 0x00, 10},
     {0x7010, 0x12, 32}, // Target counter value
 };
+
 static ec_pdo_entry_info_t el2522_160B_pdo_entries[] = {
     {0x0000, 0x00, 2},
     {0x7020, 0x03, 1},  // Set Counter
@@ -271,6 +272,7 @@ static void lcec_el2522_write(lcec_slave_t *slave, long period) {
       if ((channel->pos_scale < 1e-20) && (channel->pos_scale > -1e-20)) {
         rtapi_print_msg(
             RTAPI_MSG_ERR, "Requested pos-scale for %s.%s.ch%i is too small, dropping\n", slave->master->name, slave->name, i+1);
+        channel->pos_scale = channel->last_pos_scale;
       } else {
         channel->last_pos_scale = channel->pos_scale;
         channel->step_offset = *(channel->count) - *(channel->pos_fb) * channel->pos_scale;


### PR DESCRIPTION
Support for 2-channel pulse train output for controlling external motor drivers

Issue: #466