### PR TITLE
build: add install-rip target for LinuxCNC RIP trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all configure install clean test docs
+.PHONY: all configure install install-rip clean test docs
 
 build: configure
 	@$(MAKE) -C src all
@@ -15,6 +15,32 @@ test:
 install: configure
 	@$(MAKE) -C src install
 	@$(MAKE) -C examples install-examples
+
+# Install into a LinuxCNC RIP (run-in-place) tree.
+# Resolves the target tree from (in order):
+#   1. LINUXCNC_HOME passed explicitly (make var or env, e.g. set by sourcing
+#      $RIP/scripts/rip-environment)
+#   2. config.mk EMC2_HOME, if RUN_IN_PLACE=yes there
+#   3. error with usage hint
+install-rip: configure
+	@LCH="$(LINUXCNC_HOME)"; \
+	SRC="explicit LINUXCNC_HOME"; \
+	if [ -z "$$LCH" ] && grep -q '^RUN_IN_PLACE = yes' config.mk 2>/dev/null; then \
+	    LCH=$$(sed -n 's/^EMC2_HOME = //p' config.mk); \
+	    SRC="config.mk EMC2_HOME (RUN_IN_PLACE=yes)"; \
+	fi; \
+	if [ -z "$$LCH" ]; then \
+	    echo "Error: cannot resolve target LinuxCNC RIP tree."; \
+	    echo "  Either source the RIP environment first:"; \
+	    echo "    source /path/to/linuxcnc-rip/scripts/rip-environment"; \
+	    echo "    make install-rip"; \
+	    echo "  or pass it explicitly:"; \
+	    echo "    make install-rip LINUXCNC_HOME=/path/to/linuxcnc-rip"; \
+	    exit 1; \
+	fi; \
+	echo "Installing into RIP tree: $$LCH ($$SRC)"; \
+	$(MAKE) -C src install EMC2_HOME=$$LCH RTLIBDIR=$$LCH/rtlib; \
+	$(MAKE) -C examples install-examples EMC2_HOME=$$LCH
 
 configure: config.mk
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,7 +89,7 @@ test: $(all-tests)
 install-user: user
 	mkdir -p $(DESTDIR)$(EMC2_HOME)/bin
 	cp lcec_conf $(DESTDIR)$(EMC2_HOME)/bin/
-	cp lcec_configgen $(DESTDIR)/usr/bin/
+	cp lcec_configgen $(DESTDIR)$(EMC2_HOME)/bin/
 
 install-realtime: realtime
 	mkdir -p $(DESTDIR)$(RTLIBDIR)/


### PR DESCRIPTION
## Summary

- Add top-level `install-rip` target that installs binaries, modules, and example configs into a LinuxCNC RIP tree.
- Fix `lcec_configgen` install path: was hardcoded `/usr/bin/`, now uses `$(EMC2_HOME)/bin/` like `lcec_conf`.

Resolution order for `install-rip`:

1. Explicit `LINUXCNC_HOME` (make var or env, set by `source $RIP/scripts/rip-environment`)
2. `EMC2_HOME` from `config.mk` when `RUN_IN_PLACE=yes`
3. Error with usage hint

Closes #475. Reported by @rodw-au in #474.

## Test plan

- [x] `make install-rip` with no env / no RIP config: clean error message
- [x] `make install-rip LINUXCNC_HOME=/path DESTDIR=/sandbox`: `bin/lcec_conf`, `bin/lcec_configgen`, `rtlib/lcec.so`, `share/linuxcnc-ethercat/examples/...` land at `<sandbox><path>/...`
- [x] `make install-rip` with `config.mk RUN_IN_PLACE=yes`: resolves from config.mk, source attribution printed
- [x] Existing `make install` to system prefix unchanged
- [x] On-hardware verification by RIP user