### PR TITLE
ci: build .deb on Debian 11/12/13 and publish to apt repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,38 +3,76 @@ name: Build CI
 
 on:
     push:
-        branches: [master]
+        branches: ['**']
     pull_request:
     release:
         types: [published]
+    workflow_dispatch:
 
 permissions:
     contents: read
 
 jobs:
     build-deb:
+        name: ${{ matrix.distro }}
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                distro: [debian-11, debian-12, debian-13]
+                include:
+                    - distro: debian-11
+                      image: debian:bullseye
+                      codename: bullseye
+                      etherlab_repo: Debian_11
+                    - distro: debian-12
+                      image: debian:bookworm
+                      codename: bookworm
+                      etherlab_repo: Debian_12
+                    - distro: debian-13
+                      image: debian:trixie
+                      codename: trixie
+                      etherlab_repo: Debian_Testing
+
         container:
-            image: debian:trixie
+            image: ${{ matrix.image }}
+
         steps:
             - name: Install build dependencies
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+                  CODENAME: ${{ matrix.codename }}
+                  ETHERLAB_REPO: ${{ matrix.etherlab_repo }}
               run: |
+                  set -e
+                  echo 'Acquire::Retries "10";' > /etc/apt/apt.conf.d/80-retries
+                  echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80-retries
                   apt-get update
                   apt-get install -y --no-install-recommends ca-certificates curl gpg
-                  curl -fsSL https://download.opensuse.org/repositories/science:/EtherLab/Debian_Testing/Release.key \
+                  curl -fsSL "https://download.opensuse.org/repositories/science:/EtherLab/${ETHERLAB_REPO}/Release.key" \
                       | gpg --dearmor -o /usr/share/keyrings/etherlab.gpg
-                  echo "deb [signed-by=/usr/share/keyrings/etherlab.gpg] https://download.opensuse.org/repositories/science:/EtherLab/Debian_Testing/ ./" \
+                  echo "deb [signed-by=/usr/share/keyrings/etherlab.gpg] https://download.opensuse.org/repositories/science:/EtherLab/${ETHERLAB_REPO}/ ./" \
                       > /etc/apt/sources.list.d/etherlab.list
+                  # Two LinuxCNC signing keys are in use:
+                  # - 3CB9FD148F374FEF: old DSA key, signs bullseye/bookworm
+                  # - E43B5A8E78CC2927: 2025-10 RSA key, signs trixie
+                  { curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xEEDD0D29F81DCAA0D258661F3CB9FD148F374FEF"; \
+                    curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0CE3E44425B11F871BBCC6F5E43B5A8E78CC2927"; } \
+                      | gpg --dearmor -o /usr/share/keyrings/linuxcnc.gpg
+                  echo "deb [signed-by=/usr/share/keyrings/linuxcnc.gpg] https://www.linuxcnc.org/ ${CODENAME} base 2.9-uspace" \
+                      > /etc/apt/sources.list.d/linuxcnc.list
                   apt-get update
                   apt-get install -y --no-install-recommends \
                       git build-essential devscripts debhelper \
-                      linuxcnc-uspace-dev libethercat-dev \
-                      yapps2
+                      linuxcnc-uspace-dev libethercat-dev yapps2
 
             - name: Checkout
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+
+            - name: Mark repo as safe (container runs as root)
+              run: git config --global --add safe.directory "$PWD"
 
             - name: Set version from git
               run: |
@@ -46,8 +84,14 @@ jobs:
                   touch TODO
                   dpkg-buildpackage -d -us -uc -b
                   mkdir -p dist
-                  cp ../*.deb dist/
-                  rm -f dist/*-dbgsym*.deb
+                  for src in ../*.deb; do
+                      [ -f "$src" ] || continue
+                      case "$src" in *-dbgsym*) continue ;; esac
+                      fname="$(basename "$src")"
+                      base="${fname%_*.deb}"
+                      suffix="${fname##*_}"
+                      cp "$src" "dist/${base}_${{ matrix.distro }}_${suffix}"
+                  done
 
             - name: Run tests
               run: |
@@ -57,5 +101,6 @@ jobs:
             - name: Upload deb artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: linuxcnc-ethercat-deb
+                  name: linuxcnc-ethercat-deb-${{ matrix.distro }}
                   path: dist/*.deb
+                  if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,17 @@ jobs:
                       image: debian:bullseye
                       codename: bullseye
                       etherlab_repo: Debian_11
+                      deb_rev: deb11u1
                     - distro: debian-12
                       image: debian:bookworm
                       codename: bookworm
                       etherlab_repo: Debian_12
+                      deb_rev: deb12u1
                     - distro: debian-13
                       image: debian:trixie
                       codename: trixie
                       etherlab_repo: Debian_Testing
+                      deb_rev: deb13u1
 
         container:
             image: ${{ matrix.image }}
@@ -73,7 +76,11 @@ jobs:
             - name: Set version from git tag
               run: |
                   VERSION="${GITHUB_REF_NAME#v}"
-                  dch --newversion "${VERSION}" --distribution stable "Release ${VERSION}"
+                  # Codename-suffixed version so each distro's .deb has a
+                  # unique pool filename in the downstream apt repo.
+                  dch --newversion "${VERSION}+${{ matrix.deb_rev }}" \
+                      --distribution stable \
+                      "Release ${VERSION} for ${{ matrix.codename }}"
 
             - name: Build deb package
               run: |
@@ -83,10 +90,7 @@ jobs:
                   for src in ../*.deb; do
                       [ -f "$src" ] || continue
                       case "$src" in *-dbgsym*) continue ;; esac
-                      fname="$(basename "$src")"
-                      base="${fname%_*.deb}"
-                      suffix="${fname##*_}"
-                      cp "$src" "dist/${base}_${{ matrix.distro }}_${suffix}"
+                      cp "$src" "dist/$(basename "$src")"
                   done
 
             - name: Run tests
@@ -122,3 +126,19 @@ jobs:
                   files: artifacts/**/*.deb
                   generate_release_notes: true
                   prerelease: ${{ contains(github.ref_name, '~pre') || contains(github.ref_name, '-pre') }}
+
+            - name: Trigger apt-repo ingestion
+              env:
+                  GH_TOKEN: ${{ secrets.APT_DISPATCH_TOKEN }}
+              run: |
+                  if [ -z "$GH_TOKEN" ]; then
+                      echo "APT_DISPATCH_TOKEN not set; skipping ingestion dispatch."
+                      exit 0
+                  fi
+                  gh api \
+                      -X POST \
+                      -H "Accept: application/vnd.github+json" \
+                      /repos/linuxcnc-ethercat/apt/dispatches \
+                      -f event_type=ingest-release \
+                      -f "client_payload[source_repo]=${{ github.repository }}" \
+                      -f "client_payload[tag]=${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,29 +9,66 @@ permissions:
     contents: write
 
 jobs:
-    build-and-release:
+    build:
+        name: ${{ matrix.distro }}
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                distro: [debian-11, debian-12, debian-13]
+                include:
+                    - distro: debian-11
+                      image: debian:bullseye
+                      codename: bullseye
+                      etherlab_repo: Debian_11
+                    - distro: debian-12
+                      image: debian:bookworm
+                      codename: bookworm
+                      etherlab_repo: Debian_12
+                    - distro: debian-13
+                      image: debian:trixie
+                      codename: trixie
+                      etherlab_repo: Debian_Testing
+
         container:
-            image: debian:trixie
+            image: ${{ matrix.image }}
+
         steps:
             - name: Install build dependencies
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+                  CODENAME: ${{ matrix.codename }}
+                  ETHERLAB_REPO: ${{ matrix.etherlab_repo }}
               run: |
+                  set -e
+                  echo 'Acquire::Retries "10";' > /etc/apt/apt.conf.d/80-retries
+                  echo 'Acquire::http::Timeout "30";' >> /etc/apt/apt.conf.d/80-retries
                   apt-get update
                   apt-get install -y --no-install-recommends ca-certificates curl gpg
-                  curl -fsSL https://download.opensuse.org/repositories/science:/EtherLab/Debian_Testing/Release.key \
+                  curl -fsSL "https://download.opensuse.org/repositories/science:/EtherLab/${ETHERLAB_REPO}/Release.key" \
                       | gpg --dearmor -o /usr/share/keyrings/etherlab.gpg
-                  echo "deb [signed-by=/usr/share/keyrings/etherlab.gpg] https://download.opensuse.org/repositories/science:/EtherLab/Debian_Testing/ ./" \
+                  echo "deb [signed-by=/usr/share/keyrings/etherlab.gpg] https://download.opensuse.org/repositories/science:/EtherLab/${ETHERLAB_REPO}/ ./" \
                       > /etc/apt/sources.list.d/etherlab.list
+                  # Two LinuxCNC signing keys are in use:
+                  # - 3CB9FD148F374FEF: old DSA key, signs bullseye/bookworm
+                  # - E43B5A8E78CC2927: 2025-10 RSA key, signs trixie
+                  { curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xEEDD0D29F81DCAA0D258661F3CB9FD148F374FEF"; \
+                    curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x0CE3E44425B11F871BBCC6F5E43B5A8E78CC2927"; } \
+                      | gpg --dearmor -o /usr/share/keyrings/linuxcnc.gpg
+                  echo "deb [signed-by=/usr/share/keyrings/linuxcnc.gpg] https://www.linuxcnc.org/ ${CODENAME} base 2.9-uspace" \
+                      > /etc/apt/sources.list.d/linuxcnc.list
                   apt-get update
                   apt-get install -y --no-install-recommends \
                       git build-essential devscripts debhelper \
-                      linuxcnc-uspace-dev libethercat-dev \
-                      yapps2
+                      linuxcnc-uspace-dev libethercat-dev yapps2
 
             - name: Checkout
               uses: actions/checkout@v4
               with:
                   fetch-depth: 0
+
+            - name: Mark repo as safe (container runs as root)
+              run: git config --global --add safe.directory "$PWD"
 
             - name: Set version from git tag
               run: |
@@ -43,17 +80,45 @@ jobs:
                   touch TODO
                   dpkg-buildpackage -d -us -uc -b
                   mkdir -p dist
-                  cp ../*.deb dist/
-                  rm -f dist/*-dbgsym*.deb
+                  for src in ../*.deb; do
+                      [ -f "$src" ] || continue
+                      case "$src" in *-dbgsym*) continue ;; esac
+                      fname="$(basename "$src")"
+                      base="${fname%_*.deb}"
+                      suffix="${fname##*_}"
+                      cp "$src" "dist/${base}_${{ matrix.distro }}_${suffix}"
+                  done
 
             - name: Run tests
               run: |
                   cd src
                   make test
 
+            - name: Upload deb artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: linuxcnc-ethercat-deb-${{ matrix.distro }}
+                  path: dist/*.deb
+                  if-no-files-found: error
+
+    release:
+        name: Attach debs to GitHub release
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Download all artefacts
+              uses: actions/download-artifact@v4
+              with:
+                  path: artifacts
+
+            - name: List artefacts
+              run: find artifacts -type f -name '*.deb' -print
+
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v2
               with:
-                  files: dist/*.deb
+                  files: artifacts/**/*.deb
                   generate_release_notes: true
                   prerelease: ${{ contains(github.ref_name, '~pre') || contains(github.ref_name, '-pre') }}


### PR DESCRIPTION
## Summary

- Matrix-build .deb packages on debian-11 (bullseye), debian-12 (bookworm) and debian-13 (trixie). EtherLab repo and LinuxCNC apt source pinned per codename; both LinuxCNC archive keys (old DSA + 2025-10 RSA) imported via keyserver.ubuntu.com.
- Triggers broadened to any branch push plus workflow_dispatch so feature branches and manual runs both produce artifacts.
- Release workflow: per-codename version suffix (`+deb{11,12,13}u1`) keeps each distro's .deb uniquely named, eliminating downstream pool collisions.
- On release publish, fire `repository_dispatch` (`event_type=ingest-release`) at [linuxcnc-ethercat/apt](https://github.com/linuxcnc-ethercat/apt) using `APT_DISPATCH_TOKEN`. The apt repo workflow pulls the release assets, routes by version suffix, runs reprepro, and publishes via GitHub Pages.

Ubuntu rows intentionally absent: no upstream `linuxcnc-uspace-dev` for jammy/noble.

Pre-releases are filtered out by the apt repo's ingest workflow (skip when GitHub release `isPrerelease=true`) so testing tags don't pollute the production pool.

## Test plan

- [x] CI green on `feat/ci-multi-distro` head: all three Debian legs build and upload artifacts
- [ ] After merge, tag a non-pre release and confirm: GH release created with 3 .debs, apt repo ingest workflow runs, `pool/main/l/linuxcnc-ethercat/` populated, `dists/<codename>/main/binary-amd64/Packages` updated
- [ ] `apt-get update && apt-get install linuxcnc-ethercat` works on a clean Debian 12 container against the published Pages URL