### PR TITLE
release: 1.41.1-1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,14 @@ jobs:
             - name: Mark repo as safe (container runs as root)
               run: git config --global --add safe.directory "$PWD"
 
-            - name: Set version from git
+            - name: Stamp CI version
               run: |
-                  VERSION=$(git describe --tags --always | sed 's/^v//')
-                  dch --newversion "${VERSION}" --distribution stable "CI build ${VERSION}"
+                  # CI builds aren't published to the apt repo, so we just
+                  # need a parseable version. Force-bump via -b to bypass
+                  # dch's monotonic check (git describe on a feature branch
+                  # often sorts below the canonical changelog version).
+                  ver=$(git describe --tags --always | sed 's/^v//')
+                  dch -b --newversion "${ver}+ci" --distribution stable "CI build ${ver}"
 
             - name: Build deb package
               run: |

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+linuxcnc-ethercat (1.41.1-1) unstable; urgency=low
+
+  * Bump upstream to 1.41.1 to overtake the bad 1.41.0+debNNu1
+    pool versions that were published before release.yml was
+    fixed to read the version from debian/changelog. dpkg
+    parsed those as upstream='1.41.0+debNNu1' with no debian
+    revision, so any 1.41.0-N+debNNu1 build sorted lower and
+    apt refused to upgrade systems still running the bad build.
+    1.41.1-1 is unambiguously higher and triggers a clean
+    apt upgrade.
+
+ -- Luca Toniolo <toniolo.luca@gmail.com>  Tue, 19 May 2026 09:00:00 +0200
+
 linuxcnc-ethercat (1.41.0-2) unstable; urgency=low
 
   * shlibs.local: list libethercat first in the alternatives chain


### PR DESCRIPTION
## Summary

Bumps changelog to \`1.41.1-1\`. No code changes.

The first release (\`v1.41.0\`) was built with the old \`release.yml\` that put the codename suffix inside the upstream string, producing \`1.41.0+debNNu1\` (no debian revision). dpkg sorts \`1.41.0+debNNu1\` **above** any later \`1.41.0-N+debNNu1\` build, so hosts that installed the bad first release won't auto-upgrade to \`1.41.0-2\`.

\`1.41.1-1\` is unambiguously higher than \`1.41.0+debNNu1\`, so \`apt upgrade\` will pick it up everywhere.

## Test plan

- [x] Merge, tag \`v1.41.1\`, watch the release matrix produce \`linuxcnc-ethercat_1.41.1-1+debNNu1_amd64.deb\` artefacts
- [x] Apt repo ingest workflow publishes them; clients on the bad 1.41.0 build see a clean upgrade