### PR TITLE
fix(shlibs): list libethercat first; bump to 1.41.0-2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+linuxcnc-ethercat (1.41.0-2) unstable; urgency=low
+
+  * shlibs.local: list libethercat first in the alternatives chain
+    for libethercat.so.1. The previous order let apt resolve the
+    runtime dep to ethercat-master (which ships only the master
+    daemon, no .so), so a clean install of linuxcnc-ethercat could
+    leave lcec.so unable to load at runtime.
+
+ -- Luca Toniolo <toniolo.luca@gmail.com>  Mon, 18 May 2026 22:00:00 +0200
+
 linuxcnc-ethercat (1.41.0-1) unstable; urgency=low
 
   * Drop the -bb/-pi flavor split: bb is now the canonical driver.

--- a/debian/shlibs.local
+++ b/debian/shlibs.local
@@ -1,1 +1,1 @@
-libethercat 1 etherlabmaster (>= 1.5.2) | libethercat (>= 1.5.2) | ethercat-master (>= 1.5.2)
+libethercat 1 libethercat (>= 1.5.2) | etherlabmaster (>= 1.5.2) | ethercat-master (>= 1.5.2)


### PR DESCRIPTION
## Summary

\`debian/shlibs.local\` mapped \`libethercat.so.1\` to:
\`\`\`
etherlabmaster | libethercat | ethercat-master
\`\`\`

\`ethercat-master\` ships only the master daemon and ships **no** \`libethercat.so.1\`. With the linuxcnc-ethercat apt repo enabled, the existing \`Depends\` already pulls in \`ethercat-master\` via the second alternatives group (\`etherlabmaster | ethercat-master\`), and apt would happily mark the shlibs alternative satisfied by it too. Net effect on a clean install: \`linuxcnc-ethercat\` installs without \`libethercat\`, \`lcec.so\` fails to dlopen at LinuxCNC startup.

Reorder so \`libethercat\` comes first. apt will install it. \`etherlabmaster\`/\`ethercat-master\` remain as fallbacks for hosts coming from the opensuse build (which bundles the .so under those names).

Bumps changelog to \`1.41.0-2\`.

## Test plan

- [x] CI green on this branch
- [x] After merge + tag \`v1.41.0-2\`: \`apt-get install linuxcnc-ethercat\` on Debian 12/13 pulls \`libethercat\` automatically; \`ldd /usr/lib/linuxcnc/modules/lcec.so\` resolves cleanly