### PR TITLE
release: rename to linuxcnc-ethercat, prepare 1.41.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+linuxcnc-ethercat (1.41.0-1) unstable; urgency=low
+
+  * Drop the -bb/-pi flavor split: bb is now the canonical driver.
+    Rename source and binary package back to linuxcnc-ethercat.
+    Conflicts/Replaces/Provides arranged so any installed
+    linuxcnc-ethercat-bb or -pi migrates cleanly.
+  * Add HAL initf activation path (clean DC SYNC0 phasing on
+    LinuxCNC master/2.10 builds; legacy BANG-BANG retained as
+    fallback when initf is not registered or unavailable).
+  * Build matrix .deb packages on Debian 11/12/13 and publish to
+    linuxcnc-ethercat/apt on tagged releases.
+
+ -- Luca Toniolo <toniolo.luca@gmail.com>  Tue, 12 May 2026 12:00:00 +0200
+
 linuxcnc-ethercat-bb (1.41.0~pre5-bb1) unstable; urgency=low
 
   * Rename source/binary package to linuxcnc-ethercat-bb to ship in

--- a/debian/control
+++ b/debian/control
@@ -1,16 +1,18 @@
-Source: linuxcnc-ethercat-bb
-Section: unknown
-Priority: extra
-Maintainer: Bjarne von Horn <vh@igh.de>
+Source: linuxcnc-ethercat
+Section: misc
+Priority: optional
+Maintainer: Luca Toniolo <toniolo.luca@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), libexpat1-dev, linuxcnc-dev | linuxcnc-sim-dev | linuxcnc-uspace-dev | machinekit-dev, etherlabmaster-dev | libethercat-dev
 Standards-Version: 3.9.3
 
-Package: linuxcnc-ethercat-bb
+Package: linuxcnc-ethercat
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, linuxcnc | linuxcnc-sim | linuxcnc-uspace | machinekit, etherlabmaster | ethercat-master
-Conflicts: linuxcnc-ethercat, linuxcnc-ethercat-pi
-Provides: linuxcnc-ethercat
-Replaces: linuxcnc-ethercat
-Description: LinuxCNC EtherCAT HAL driver (bang-bang DC sync)
- Bang-bang inline DC sync controller flavor of linuxcnc-ethercat.
- Conflicts with linuxcnc-ethercat-pi (PI controller flavor).
+Conflicts: linuxcnc-ethercat-bb, linuxcnc-ethercat-pi
+Replaces: linuxcnc-ethercat-bb, linuxcnc-ethercat-pi
+Provides: linuxcnc-ethercat-bb
+Description: LinuxCNC EtherCAT HAL driver
+ HAL driver letting LinuxCNC drive EtherCAT slave devices via the
+ IgH EtherLab master. Supports CiA 402 motion devices, generic PDOs,
+ distributed-clock sync, and a growing catalog of vendor-specific
+ modules.


### PR DESCRIPTION
## Summary

- Drop the bb/pi flavor split. \`bb\` (bang-bang DC sync) is now the canonical and only driver. Source and binary package renamed from \`linuxcnc-ethercat-bb\` back to \`linuxcnc-ethercat\`.
- \`Conflicts\` and \`Replaces\` cover both \`linuxcnc-ethercat-bb\` and \`linuxcnc-ethercat-pi\`, so an apt upgrade migrates any existing flavor install cleanly. \`Provides: linuxcnc-ethercat-bb\` keeps third-party dependers happy.
- Maintainer updated; \`Section: misc\`, \`Priority: optional\` (lintian-clean defaults); description rewritten.
- Changelog entry \`1.41.0-1\` records the rename, the new HAL \`initf\` activation path, and the Debian 11/12/13 build pipeline.

\`1.41.0-1\` sorts above the previous test tags (\`1.41.0~pre5-bb2\`) so the bump is a clean upgrade.

## Test plan

- [x] CI green on this branch
- [ ] After merge, tag \`v1.41.0\`: release workflow builds three .debs (one per Debian codename), creates the GitHub release, dispatches to \`linuxcnc-ethercat/apt\`
- [ ] Apt repo \`pool/main/l/linuxcnc-ethercat/\` populated; \`apt-get install linuxcnc-ethercat\` works on Debian 12 against the Pages URL
- [ ] On a host with old \`linuxcnc-ethercat-bb\` installed (if any), \`apt-get upgrade\` cleanly replaces it with the new package