### PR TITLE
feat(leadshine): R2EC/R3EC modular coupler driver with <subModule> XML support

### DIFF
--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -163,6 +163,55 @@ In order to get this correct for any given device, you'll need to
 refer to the manufacturer's documentation, and some trial and error
 may be required.
 
+### `<subModule>`
+
+Some EtherCAT devices are *modular*: a single slave (typically a bus
+coupler) hosts a number of pluggable modules on a backplane, and each
+module is configured independently.  The Leadshine `R2EC`/`R3EC`
+digital-I/O couplers are an example — one coupler is a single slave
+that can carry up to 32 (R2EC) or 64 (R3EC) input, output, analog, or
+encoder modules.
+
+For these devices you describe each populated slot with a
+`<subModule>` tag inside the `<slave>`:
+
+- `id="<slot>"`: (required): the backplane slot the module is plugged
+  into, starting at `0`.  Accepts decimal or `0x`-prefixed hex.  Used
+  when naming the module's HAL pins.
+- `ident="<ident>"`: (required): the module's type identifier, as
+  reported by the coupler and listed in the manufacturer's ESI/module
+  documentation.  Accepts decimal or `0x`-prefixed hex.  The driver
+  validates this against the modules it knows about, so an unknown
+  `ident` (or a `<subModule>` under a slave type that isn't modular)
+  is rejected at parse time.
+- `name="<name>"`: (optional, defaults to the value of `id`): the name
+  used when naming this module's HAL pins.
+
+Each `<subModule>` may contain its own `<modParam name="..."
+value="..."/>` tags.  These work exactly like the slave-level
+`<modParam>` tags described above, except that the allowed names and
+values are defined by the *module type* (the `ident`) rather than by
+the coupler.  You can mix slave-level `<modParam>` tags (which
+configure the coupler itself) with `<subModule>` tags in any order.
+
+Here is an example for a Leadshine `R2EC` coupler carrying a 16-channel
+digital-input module in slot 0 and a 16-channel digital-output module
+in slot 1:
+
+```xml
+    <slave idx="0" type="R2EC" name="io">
+      <subModule id="0" ident="0x61100025" name="in0">
+        <modParam name="inputFilter0" value="20"/>
+      </subModule>
+      <subModule id="1" ident="0x61100205" name="out0">
+        <modParam name="safeState" value="0"/>
+      </subModule>
+    </slave>
+```
+
+Refer to the specific driver's documentation for the list of supported
+module `ident`s and the `<modParam>`s available for each.
+
 ### `<syncManagers>`
 
 The `<syncManager>` tag sets up an EtherCAT sync manager.  (link

--- a/src/devices/lcec_leadshine_ec.c
+++ b/src/devices/lcec_leadshine_ec.c
@@ -1,0 +1,543 @@
+//
+//    Copyright (C) 2026 linuxcnc-ethercat contributors
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+/// @file
+/// @brief Driver for the Leadshine R2EC / R3EC modular EtherCAT bus couplers.
+///
+/// See lcec_leadshine_ec.h for the device overview.  This is the first driver
+/// to consume the generic `<subModule>` support: the coupler declares the
+/// module types it accepts via `types[].modules` (built from
+/// `leadshine_ec_module_table`), and in `_init` it walks the configured
+/// `slave->submodules` list, builds a dynamic PDO/sync-manager layout, exports
+/// the per-slot HAL pins through the `lcec_class_*` helpers, applies each
+/// module's `<modParam>`s, and writes the configured module ident list (0xF030).
+///
+/// All CoE object / PDO / subindex addresses are taken from the R3EC ESI in
+/// documentation/R3EC-v2.4.xml.  Digital modules default to the bit-wise PDO
+/// mapping (object 0x6000/0x7000, one BOOL per subindex); packed-word mappings
+/// (0x6001/0x6002) are not used.
+
+#include "lcec_leadshine_ec.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../lcec.h"
+
+static int lcec_leadshine_ec_init(int comp_id, lcec_slave_t *slave);
+static void lcec_leadshine_ec_read(lcec_slave_t *slave, long period);
+static void lcec_leadshine_ec_write(lcec_slave_t *slave, long period);
+
+static lcec_typelist_t types[] = {
+    {"R2EC", LCEC_LEADSHINE_VID, 0x61400005, 0, NULL, lcec_leadshine_ec_init, NULL, LEADSHINE_EC_FLAG(32, 0x10)},
+    {"R3EC", LCEC_LEADSHINE_VID, 0x61400025, 0, NULL, lcec_leadshine_ec_init, NULL, LEADSHINE_EC_FLAG(64, 0x08)},
+    {NULL},
+};
+
+/// @brief Register the coupler types, building the submodule descriptor table
+/// from `leadshine_ec_module_table` (single source of truth) and attaching it
+/// to every type's `.modules`.  Modeled on ADD_TYPES_WITH_CIA402_MODPARAMS;
+/// runs at load time, so it uses the malloc-based LCEC_ALLOCATE_ARRAY.
+static void AddTypesLeadshineEc(void) __attribute__((constructor));
+static void AddTypesLeadshineEc(void) {
+  int n = 0;
+  while (leadshine_ec_module_table[n].name != NULL) n++;
+
+  lcec_submodule_desc_t *subs = LCEC_ALLOCATE_ARRAY(lcec_submodule_desc_t, (n + 1));
+  for (int i = 0; i < n; i++) {
+    subs[i].name = leadshine_ec_module_table[i].name;
+    subs[i].ident = leadshine_ec_module_table[i].ident;
+    subs[i].modparams = leadshine_ec_module_table[i].modparams;
+  }
+  subs[n].name = NULL;  // NULL-terminate
+
+  for (int i = 0; types[i].name != NULL; i++) {
+    types[i].modules = subs;
+  }
+  lcec_addtypes(types, __FILE__);
+}
+
+/// @brief Look up a module definition by its ident.
+static const leadshine_ec_module_def_t *leadshine_ec_find_module(uint32_t ident) {
+  for (const leadshine_ec_module_def_t *m = leadshine_ec_module_table; m->name != NULL; m++) {
+    if (m->ident == ident) {
+      return m;
+    }
+  }
+  return NULL;
+}
+
+/// @brief Count the configured submodules on a slave.
+static int leadshine_ec_count_slots(lcec_slave_t *slave) {
+  int n = 0;
+  for (lcec_slave_submodule_t *s = slave->submodules; s != NULL; s = s->next) {
+    n++;
+  }
+  return n;
+}
+
+/// @brief Allocate a persistent "<base>-<kind>-<ch>" HAL pin name.
+static char *leadshine_ec_name(const char *base, const char *kind, int ch) {
+  char buf[HAL_NAME_LEN];
+  snprintf(buf, sizeof(buf), "%s-%s-%d", base, kind, ch);
+  char *s = LCEC_HAL_ALLOCATE_ARRAY(char, (strlen(buf) + 1));
+  strcpy(s, buf);
+  return s;
+}
+
+/// @brief Allocate a persistent "<base>-<kind>" HAL pin-name prefix.
+static char *leadshine_ec_prefix(const char *base, const char *kind) {
+  char buf[HAL_NAME_LEN];
+  snprintf(buf, sizeof(buf), "%s-%s", base, kind);
+  char *s = LCEC_HAL_ALLOCATE_ARRAY(char, (strlen(buf) + 1));
+  strcpy(s, buf);
+  return s;
+}
+
+// ------------------------------------------------------------------
+// PDO/sync-manager layout
+//
+// Each PDO/entry index is DependOnSlot: real index = base + slot*increment
+// (SLOT_INCR for CoE objects, pdo_incr for PDO indices).  The bit-wise digital
+// mapping (default) and the analog/encoder value+diagnostic mappings come
+// straight from the ESI.  Mandatory input PDOs that we don't expose as HAL
+// pins (analog/DA diagnostics, encoder error words) are still mapped so the
+// module reaches OP.
+// ------------------------------------------------------------------
+
+/// @brief Append a slot's output (RxPDO, SM2) mapping.
+static void leadshine_ec_append_output_pdos(lcec_syncs_t *syncs, lcec_slave_submodule_t *s, const leadshine_ec_module_def_t *def,
+    int pdo_incr) {
+  uint16_t obj = LEADSHINE_EC_OUTOBJ + s->id * LEADSHINE_EC_SLOT_INCR;
+  uint16_t pdo = LEADSHINE_EC_RXPDO + s->id * pdo_incr;
+
+  switch (def->type) {
+    case MODULE_DOUT:
+    case MODULE_DIO:
+      if (def->out == 0) break;
+      lcec_syncs_add_pdo_info(syncs, pdo);
+      for (int ch = 0; ch < def->out; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, obj, ch + 1, 1);  // BOOL
+      }
+      break;
+    case MODULE_AOUT:
+      lcec_syncs_add_pdo_info(syncs, pdo);
+      for (int ch = 0; ch < def->out; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, obj, ch + 1, 16);  // INT
+      }
+      break;
+    case MODULE_ENCODER:
+      // mandatory "general output" byte
+      lcec_syncs_add_pdo_info(syncs, pdo);
+      lcec_syncs_add_pdo_entry(syncs, obj, 1, 8);  // USINT
+      break;
+    default: break;
+  }
+}
+
+/// @brief Append a slot's input (TxPDO, SM3) mapping.
+static void leadshine_ec_append_input_pdos(lcec_syncs_t *syncs, lcec_slave_submodule_t *s, const leadshine_ec_module_def_t *def,
+    int pdo_incr) {
+  uint16_t obj = LEADSHINE_EC_INOBJ + s->id * LEADSHINE_EC_SLOT_INCR;
+  uint16_t diag = LEADSHINE_EC_DIAGOBJ + s->id * LEADSHINE_EC_SLOT_INCR;
+  uint16_t pdo = LEADSHINE_EC_TXPDO + s->id * pdo_incr;
+
+  switch (def->type) {
+    case MODULE_DIN:
+    case MODULE_DIO:
+      if (def->in == 0) break;
+      lcec_syncs_add_pdo_info(syncs, pdo);
+      for (int ch = 0; ch < def->in; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, obj, ch + 1, 1);  // BOOL
+      }
+      break;
+    case MODULE_AIN:
+      lcec_syncs_add_pdo_info(syncs, pdo);  // 0x1A00 value
+      for (int ch = 0; ch < def->in; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, obj, ch + 1, 16);  // INT
+      }
+      lcec_syncs_add_pdo_info(syncs, pdo + 1);  // 0x1A01 diagnostic (mandatory)
+      for (int ch = 0; ch < def->in; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, diag, ch + 1, 8);  // USINT
+      }
+      break;
+    case MODULE_AOUT:
+      // analog output modules also carry a mandatory input diagnostic PDO
+      lcec_syncs_add_pdo_info(syncs, pdo);  // 0x1A00 diagnostic
+      for (int ch = 0; ch < def->out; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, diag, ch + 1, 8);  // USINT
+      }
+      break;
+    case MODULE_ENCODER:
+      lcec_syncs_add_pdo_info(syncs, pdo);  // 0x1A00 position + error
+      for (int ch = 0; ch < def->in; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, obj, ch + 1, 32);  // DINT position
+      }
+      for (int ch = 0; ch < def->in; ch++) {
+        lcec_syncs_add_pdo_entry(syncs, obj, def->in + ch + 1, 8);  // USINT error
+      }
+      // TODO(hw): the encoder also declares further mandatory TxPDOs (0x1A01+,
+      // latch/compare).  They are not mapped here; if a module fails to reach
+      // OP without them, add them following the ESI.
+      break;
+    default: break;
+  }
+}
+
+/// @brief Build the dynamic sync-manager / PDO layout for the configured slots.
+///
+/// SM0/SM1 are (empty) mailbox syncs; process data lives on SM2 (outputs) and
+/// SM3 (inputs).  All outputs are grouped under SM2 and all inputs under SM3,
+/// because the builder appends PDOs to the most recently added sync.
+static void leadshine_ec_build_syncs(lcec_slave_t *slave, lcec_syncs_t *syncs, int pdo_incr) {
+  lcec_syncs_init(slave, syncs);
+
+  lcec_syncs_add_sync(syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);  // SM0 mailbox out
+  lcec_syncs_add_sync(syncs, EC_DIR_INPUT, EC_WD_DEFAULT);   // SM1 mailbox in
+
+  // SM2: outputs (RxPDO)
+  lcec_syncs_add_sync(syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);
+  for (lcec_slave_submodule_t *s = slave->submodules; s != NULL; s = s->next) {
+    const leadshine_ec_module_def_t *def = leadshine_ec_find_module(s->ident);
+    if (def != NULL) {
+      leadshine_ec_append_output_pdos(syncs, s, def, pdo_incr);
+    }
+  }
+
+  // SM3: inputs (TxPDO)
+  lcec_syncs_add_sync(syncs, EC_DIR_INPUT, EC_WD_DEFAULT);
+  for (lcec_slave_submodule_t *s = slave->submodules; s != NULL; s = s->next) {
+    const leadshine_ec_module_def_t *def = leadshine_ec_find_module(s->ident);
+    if (def != NULL) {
+      leadshine_ec_append_input_pdos(syncs, s, def, pdo_incr);
+    }
+  }
+
+  slave->sync_info = &syncs->syncs[0];
+}
+
+// ------------------------------------------------------------------
+// Per-slot HAL registration
+// ------------------------------------------------------------------
+
+static void leadshine_ec_register_din(lcec_slave_t *slave, leadshine_ec_slot_t *slot, const char *base, int count) {
+  uint16_t obj = LEADSHINE_EC_INOBJ + slot->id * LEADSHINE_EC_SLOT_INCR;
+  slot->din = lcec_din_allocate_channels(count);
+  for (int ch = 0; ch < count; ch++) {
+    slot->din->channels[ch] = lcec_din_register_channel_named(slave, obj, ch + 1, leadshine_ec_name(base, "din", ch));
+  }
+}
+
+static void leadshine_ec_register_dout(lcec_slave_t *slave, leadshine_ec_slot_t *slot, const char *base, int count) {
+  uint16_t obj = LEADSHINE_EC_OUTOBJ + slot->id * LEADSHINE_EC_SLOT_INCR;
+  slot->dout = lcec_dout_allocate_channels(count);
+  for (int ch = 0; ch < count; ch++) {
+    slot->dout->channels[ch] = lcec_dout_register_channel_named(slave, obj, ch + 1, leadshine_ec_name(base, "dout", ch));
+  }
+}
+
+static void leadshine_ec_register_ain(lcec_slave_t *slave, leadshine_ec_slot_t *slot, const char *base, int count) {
+  uint16_t obj = LEADSHINE_EC_INOBJ + slot->id * LEADSHINE_EC_SLOT_INCR;
+  char *prefix = leadshine_ec_prefix(base, "ain");
+  slot->ain = lcec_ain_allocate_channels(count);
+  for (int ch = 0; ch < count; ch++) {
+    lcec_class_ain_options_t *opt = lcec_ain_options();
+    opt->name_prefix = prefix;
+    opt->valueonly = 1;        // diagnostics are mapped but not exposed as pins
+    opt->value_sidx = ch + 1;  // 0x6000:1..N, INT16 (ESI)
+    slot->ain->channels[ch] = lcec_ain_register_channel(slave, ch, obj, opt);
+  }
+}
+
+static void leadshine_ec_register_aout(lcec_slave_t *slave, leadshine_ec_slot_t *slot, const char *base, int count) {
+  uint16_t obj = LEADSHINE_EC_OUTOBJ + slot->id * LEADSHINE_EC_SLOT_INCR;
+  char *prefix = leadshine_ec_prefix(base, "aout");
+  slot->aout = lcec_aout_allocate_channels(count);
+  for (int ch = 0; ch < count; ch++) {
+    lcec_class_aout_options_t *opt = lcec_aout_options();
+    opt->name_prefix = prefix;
+    opt->value_sidx = ch + 1;  // 0x7000:1..N, INT16 (ESI)
+    slot->aout->channels[ch] = lcec_aout_register_channel(slave, ch, obj, opt);
+  }
+}
+
+static void leadshine_ec_register_enc(lcec_slave_t *slave, leadshine_ec_slot_t *slot, const char *base, int count) {
+  uint16_t obj = LEADSHINE_EC_INOBJ + slot->id * LEADSHINE_EC_SLOT_INCR;
+  slot->enc_count = count;
+  slot->enc = LCEC_HAL_ALLOCATE_ARRAY(lcec_class_enc_data_t, count);
+  slot->enc_pos_os = LCEC_HAL_ALLOCATE_ARRAY(unsigned int, count);
+  for (int ch = 0; ch < count; ch++) {
+    class_enc_init(slave, &slot->enc[ch], 32, leadshine_ec_name(base, "enc", ch));
+    // class_enc registers no PDO itself; map the 32-bit position value here
+    // (0x6000:1..N, DINT).
+    lcec_pdo_init(slave, obj, ch + 1, &slot->enc_pos_os[ch], NULL);
+  }
+}
+
+// ------------------------------------------------------------------
+// Modparam application (per slot).  Addresses per the R3EC ESI DT8000 layouts.
+// Writes are only issued for modparams the user actually set.
+// ------------------------------------------------------------------
+
+static int leadshine_ec_apply_modparams(lcec_slave_t *slave, lcec_slave_submodule_t *sub, const leadshine_ec_module_def_t *def) {
+  LCEC_CONF_MODPARAM_VAL_T *v;
+  uint16_t cfg = LEADSHINE_EC_CFGOBJ + sub->id * LEADSHINE_EC_SLOT_INCR;
+  int err;
+
+  // digital output safe state: 16-bit low word (bits 0-15) at sub 1, high word
+  // (bits 16-31) at sub 2 for 32-channel modules.
+  if (def->type == MODULE_DOUT || def->type == MODULE_DIO) {
+    v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_SAFESTATE);
+    if (v != NULL) {
+      if ((err = lcec_write_sdo16(slave, cfg, LEADSHINE_EC_SUB_SAFESTATE_LO, v->u32 & 0xffff)) != 0) {
+        return err;
+      }
+      if (def->out > 16 && (err = lcec_write_sdo16(slave, cfg, LEADSHINE_EC_SUB_SAFESTATE_HI, (v->u32 >> 16) & 0xffff)) != 0) {
+        return err;
+      }
+    }
+  }
+
+  // digital input filters: one 16-bit value per group of 8 channels, sub 3..6.
+  if (def->type == MODULE_DIN || def->type == MODULE_DIO) {
+    int groups = (def->in + 7) / 8;
+    for (int g = 0; g < groups && g < 4; g++) {
+      v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_INPUTFILTER(g));
+      if (v != NULL && (err = lcec_write_sdo16(slave, cfg, LEADSHINE_EC_SUB_FILTER_BASE + g, v->u32 & 0xffff)) != 0) {
+        return err;
+      }
+    }
+  }
+
+  // analog per-channel range/mode config: 8-bit value at sub 1..4.
+  if (def->type == MODULE_AIN || def->type == MODULE_AOUT) {
+    int count = (def->type == MODULE_AIN) ? def->in : def->out;
+    for (int ch = 0; ch < count && ch < 4; ch++) {
+      v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ANALOG_CFG(ch));
+      if (v != NULL && (err = lcec_write_sdo8(slave, cfg, LEADSHINE_EC_SUB_ANALOG_BASE + ch, v->u32 & 0xff)) != 0) {
+        return err;
+      }
+    }
+  }
+
+  // encoder config: one object per encoder channel (0x8000 = ch0, 0x8001 = ch1).
+  // A single set of modparams is applied to every channel on the module.
+  if (def->type == MODULE_ENCODER) {
+    for (int ch = 0; ch < def->in; ch++) {
+      uint16_t eobj = cfg + ch;
+      if ((v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ENC_MODE)) != NULL &&
+          (err = lcec_write_sdo8(slave, eobj, LEADSHINE_EC_SUB_ENC_MODE, v->u32 & 0xff)) != 0) {
+        return err;
+      }
+      if ((v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ENC_ABPHASE)) != NULL &&
+          (err = lcec_write_sdo8(slave, eobj, LEADSHINE_EC_SUB_ENC_ABPHASE, v->u32 & 0xff)) != 0) {
+        return err;
+      }
+      if ((v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ENC_MINVALUE)) != NULL &&
+          (err = lcec_write_sdo32(slave, eobj, LEADSHINE_EC_SUB_ENC_MIN, (uint32_t)v->s32)) != 0) {
+        return err;
+      }
+      if ((v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ENC_MAXVALUE)) != NULL &&
+          (err = lcec_write_sdo32(slave, eobj, LEADSHINE_EC_SUB_ENC_MAX, (uint32_t)v->s32)) != 0) {
+        return err;
+      }
+      if ((v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ENC_COUNTMODE)) != NULL &&
+          (err = lcec_write_sdo8(slave, eobj, LEADSHINE_EC_SUB_ENC_COUNTMODE, v->u32 & 0xff)) != 0) {
+        return err;
+      }
+      if ((v = lcec_submodule_modparam_get(sub, LEADSHINE_EC_MP_ENC_FILTER)) != NULL &&
+          (err = lcec_write_sdo16(slave, eobj, LEADSHINE_EC_SUB_ENC_FILTER, v->u32 & 0xffff)) != 0) {
+        return err;
+      }
+    }
+  }
+
+  return 0;
+}
+
+/// @brief Write the configured module ident list (0xF030) so the coupler
+/// accepts the PDO mapping.  Per the ESI, sub 0 is a USINT count and subs 1..N
+/// are one UDINT (32-bit) module ident each (slot id + 1).
+static void leadshine_ec_write_module_list(lcec_slave_t *slave) {
+  int count = 0;
+
+  for (lcec_slave_submodule_t *s = slave->submodules; s != NULL; s = s->next) {
+    if (lcec_write_sdo32(slave, LEADSHINE_EC_CONFMODULES, s->id + 1, s->ident) != 0) {
+      rtapi_print_msg(RTAPI_MSG_WARN, LCEC_MSG_PFX "%s.%s: failed writing module ident 0x%08x to 0x%04x:%02x\n", slave->master->name,
+          slave->name, s->ident, LEADSHINE_EC_CONFMODULES, s->id + 1);
+    }
+    if (s->id + 1 > count) {
+      count = s->id + 1;
+    }
+  }
+
+  if (lcec_write_sdo8(slave, LEADSHINE_EC_CONFMODULES, 0x00, count) != 0) {
+    rtapi_print_msg(RTAPI_MSG_WARN, LCEC_MSG_PFX "%s.%s: failed writing module count to 0x%04x:00\n", slave->master->name, slave->name,
+        LEADSHINE_EC_CONFMODULES);
+  }
+}
+
+/// @brief Explicitly write the SM2/SM3 PDO assignment objects (0x1C12/0x1C13).
+///
+/// The master's automatic assignment (from `sync_info`) does not "take" for
+/// this coupler's input sync manager — the default input PDO (0x1A00) is marked
+/// `Fixed` in the ESI, so the master skips writing 0x1C13 and the module's
+/// inputs never appear.  We therefore force the assignment by hand, exactly as
+/// the CoE PDO-assignment protocol requires: clear the count (sub 0 = 0), write
+/// each active PDO index (sub 1..N), then write the count (sub 0 = N).
+///
+/// `sync_info` is still provided so the master knows the PDO/entry layout for
+/// process-image offset resolution; the values written here match it, taken
+/// straight from the built sync structure so the two cannot drift.
+static int leadshine_ec_assign_pdos(lcec_slave_t *slave, lcec_syncs_t *syncs) {
+  ec_sync_info_t *sm_out = &syncs->syncs[LEADSHINE_EC_SM_OUT];
+  ec_sync_info_t *sm_in = &syncs->syncs[LEADSHINE_EC_SM_IN];
+  uint16_t out_obj = LEADSHINE_EC_SM_PDO_ASSIGN(LEADSHINE_EC_SM_OUT);  // 0x1C12
+  uint16_t in_obj = LEADSHINE_EC_SM_PDO_ASSIGN(LEADSHINE_EC_SM_IN);    // 0x1C13
+  int err;
+
+  // clear both assignments first
+  if ((err = lcec_write_sdo8(slave, out_obj, 0, 0)) != 0) return err;
+  if ((err = lcec_write_sdo8(slave, in_obj, 0, 0)) != 0) return err;
+
+  // assign the output PDOs (SM2)
+  for (unsigned int i = 0; i < sm_out->n_pdos; i++) {
+    if ((err = lcec_write_sdo16(slave, out_obj, i + 1, sm_out->pdos[i].index)) != 0) return err;
+  }
+  // assign the input PDOs (SM3)
+  for (unsigned int i = 0; i < sm_in->n_pdos; i++) {
+    if ((err = lcec_write_sdo16(slave, in_obj, i + 1, sm_in->pdos[i].index)) != 0) return err;
+  }
+
+  // write the counts last to activate each assignment
+  if ((err = lcec_write_sdo8(slave, out_obj, 0, sm_out->n_pdos)) != 0) return err;
+  if ((err = lcec_write_sdo8(slave, in_obj, 0, sm_in->n_pdos)) != 0) return err;
+
+  return 0;
+}
+
+// ------------------------------------------------------------------
+// init / read / write
+// ------------------------------------------------------------------
+
+static int lcec_leadshine_ec_init(int comp_id, lcec_slave_t *slave) {
+  lcec_master_t *master = slave->master;
+  int pdo_incr = LEADSHINE_EC_PDO_INCR(slave->flags);
+  int max_slots = LEADSHINE_EC_MAX_SLOTS(slave->flags);
+  int err;
+
+  lcec_leadshine_ec_data_t *hal_data = LCEC_HAL_ALLOCATE(lcec_leadshine_ec_data_t);
+  slave->hal_data = hal_data;
+  hal_data->slot_count = leadshine_ec_count_slots(slave);
+  hal_data->slots = hal_data->slot_count > 0 ? LCEC_HAL_ALLOCATE_ARRAY(leadshine_ec_slot_t, hal_data->slot_count) : NULL;
+
+  // Build the dynamic PDO / sync-manager layout (consumed after _init returns).
+  lcec_syncs_t *syncs = LCEC_HAL_ALLOCATE(lcec_syncs_t);
+  leadshine_ec_build_syncs(slave, syncs, pdo_incr);
+
+  // Register HAL pins + PDO entries and apply modparams, one slot at a time.
+  int i = 0;
+  for (lcec_slave_submodule_t *s = slave->submodules; s != NULL; s = s->next, i++) {
+    leadshine_ec_slot_t *slot = &hal_data->slots[i];
+    const leadshine_ec_module_def_t *def = leadshine_ec_find_module(s->ident);
+
+    // The parser validates idents against this same table, so this should not
+    // happen; guard defensively rather than crash.
+    if (def == NULL) {
+      rtapi_print_msg(RTAPI_MSG_WARN, LCEC_MSG_PFX "%s.%s: unknown submodule ident 0x%08x in slot %d, skipping\n", master->name,
+          slave->name, s->ident, s->id);
+      continue;
+    }
+    if (s->id >= max_slots) {
+      rtapi_print_msg(RTAPI_MSG_WARN, LCEC_MSG_PFX "%s.%s: submodule slot %d exceeds max %d for this coupler\n", master->name,
+          slave->name, s->id, max_slots);
+    }
+
+    slot->id = s->id;
+    slot->ident = s->ident;
+    slot->type = def->type;
+
+    switch (def->type) {
+      case MODULE_DIN: leadshine_ec_register_din(slave, slot, s->name, def->in); break;
+      case MODULE_DOUT: leadshine_ec_register_dout(slave, slot, s->name, def->out); break;
+      case MODULE_DIO:
+        leadshine_ec_register_din(slave, slot, s->name, def->in);
+        leadshine_ec_register_dout(slave, slot, s->name, def->out);
+        break;
+      case MODULE_AIN: leadshine_ec_register_ain(slave, slot, s->name, def->in); break;
+      case MODULE_AOUT: leadshine_ec_register_aout(slave, slot, s->name, def->out); break;
+      case MODULE_ENCODER: leadshine_ec_register_enc(slave, slot, s->name, def->in); break;
+      default: break;
+    }
+
+    if ((err = leadshine_ec_apply_modparams(slave, s, def)) != 0) {
+      return err;
+    }
+  }
+
+  // Tell the coupler which modules the config expects, then force the SM PDO
+  // assignment (the master does not reliably assign the input SM by itself).
+  leadshine_ec_write_module_list(slave);
+  if ((err = leadshine_ec_assign_pdos(slave, syncs)) != 0) {
+    return err;
+  }
+
+  slave->proc_read = lcec_leadshine_ec_read;
+  slave->proc_write = lcec_leadshine_ec_write;
+  return 0;
+}
+
+static void lcec_leadshine_ec_read(lcec_slave_t *slave, long period) {
+  lcec_leadshine_ec_data_t *hal_data = (lcec_leadshine_ec_data_t *)slave->hal_data;
+  uint8_t *pd = slave->master->process_data;
+
+  if (!slave->state.operational) {
+    return;
+  }
+
+  for (int i = 0; i < hal_data->slot_count; i++) {
+    leadshine_ec_slot_t *slot = &hal_data->slots[i];
+    if (slot->din != NULL) {
+      lcec_din_read_all(slave, slot->din);
+    }
+    if (slot->ain != NULL) {
+      lcec_ain_read_all(slave, slot->ain);
+    }
+    for (int ch = 0; ch < slot->enc_count; ch++) {
+      class_enc_update(&slot->enc[ch], 0, 1.0, EC_READ_U32(&pd[slot->enc_pos_os[ch]]), 0, 0);
+    }
+  }
+}
+
+static void lcec_leadshine_ec_write(lcec_slave_t *slave, long period) {
+  lcec_leadshine_ec_data_t *hal_data = (lcec_leadshine_ec_data_t *)slave->hal_data;
+
+  if (!slave->state.operational) {
+    return;
+  }
+
+  for (int i = 0; i < hal_data->slot_count; i++) {
+    leadshine_ec_slot_t *slot = &hal_data->slots[i];
+    if (slot->dout != NULL) {
+      lcec_dout_write_all(slave, slot->dout);
+    }
+    if (slot->aout != NULL) {
+      lcec_aout_write_all(slave, slot->aout);
+    }
+  }
+}

--- a/src/devices/lcec_leadshine_ec.h
+++ b/src/devices/lcec_leadshine_ec.h
@@ -1,0 +1,268 @@
+//
+//    Copyright (C) 2026 linuxcnc-ethercat contributors
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+/// @file
+/// @brief Driver for the Leadshine R2EC / R3EC EtherCAT bus couplers and
+/// their modular I/O sub-devices (issue #434).
+///
+/// The R2EC/R3EC is a single EtherCAT slave that hosts up to 32 (R2EC) or
+/// 64 (R3EC) modules on a passive backplane.  Each populated slot is
+/// described in the LinuxCNC XML config as a `<subModule>` (see the generic
+/// submodule support in lcec_conf.c / lcec_main.c):
+///
+///   <slave idx="0" type="R2EC" name="io">
+///     <subModule id="0" ident="0x61100025" name="in0">
+///       <modParam name="inputFilter0" value="20"/>
+///     </subModule>
+///     <subModule id="1" ident="0x61100205" name="out0">
+///       <modParam name="safeState" value="0"/>
+///     </subModule>
+///   </slave>
+///
+/// The coupler reports the modules it actually detects in 0xF050; the master
+/// mirrors the configured list into 0xF030 so the coupler accepts the PDO
+/// mapping at the SafeOp transition.
+///
+/// Addressing (per ESI / MDP conventions), for slot N (= `<subModule id>`):
+///   CoE objects : inputs 0x6000 + N*SLOT_INCR, outputs 0x7000 + N*SLOT_INCR
+///   PDOs        : TxPdo (in)  0x1A00 + N*PdoIncr
+///                 RxPdo (out) 0x1600 + N*PdoIncr
+///   SLOT_INCR is 0x10 for both couplers.  PdoIncr is 0x10 for R2EC and
+///   0x08 for R3EC (packed into the type's `flags`, see LEADSHINE_EC_FLAG).
+
+#ifndef _LCEC_LEADSHINE_EC_H_
+#define _LCEC_LEADSHINE_EC_H_
+
+#include <stdint.h>
+
+#include "../lcec.h"
+#include "lcec_class_ain.h"
+#include "lcec_class_aout.h"
+#include "lcec_class_din.h"
+#include "lcec_class_dout.h"
+#include "lcec_class_enc.h"
+
+// CoE objects the coupler exposes.
+#define LEADSHINE_EC_READMODULES 0xF050  // detected module ident list (read)
+#define LEADSHINE_EC_CONFMODULES 0xF030  // configured module ident list (written by us)
+#define LEADSHINE_EC_INOBJ       0x6000  // per-slot input object base
+#define LEADSHINE_EC_OUTOBJ      0x7000  // per-slot output object base
+#define LEADSHINE_EC_TXPDO       0x1A00  // per-slot input (Tx) PDO base
+#define LEADSHINE_EC_RXPDO       0x1600  // per-slot output (Rx) PDO base
+#define LEADSHINE_EC_SLOT_INCR   0x10    // CoE object index increment per slot
+
+// The coupler is a CoE device with mailbox sync managers, so process-data
+// PDOs live on SM2 (outputs) / SM3 (inputs).
+#define LEADSHINE_EC_SM_MBOX_OUT 0  // SM0: mailbox out (empty)
+#define LEADSHINE_EC_SM_MBOX_IN  1  // SM1: mailbox in (empty)
+#define LEADSHINE_EC_SM_OUT      2  // SM2: RxPDO / outputs
+#define LEADSHINE_EC_SM_IN       3  // SM3: TxPDO / inputs
+
+// SM PDO-assignment objects: 0x1C10 + SM index (0x1C12 = SM2, 0x1C13 = SM3).
+// Subindex 0 is the USINT count; subindices 1..N are UINT PDO indices.
+#define LEADSHINE_EC_SM_PDO_ASSIGN(sm) (0x1C10 + (sm))
+
+// Per-slot config object base (0x8000 + slot*SLOT_INCR) and the analog/temperature
+// diagnostic object base (0xA000).  All addresses below are taken from the R3EC
+// ESI (documentation/R3EC-v2.4.xml) and are DependOnSlot, i.e. base + slot*incr.
+#define LEADSHINE_EC_CFGOBJ  0x8000  // per-slot config object base
+#define LEADSHINE_EC_DIAGOBJ 0xA000  // analog/temp diagnostic (input) object base
+
+// Config-object subindices (per the ESI DT8000 layouts).
+#define LEADSHINE_EC_SUB_SAFESTATE_LO 1  // DO/relay: output state on link loss, bits 0-15  (UINT16)
+#define LEADSHINE_EC_SUB_SAFESTATE_HI 2  // DO 32-ch: output state on link loss, bits 16-31 (UINT16)
+#define LEADSHINE_EC_SUB_FILTER_BASE  3  // DI: input filter, subindices 3..6 per 8-channel group (UINT16)
+#define LEADSHINE_EC_SUB_ANALOG_BASE  1  // AIN/AOUT: per-channel range/mode config, sub 1..4 (USINT8)
+#define LEADSHINE_EC_SUB_ENC_MODE     1  // encoder: operation mode (USINT8)
+#define LEADSHINE_EC_SUB_ENC_ABPHASE  2  // encoder: AB phase (USINT8)
+#define LEADSHINE_EC_SUB_ENC_MIN      4  // encoder: minimum value (DINT32)
+#define LEADSHINE_EC_SUB_ENC_MAX      5  // encoder: maximum value (DINT32)
+#define LEADSHINE_EC_SUB_ENC_COUNTMODE 8  // encoder: count mode (USINT8)
+#define LEADSHINE_EC_SUB_ENC_FILTER    9  // encoder: input filter (UINT16)
+
+/// @brief Pack per-type geometry into the typelist `flags` field.
+/// @param max_slots Number of backplane slots the coupler supports.
+/// @param pdo_incr  PDO index increment per slot (0x10 R2EC, 0x08 R3EC).
+#define LEADSHINE_EC_FLAG(max_slots, pdo_incr) (((uint64_t)(max_slots) & 0xff) | (((uint64_t)(pdo_incr) & 0xff) << 8))
+#define LEADSHINE_EC_MAX_SLOTS(f)              ((int)((f) & 0xff))
+#define LEADSHINE_EC_PDO_INCR(f)               ((int)(((f) >> 8) & 0xff))
+
+/// @brief Kind of module in a slot; selects the PDO shape and HAL class.
+typedef enum {
+  MODULE_UNKNOWN = 0,
+  MODULE_DIN,      // digital input
+  MODULE_DOUT,     // digital output (incl. relay)
+  MODULE_DIO,      // mixed digital input + output
+  MODULE_AIN,      // analog input
+  MODULE_AOUT,     // analog output
+  MODULE_ENCODER,  // encoder
+} leadshine_ec_modkind_t;
+
+/// @brief Static description of a supported module type.
+///
+/// `in` / `out` are the channel counts (digital: bits; analog/encoder:
+/// channels).  This single table is the source of truth: the driver builds
+/// the `lcec_submodule_desc_t[]` (attached to `types[].modules`) from it at
+/// load time, so the XML parser can validate `<subModule ident=...>` and its
+/// child `<modParam>`s.
+typedef struct {
+  uint32_t ident;                         // module ident (matches <subModule ident=...>)
+  const char *name;                       // module name (per ESI)
+  leadshine_ec_modkind_t type;            // module kind
+  uint8_t in;                             // input channel count
+  uint8_t out;                            // output channel count
+  const lcec_modparam_desc_t *modparams;  // modparams supported by this module type
+} leadshine_ec_module_def_t;
+
+/// @brief Runtime state for one populated backplane slot.
+///
+/// Only the class container(s) relevant to the module kind are allocated; the
+/// rest stay NULL.  Encoders don't use a class container (class_enc owns its
+/// own struct), so we keep an array plus per-channel position PDO offsets.
+typedef struct {
+  uint8_t id;                        // backplane slot (= <subModule id>)
+  uint32_t ident;                    // module ident
+  leadshine_ec_modkind_t type;       // module kind
+  lcec_class_din_channels_t *din;    // DIN / DIO inputs, or NULL
+  lcec_class_dout_channels_t *dout;  // DOUT / DIO outputs, or NULL
+  lcec_class_ain_channels_t *ain;    // AIN inputs, or NULL
+  lcec_class_aout_channels_t *aout;  // AOUT outputs, or NULL
+  int enc_count;                     // number of encoder channels
+  lcec_class_enc_data_t *enc;        // encoder channel array, or NULL
+  unsigned int *enc_pos_os;          // per-encoder position PDO offset, or NULL
+} leadshine_ec_slot_t;
+
+/// @brief Per-slave HAL data: one entry per configured `<subModule>`.
+typedef struct {
+  int slot_count;
+  leadshine_ec_slot_t *slots;
+} lcec_leadshine_ec_data_t;
+
+// Modparam ids.  These are the keys passed to lcec_submodule_modparam_get();
+// they are per-module-type, so the same numeric id may recur across the
+// digital/analog/encoder tables without conflict.
+#define LEADSHINE_EC_MP_SAFESTATE      1  // digital output safe value on link loss
+#define LEADSHINE_EC_MP_INPUTFILTER(g) (3 + (g))  // digital input filter, group g (0..3)
+#define LEADSHINE_EC_MP_ANALOG_CFG(ch) (2 + (ch))  // analog channel config, ch (0..3)
+#define LEADSHINE_EC_MP_ENC_MODE       2
+#define LEADSHINE_EC_MP_ENC_ABPHASE    3
+#define LEADSHINE_EC_MP_ENC_MINVALUE   4
+#define LEADSHINE_EC_MP_ENC_MAXVALUE   5
+#define LEADSHINE_EC_MP_ENC_COUNTMODE  6
+#define LEADSHINE_EC_MP_ENC_FILTER     7
+
+static const lcec_modparam_desc_t leadshine_ec_digital_params[] = {
+    {"safeState", LEADSHINE_EC_MP_SAFESTATE, MODPARAM_TYPE_U32, "0", "Output value when link is lost (0 = all off)"},
+    {"inputFilter0", LEADSHINE_EC_MP_INPUTFILTER(0), MODPARAM_TYPE_U32, "10", "Input filter time group 0 (channels 0-7), 0-255 ms"},
+    {"inputFilter1", LEADSHINE_EC_MP_INPUTFILTER(1), MODPARAM_TYPE_U32, "10", "Input filter time group 1 (channels 8-15), 0-255 ms"},
+    {"inputFilter2", LEADSHINE_EC_MP_INPUTFILTER(2), MODPARAM_TYPE_U32, "10", "Input filter time group 2 (channels 16-23), 0-255 ms"},
+    {"inputFilter3", LEADSHINE_EC_MP_INPUTFILTER(3), MODPARAM_TYPE_U32, "10", "Input filter time group 3 (channels 24-31), 0-255 ms"},
+    {NULL},
+};
+
+static const lcec_modparam_desc_t leadshine_ec_analog_params[] = {
+    {"ch0Config", LEADSHINE_EC_MP_ANALOG_CFG(0), MODPARAM_TYPE_U32, "0", "Channel 0 configuration (AD/DA config)"},
+    {"ch1Config", LEADSHINE_EC_MP_ANALOG_CFG(1), MODPARAM_TYPE_U32, "0", "Channel 1 configuration (AD/DA config)"},
+    {"ch2Config", LEADSHINE_EC_MP_ANALOG_CFG(2), MODPARAM_TYPE_U32, "0", "Channel 2 configuration (AD/DA config)"},
+    {"ch3Config", LEADSHINE_EC_MP_ANALOG_CFG(3), MODPARAM_TYPE_U32, "0", "Channel 3 configuration (AD/DA config)"},
+    {NULL},
+};
+
+static const lcec_modparam_desc_t leadshine_ec_encoder_params[] = {
+    {"encoderMode", LEADSHINE_EC_MP_ENC_MODE, MODPARAM_TYPE_U32, "0", "Encoder operation mode"},
+    {"abPhase", LEADSHINE_EC_MP_ENC_ABPHASE, MODPARAM_TYPE_U32, "0", "AB phase configuration"},
+    {"minValue", LEADSHINE_EC_MP_ENC_MINVALUE, MODPARAM_TYPE_S32, "-100000", "Minimum encoder value"},
+    {"maxValue", LEADSHINE_EC_MP_ENC_MAXVALUE, MODPARAM_TYPE_S32, "100000", "Maximum encoder value"},
+    {"countMode", LEADSHINE_EC_MP_ENC_COUNTMODE, MODPARAM_TYPE_U32, "0", "Counting mode"},
+    {"encoderFilter", LEADSHINE_EC_MP_ENC_FILTER, MODPARAM_TYPE_U32, "2", "Encoder input filter"},
+    {NULL},
+};
+
+/// @brief The one supported-module table (source of truth for `types[].modules`).
+static const leadshine_ec_module_def_t leadshine_ec_module_table[] = {
+    // ---- Digital input ----
+    {0x61100025, "PM-1600", MODULE_DIN, 16, 0, leadshine_ec_digital_params},
+    {0x61100026, "R3-1600-V20", MODULE_DIN, 16, 0, leadshine_ec_digital_params},
+    {0x81100025, "R3-1600", MODULE_DIN, 16, 0, leadshine_ec_digital_params},
+    {0x61100045, "PM-3200", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x61100046, "R3-3200-V20", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x61101045, "PM-3200-1", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x61101046, "R3-3200-1-V20", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x61102045, "PM-3200-2", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x61102046, "R3-3200-2-V20", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x81100045, "R3-3200", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x81101045, "R3-3200-1", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+    {0x81102045, "R3-3200-2", MODULE_DIN, 32, 0, leadshine_ec_digital_params},
+
+    // ---- Digital output (incl. relay) ----
+    {0x61100205, "PM-0016-N", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x61100206, "R3-0016-N-V20", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x81100205, "R3-0016-N", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x61110205, "PM-0016-P", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x61110206, "R3-0016-P-V20", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x81110205, "R3-0016-P", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x61100405, "PM-0032-N", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61100406, "R3-0032-N-V20", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61101405, "PM-0032-N-1", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61101406, "R3-0032-N-1-V20", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61102405, "PM-0032-N-2", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61102406, "R3-0032-N-2-V20", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x81100405, "R3-0032-N", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x81101405, "R3-0032-N-1", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x81102405, "R3-0032-N-2", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61110406, "R3-0032-P-V20", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x81110405, "R3-0032-P", MODULE_DOUT, 0, 32, leadshine_ec_digital_params},
+    {0x61900106, "R3-0008-R-V20", MODULE_DOUT, 0, 8, leadshine_ec_digital_params},
+    {0x81900105, "R3-0008-R", MODULE_DOUT, 0, 8, leadshine_ec_digital_params},
+    {0x61900205, "PM-0016-R", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x61900206, "R3-0016-R-V20", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+    {0x81900205, "R3-0016-R", MODULE_DOUT, 0, 16, leadshine_ec_digital_params},
+
+    // ---- Mixed digital input + output ----
+    {0x61100116, "R3-0808-N-V20", MODULE_DIO, 8, 8, leadshine_ec_digital_params},
+    {0x81100115, "R3-0808-N", MODULE_DIO, 8, 8, leadshine_ec_digital_params},
+    {0x61100225, "PM-1616-N", MODULE_DIO, 16, 16, leadshine_ec_digital_params},
+    {0x61100226, "R3-1616-N-V20", MODULE_DIO, 16, 16, leadshine_ec_digital_params},
+    {0x81100225, "R3-1616-N", MODULE_DIO, 16, 16, leadshine_ec_digital_params},
+    {0x61110226, "R3-1616-P-V20", MODULE_DIO, 16, 16, leadshine_ec_digital_params},
+    {0x81110225, "R3-1616-P", MODULE_DIO, 16, 16, leadshine_ec_digital_params},
+    {0x61101446, "R3-3232-N-1-V20", MODULE_DIO, 32, 32, leadshine_ec_digital_params},
+    {0x81101445, "R3-3232-N-1", MODULE_DIO, 32, 32, leadshine_ec_digital_params},
+
+    // ---- Analog input ----
+    {0x61000025, "PM-A0400-IV", MODULE_AIN, 4, 0, leadshine_ec_analog_params},
+    {0x61000026, "R3-A0400-IV-V20", MODULE_AIN, 4, 0, leadshine_ec_analog_params},
+    {0x81000025, "R3-A0400-IV", MODULE_AIN, 4, 0, leadshine_ec_analog_params},
+
+    // ---- Analog output ----
+    {0x61000205, "PM-A0004-IV", MODULE_AOUT, 0, 4, leadshine_ec_analog_params},
+    {0x61000206, "R3-A0004-IV-V20", MODULE_AOUT, 0, 4, leadshine_ec_analog_params},
+    {0x81000205, "R3-A0004-IV", MODULE_AOUT, 0, 4, leadshine_ec_analog_params},
+
+    // ---- Encoder ----
+    {0x61300025, "PM-E0200-S", MODULE_ENCODER, 2, 0, leadshine_ec_encoder_params},
+    {0x61300026, "R3-E0200-S-V20", MODULE_ENCODER, 2, 0, leadshine_ec_encoder_params},
+    {0x61300125, "PM-E0200-D", MODULE_ENCODER, 2, 0, leadshine_ec_encoder_params},
+    {0x61300126, "R3-E0200-D-V20", MODULE_ENCODER, 2, 0, leadshine_ec_encoder_params},
+    {0x81300025, "R3-E0200-S", MODULE_ENCODER, 2, 0, leadshine_ec_encoder_params},
+    {0x81300125, "R3-E0200-D", MODULE_ENCODER, 2, 0, leadshine_ec_encoder_params},
+
+    {0, NULL, MODULE_UNKNOWN, 0, 0, NULL},
+};
+
+#endif

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -69,6 +69,7 @@ extern "C" {
 #define LCEC_MODUSOFT_VID   0x00000907
 #define LCEC_LICHUAN_VID    0x00000a79
 #define LCEC_RTELLIGENT_VID 0x00000a88
+#define LCEC_LEADSHINE_VID  0x00004321
 
 // State update period (ns)
 #define LCEC_STATE_UPDATE_PERIOD 1000000000LL
@@ -147,6 +148,18 @@ typedef struct {
   const char *config_comment;  ///< A comment to added to the output in lcec_configgen.
 } lcec_modparam_doc_t;
 
+/// @brief Definition of a submodule type supported by a modular device.
+///
+/// A modular coupler (e.g. a bus coupler with a backplane) exposes a
+/// NULL-terminated array of these via `lcec_typelist_t.modules`.  The XML
+/// parser uses it to validate `<subModule ident="...">` and its child
+/// `<modParam>` entries.
+typedef struct {
+  const char *name;                       /// name of the module as per ESI file
+  uint32_t ident;                         /// ident of the module as per ESI file, matched against <subModule ident=...>
+  const lcec_modparam_desc_t *modparams;  /// modparams supported by this submodule type (may be NULL)
+} lcec_submodule_desc_t;
+
 /// @brief Definition of a device that LinuxCNC-Ethercat supports.
 typedef struct {
   const char *name;                       ///< The device's name ("EL1008")
@@ -158,6 +171,7 @@ typedef struct {
   const lcec_modparam_desc_t *modparams;  ///< XML modparams, if any
   uint64_t flags;                         ///< Flags, passed through to `proc_init` as `slave->flags`.
   const char *sourcefile;                 ///< Source filename, autopopulated.
+  const lcec_submodule_desc_t *modules;   /// XXX: added slave submodule or channels*(could be implemented later)
 } lcec_typelist_t;
 
 /// @brief Linked list for holding device type definitions.
@@ -187,22 +201,22 @@ typedef struct lcec_master_data {
   hal_u32_t pll_max_err;
   hal_u32_t *pll_reset_cnt;
   hal_u32_t dc_phase_max_err;
-  hal_s32_t *app_phase;            // Our execution phase in local cycle (ns, real-time)
-  hal_bit_t *dc_phased;           // PLL lock status indicator
-  hal_s32_t *phase_jitter_out;     // Output: measured app_phase jitter amplitude (ns)
-  hal_s32_t *drift_mode;            // Input: 0=simple, 1=manual
-  hal_s32_t *pll_drift;            // Input: debug offset added to PLL correction (ns)
-  hal_s32_t *pll_final;            // Output: final PLL correction value sent to rtapi (ns)
-  int32_t auto_drift_delay;        // Internal: auto-drift delay counter
+  hal_s32_t *app_phase;         // Our execution phase in local cycle (ns, real-time)
+  hal_bit_t *dc_phased;         // PLL lock status indicator
+  hal_s32_t *phase_jitter_out;  // Output: measured app_phase jitter amplitude (ns)
+  hal_s32_t *drift_mode;        // Input: 0=simple, 1=manual
+  hal_s32_t *pll_drift;         // Input: debug offset added to PLL correction (ns)
+  hal_s32_t *pll_final;         // Output: final PLL correction value sent to rtapi (ns)
+  int32_t auto_drift_delay;     // Internal: auto-drift delay counter
 #endif
   // Phase calibration for sync_to_ref_clock=false mode
-  int32_t phase_measure_cnt;       // Internal: measurement cycle counter
-  int32_t phase_min;               // Internal: minimum app_phase during measurement
-  int32_t phase_max;               // Internal: maximum app_phase during measurement
-  int32_t phase_last;              // Internal: last app_phase value (for boundary detection)
-  int32_t phase_jitter;            // Internal: calculated jitter amplitude
-  int32_t phase_target;            // Internal: target app_phase position
-  int32_t phase_calibrated;        // Internal: 0=measuring, 1=calibrated
+  int32_t phase_measure_cnt;  // Internal: measurement cycle counter
+  int32_t phase_min;          // Internal: minimum app_phase during measurement
+  int32_t phase_max;          // Internal: maximum app_phase during measurement
+  int32_t phase_last;         // Internal: last app_phase value (for boundary detection)
+  int32_t phase_jitter;       // Internal: calculated jitter amplitude
+  int32_t phase_target;       // Internal: target app_phase position
+  int32_t phase_calibrated;   // Internal: 0=measuring, 1=calibrated
 } lcec_master_data_t;
 
 typedef struct lcec_slave_state {
@@ -236,14 +250,15 @@ typedef struct lcec_master {
   int sync_to_ref_clock;
   long long state_update_timer;
   ec_master_state_t ms;
-  int activated;                    // Flag: master has been activated (0=not yet, 1=activated)
-  int initf_activated;              // Flag: activation happened via initf path (clean RT-context); when set, BANG-BANG PLL trim is skipped because app_phase was born stable
-  int forgot_warned;                // One-shot guard for the "user forgot initf lcec.activate" warning in lcec_write_master
+  int activated;        // Flag: master has been activated (0=not yet, 1=activated)
+  int initf_activated;  // Flag: activation happened via initf path (clean RT-context); when set, BANG-BANG PLL trim is skipped because
+                        // app_phase was born stable
+  int forgot_warned;    // One-shot guard for the "user forgot initf lcec.activate" warning in lcec_write_master
 #ifdef RTAPI_TASK_PLL_SUPPORT
   uint64_t dc_ref;
-  uint64_t dc_ref_time;          // DC reference time (epoch) - set on first app_time call
+  uint64_t dc_ref_time;  // DC reference time (epoch) - set on first app_time call
   uint32_t app_time_last;
-  int dc_time_valid_last;         // Previous cycle's dc_time_valid (for detecting consecutive valid reads)
+  int dc_time_valid_last;  // Previous cycle's dc_time_valid (for detecting consecutive valid reads)
 #endif
 } lcec_master_t;
 
@@ -292,6 +307,15 @@ typedef struct {
   LCEC_CONF_MODPARAM_VAL_T value;  /// The value set in `<modparam name="..." value="..."/>`
 } lcec_slave_modparam_t;
 
+/// @brief A submodule configured on a modular slave, reconstructed from `<subModule>`.
+typedef struct lcec_slave_submodule {
+  struct lcec_slave_submodule *next;  /// Next submodule on the same slave, or NULL.
+  uint8_t id;                         /// Slot id from `<subModule id="...">`.
+  uint32_t ident;                     /// Module ident from `<subModule ident="...">`.
+  char name[LCEC_CONF_STR_MAXLEN];    /// Name from `<subModule name="...">`.
+  lcec_slave_modparam_t *modparams;   /// This submodule's modparams, id=-1 terminated (NULL if none).
+} lcec_slave_submodule_t;
+
 /// @brief EtherCAT slave.
 typedef struct lcec_slave {
   lcec_slave_t *prev;                        ///< Next slave
@@ -320,6 +344,8 @@ typedef struct lcec_slave {
   lcec_slave_sdoconf_t *sdo_config;          ///< SDO config.
   lcec_slave_idnconf_t *idn_config;          ///< IDN config.
   lcec_slave_modparam_t *modparams;          ///< modParams.
+  lcec_slave_submodule_t *submodules;        ///<  XXX: submodule implementation
+                                             ///
   const LCEC_CONF_FSOE_T *fsoeConf;          ///< Safety config.
   int is_fsoe_logic;                         ///< Device supports FSoE safety logic.
   unsigned int *fsoe_slave_offset;           ///< FSoE slave offset.
@@ -431,5 +457,17 @@ int lcec_append_pdo_entry_reg(lcec_pdo_entry_reg_t *dest, lcec_pdo_entry_reg_t *
 
 void *lcec_hal_malloc(size_t size, const char *file, const char *func, int line);
 void *lcec_malloc(size_t size, const char *file, const char *func, int line);
+
+/// @brief Find a configured submodule on a slave by its slot id.
+/// @param[in] slave the slave (modular coupler) to search.
+/// @param[in] id    the slot id from <submodule id="...">.
+/// @returns a pointer to the matching submodule, or NULL if not found.
+lcec_slave_submodule_t *lcec_submodule_find(lcec_slave_t *slave, uint8_t id);
+
+/// @brief Get a modparam value from a submodule by its numeric id.
+/// @param[in] submodule the submodule to search (e.g. from lcec_submodule_find).
+/// @param[in] id        the modparam id from the submodule type's lcec_modparam_desc_t.
+/// @returns a pointer to the value union, or NULL if that modparam was not set.
+LCEC_CONF_MODPARAM_VAL_T *lcec_submodule_modparam_get(lcec_slave_submodule_t *submodule, int id);
 
 #endif

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -52,6 +52,8 @@ typedef struct {
   LCEC_CONF_MASTER_T *currMaster;
   const lcec_typelist_t *currSlaveType;
   LCEC_CONF_SLAVE_T *currSlave;
+  LCEC_CONF_SUBMODULE_T *currSubModule;            // current <subModule> being parsed, or NULL
+  const lcec_submodule_desc_t *currSubModuleType;  // matched entry in currSlaveType->modules, or NULL
   LCEC_CONF_SYNCMANAGER_T *currSyncManager;
   LCEC_CONF_PDO_T *currPdo;
   LCEC_CONF_SDOCONF_T *currSdoConf;
@@ -76,23 +78,31 @@ static void parsePdoEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
 static void parseComplexEntryAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr);
 static void parseModParamAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr);
 
+/// XXX: submodule implementation
+static void parseSubModuleAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr);
+static void endSubModule(LCEC_CONF_XML_INST_T *inst, int next);
+
 static const LCEC_CONF_XML_HANLDER_T xml_states[] = {
-    {"masters", lcecConfTypeNone, lcecConfTypeMasters, NULL, NULL},
-    {"master", lcecConfTypeMasters, lcecConfTypeMaster, parseMasterAttrs, NULL},
-    {"slave", lcecConfTypeMaster, lcecConfTypeSlave, parseSlaveAttrs, NULL},
-    {"dcConf", lcecConfTypeSlave, lcecConfTypeDcConf, parseDcConfAttrs, NULL},
-    {"watchdog", lcecConfTypeSlave, lcecConfTypeWatchdog, parseWatchdogAttrs, NULL},
-    {"sdoConfig", lcecConfTypeSlave, lcecConfTypeSdoConfig, parseSdoConfigAttrs, NULL},
-    {"sdoDataRaw", lcecConfTypeSdoConfig, lcecConfTypeSdoDataRaw, parseDataRawAttrs, NULL},
-    {"idnConfig", lcecConfTypeSlave, lcecConfTypeIdnConfig, parseIdnConfigAttrs, NULL},
-    {"idnDataRaw", lcecConfTypeIdnConfig, lcecConfTypeIdnDataRaw, parseDataRawAttrs, NULL},
-    {"initCmds", lcecConfTypeSlave, lcecConfTypeInitCmds, parseInitCmdsAttrs, NULL},
-    {"syncManager", lcecConfTypeSlave, lcecConfTypeSyncManager, parseSyncManagerAttrs, NULL},
-    {"pdo", lcecConfTypeSyncManager, lcecConfTypePdo, parsePdoAttrs, NULL},
-    {"pdoEntry", lcecConfTypePdo, lcecConfTypePdoEntry, parsePdoEntryAttrs, NULL},
-    {"complexEntry", lcecConfTypePdoEntry, lcecConfTypeComplexEntry, parseComplexEntryAttrs, NULL},
-    {"modParam", lcecConfTypeSlave, lcecConfTypeModParam, parseModParamAttrs, NULL},
-    {"NULL", -1, -1, NULL, NULL},
+    {"masters",      lcecConfTypeNone,        lcecConfTypeMasters,      NULL,                   NULL},
+    {"master",       lcecConfTypeMasters,     lcecConfTypeMaster,       parseMasterAttrs,       NULL},
+    {"slave",        lcecConfTypeMaster,      lcecConfTypeSlave,        parseSlaveAttrs,        NULL},
+    {"dcConf",       lcecConfTypeSlave,       lcecConfTypeDcConf,       parseDcConfAttrs,       NULL},
+    {"watchdog",     lcecConfTypeSlave,       lcecConfTypeWatchdog,     parseWatchdogAttrs,     NULL},
+    {"sdoConfig",    lcecConfTypeSlave,       lcecConfTypeSdoConfig,    parseSdoConfigAttrs,    NULL},
+    {"sdoDataRaw",   lcecConfTypeSdoConfig,   lcecConfTypeSdoDataRaw,   parseDataRawAttrs,      NULL},
+    {"idnConfig",    lcecConfTypeSlave,       lcecConfTypeIdnConfig,    parseIdnConfigAttrs,    NULL},
+    {"idnDataRaw",   lcecConfTypeIdnConfig,   lcecConfTypeIdnDataRaw,   parseDataRawAttrs,      NULL},
+    {"initCmds",     lcecConfTypeSlave,       lcecConfTypeInitCmds,     parseInitCmdsAttrs,     NULL},
+    {"syncManager",  lcecConfTypeSlave,       lcecConfTypeSyncManager,  parseSyncManagerAttrs,  NULL},
+    {"pdo",          lcecConfTypeSyncManager, lcecConfTypePdo,          parsePdoAttrs,          NULL},
+    {"pdoEntry",     lcecConfTypePdo,         lcecConfTypePdoEntry,     parsePdoEntryAttrs,     NULL},
+    {"complexEntry", lcecConfTypePdoEntry,    lcecConfTypeComplexEntry, parseComplexEntryAttrs, NULL},
+    {"modParam",     lcecConfTypeSlave,       lcecConfTypeModParam,     parseModParamAttrs,     NULL},
+    /// XXX: submodule implementation
+    {"subModule",    lcecConfTypeSlave,       lcecConfTypeSubModule,         parseSubModuleAttrs, endSubModule},
+    {"modParam",     lcecConfTypeSubModule,   lcecConfTypeSubModuleModParam, parseModParamAttrs,  NULL},
+    ///
+    {"NULL",         -1,                      -1,                       NULL,                   NULL},
 };
 
 static int parseSyncCycle(LCEC_CONF_XML_STATE_T *state, const char *nptr);
@@ -295,10 +305,10 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
 
     // parse syncToRefClock
     if (strcmp(name, "syncToRefClock") == 0) {
-      p->syncToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1; // -1 = Need to know if option was given
-      continue; // TODO: A general function that can handle four states: yes, no, not given, wrong. Recognize yes/on/true/1/enabled as true
+      p->syncToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1;  // -1 = Need to know if option was given
+      continue;  // TODO: A general function that can handle four states: yes, no, not given, wrong. Recognize yes/on/true/1/enabled as true
     }
- 
+
     // handle error
     fprintf(stderr, "%s: ERROR: Invalid master attribute %s\n", modname, name);
     XML_StopParser(inst->parser, 0);
@@ -317,8 +327,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
   int given_cycles = p->refClockSyncCycles;
 
   if (given_cycles < -1) {
-    fprintf(stderr, "%s: ERROR: refClockSyncCycles=%d invalid, only -1, 0, or positive values allowed\n",
-        modname, given_cycles);
+    fprintf(stderr, "%s: ERROR: refClockSyncCycles=%d invalid, only -1, 0, or positive values allowed\n", modname, given_cycles);
     XML_StopParser(inst->parser, 0);
     return;
   }
@@ -333,8 +342,8 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
       fprintf(stderr, "%s: WARNING: syncToRefClock=\"true\" with refClockSyncCycles=%d is redundant, just use refClockSyncCycles=\"-1\"\n",
           modname, given_cycles);
     } else if (given_cycles > 0) {
-      fprintf(stderr, "%s: ERROR: syncToRefClock=\"true\" conflicts with refClockSyncCycles=%d (positive = R2M mode)\n",
-          modname, given_cycles);
+      fprintf(
+          stderr, "%s: ERROR: syncToRefClock=\"true\" conflicts with refClockSyncCycles=%d (positive = R2M mode)\n", modname, given_cycles);
       XML_StopParser(inst->parser, 0);
       return;
     }
@@ -344,8 +353,8 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
   } else {
     // syncToRefClock="false"
     if (given_cycles < 0) {
-      fprintf(stderr, "%s: ERROR: syncToRefClock=\"false\" conflicts with refClockSyncCycles=%d (negative = M2R mode)\n",
-          modname, given_cycles);
+      fprintf(stderr, "%s: ERROR: syncToRefClock=\"false\" conflicts with refClockSyncCycles=%d (negative = M2R mode)\n", modname,
+          given_cycles);
       XML_StopParser(inst->parser, 0);
       return;
     }
@@ -356,7 +365,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
     p->syncToRefClock = 0;
     // refClockSyncCycles already >= 0, keep as-is
   }
-  
+
   // set default name
   if (p->name[0] == 0) {
     snprintf(p->name, LCEC_CONF_STR_MAXLEN, "%d", p->index);
@@ -471,6 +480,8 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
   (*(conf_hal_data->slave_count))++;
   state->currSlaveType = slaveType;
   state->currSlave = p;
+  state->currSubModule = NULL;
+  state->currSubModuleType = NULL;
 }
 
 static void parseDcConfAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
@@ -1247,10 +1258,23 @@ static void parseModParamAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
   const char *pname, *pval;
   const lcec_modparam_desc_t *modparams;
 
-  if (state->currSlaveType->modparams == NULL) {
-    fprintf(stderr, "%s: ERROR: modparam not allowed for this slave\n", modname);
-    XML_StopParser(inst->parser, 0);
-    return;
+  // Select the modparam descriptor list to validate against: when inside a
+  // <subModule>, use that submodule type's modparams; otherwise the slave's.
+  const lcec_modparam_desc_t *allowed;
+  if (state->currSubModule != NULL) {
+    allowed = state->currSubModuleType->modparams;
+    if (allowed == NULL) {
+      fprintf(stderr, "%s: ERROR: modparam not allowed for this submodule\n", modname);
+      XML_StopParser(inst->parser, 0);
+      return;
+    }
+  } else {
+    allowed = state->currSlaveType->modparams;
+    if (allowed == NULL) {
+      fprintf(stderr, "%s: ERROR: modparam not allowed for this slave\n", modname);
+      XML_StopParser(inst->parser, 0);
+      return;
+    }
   }
 
   LCEC_CONF_MODPARAM_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_MODPARAM_T);
@@ -1300,7 +1324,7 @@ static void parseModParamAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
   }
 
   // search for matching param name
-  for (modparams = state->currSlaveType->modparams; modparams->name != NULL; modparams++) {
+  for (modparams = allowed; modparams->name != NULL; modparams++) {
     if (strcmp(pname, modparams->name) == 0) {
       break;
     }
@@ -1368,7 +1392,115 @@ static void parseModParamAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char 
       break;
   }
 
-  (state->currSlave->modParamCount)++;
+  // count the modparam against its owner: the submodule if we are inside one,
+  // otherwise the slave.  This keeps slave->modParamCount meaning "slave-level
+  // modparams only" so the runtime allocation stays correct.
+  if (state->currSubModule != NULL) {
+    (state->currSubModule->modParamCount)++;
+  } else {
+    (state->currSlave->modParamCount)++;
+  }
+}
+
+static void parseSubModuleAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
+  LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
+  const lcec_submodule_desc_t *modules;
+  char *s;
+
+  // the slave type must declare submodule support
+  if (state->currSlaveType->modules == NULL) {
+    fprintf(stderr, "%s: ERROR: subModule not supported by slave type '%s'\n", modname, state->currSlaveType->name);
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  LCEC_CONF_SUBMODULE_T *p = ADD_OUTPUT_BUFFER(&state->outputBuf, LCEC_CONF_SUBMODULE_T);
+  if (p == NULL) {
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  p->confType = lcecConfTypeSubModule;
+  p->modParamCount = 0;
+
+  int have_ident = 0;
+  while (*attr) {
+    const char *name = *(attr++);
+    const char *val = *(attr++);
+
+    // parse slot id
+    if (strcmp(name, "id") == 0) {
+      s = NULL;
+      unsigned long id = strtoul(val, &s, 0);
+      if (*s != 0 || id > 0xff) {
+        fprintf(stderr, "%s: ERROR: Invalid subModule id '%s'\n", modname, val);
+        XML_StopParser(inst->parser, 0);
+        return;
+      }
+      p->id = (uint8_t)id;
+      continue;
+    }
+
+    // parse module ident
+    if (strcmp(name, "ident") == 0) {
+      s = NULL;
+      p->ident = (uint32_t)strtoul(val, &s, 0);
+      if (*s != 0) {
+        fprintf(stderr, "%s: ERROR: Invalid subModule ident '%s'\n", modname, val);
+        XML_StopParser(inst->parser, 0);
+        return;
+      }
+      have_ident = 1;
+      continue;
+    }
+
+    // parse name
+    if (strcmp(name, "name") == 0) {
+      strncpy(p->name, val, LCEC_CONF_STR_MAXLEN);
+      p->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+      continue;
+    }
+
+    // handle error
+    fprintf(stderr, "%s: ERROR: Invalid subModule attribute %s\n", modname, name);
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  // ident is required
+  if (!have_ident) {
+    fprintf(stderr, "%s: ERROR: subModule has no ident attribute\n", modname);
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  // the ident must be a module type the slave type knows about
+  for (modules = state->currSlaveType->modules; modules->name != NULL; modules++) {
+    if (modules->ident == p->ident) {
+      break;
+    }
+  }
+  if (modules->name == NULL) {
+    fprintf(stderr, "%s: ERROR: Unknown subModule ident 0x%08x for slave type '%s'\n", modname, p->ident, state->currSlaveType->name);
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  // set default name
+  if (p->name[0] == 0) {
+    snprintf(p->name, LCEC_CONF_STR_MAXLEN, "%d", p->id);
+  }
+
+  state->currSubModule = p;
+  state->currSubModuleType = modules;
+}
+
+static void endSubModule(LCEC_CONF_XML_INST_T *inst, int next) {
+  LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
+
+  // leaving the <subModule>: subsequent modparams belong to the slave again
+  state->currSubModule = NULL;
+  state->currSubModuleType = NULL;
 }
 
 static int parseSyncCycle(LCEC_CONF_XML_STATE_T *state, const char *nptr) {

--- a/src/lcec_conf.h
+++ b/src/lcec_conf.h
@@ -51,7 +51,9 @@ typedef enum {
   lcecConfTypeIdnDataRaw,
   lcecConfTypeInitCmds,
   lcecConfTypeComplexEntry,
-  lcecConfTypeModParam
+  lcecConfTypeModParam,
+  lcecConfTypeSubModule,          /// XXX: Submodule Implementation
+  lcecConfTypeSubModuleModParam,  /// Submodule Implementation
 } LCEC_CONF_TYPE_T;
 
 typedef enum {
@@ -166,6 +168,15 @@ typedef struct {
   size_t length;
   uint8_t data[];
 } LCEC_CONF_IDNCONF_T;
+
+/// XXX: submodule implementation
+typedef struct {
+  LCEC_CONF_TYPE_T confType;
+  uint8_t id;  // slot id
+  uint32_t ident;
+  unsigned int modParamCount;
+  char name[LCEC_CONF_STR_MAXLEN];
+} LCEC_CONF_SUBMODULE_T;
 
 typedef union {
   hal_bit_t bit;

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -409,6 +409,7 @@ int lcec_parse_config(void) {
   LCEC_CONF_SDOCONF_T *sdo_conf;
   LCEC_CONF_IDNCONF_T *idn_conf;
   LCEC_CONF_MODPARAM_T *modparam_conf;
+  LCEC_CONF_SUBMODULE_T *submodule_conf;
   ec_pdo_entry_info_t *generic_pdo_entries;
   ec_pdo_info_t *generic_pdos;
   ec_sync_info_t *generic_sync_managers;
@@ -417,6 +418,9 @@ int lcec_parse_config(void) {
   lcec_slave_sdoconf_t *sdo_config;
   lcec_slave_idnconf_t *idn_config;
   lcec_slave_modparam_t *modparams;
+  lcec_slave_submodule_t *submodule, *last_submodule;
+  lcec_slave_modparam_t *submodule_modparams;
+  int submodule_mp_remaining;
 
   // initialize list
   first_master = NULL;
@@ -469,6 +473,10 @@ int lcec_parse_config(void) {
   idn_config = NULL;
   pe_conf = NULL;
   modparams = NULL;
+  submodule = NULL;
+  last_submodule = NULL;
+  submodule_modparams = NULL;
+  submodule_mp_remaining = 0;
   while ((conf_type = ((LCEC_CONF_NULL_T *)conf)->confType) != lcecConfTypeNone) {
     // get type
     switch (conf_type) {
@@ -531,6 +539,10 @@ int lcec_parse_config(void) {
         sdo_config = NULL;
         idn_config = NULL;
         modparams = NULL;
+        submodule = NULL;
+        last_submodule = NULL;
+        submodule_modparams = NULL;
+        submodule_mp_remaining = 0;
 
         slave->index = slave_conf->index;
         strncpy(slave->name, slave_conf->name, LCEC_CONF_STR_MAXLEN);
@@ -618,11 +630,49 @@ int lcec_parse_config(void) {
         slave->sdo_config = sdo_config;
         slave->idn_config = idn_config;
         slave->modparams = modparams;
+        slave->submodules = NULL;
         slave->dc_conf = NULL;
         slave->wd_conf = NULL;
 
         // update slave count
         slave_count++;
+        break;
+
+      case lcecConfTypeSubModule:
+        // get config token
+        submodule_conf = (LCEC_CONF_SUBMODULE_T *)conf;
+        conf += sizeof(LCEC_CONF_SUBMODULE_T);
+
+        // check for slave
+        if (slave == NULL) {
+          rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "Slave node for submodule config missing\n");
+          goto fail2;
+        }
+
+        // create new submodule
+        submodule = LCEC_ALLOCATE(lcec_slave_submodule_t);
+        submodule->next = NULL;
+        submodule->id = submodule_conf->id;
+        submodule->ident = submodule_conf->ident;
+        strncpy(submodule->name, submodule_conf->name, LCEC_CONF_STR_MAXLEN);
+        submodule->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+
+        // alloc this submodule's modparam array (id=-1 terminated)
+        submodule_modparams = NULL;
+        submodule_mp_remaining = submodule_conf->modParamCount;
+        if (submodule_conf->modParamCount > 0) {
+          submodule_modparams = LCEC_ALLOCATE_ARRAY(lcec_slave_modparam_t, (submodule_conf->modParamCount + 1));
+          submodule_modparams[submodule_conf->modParamCount].id = -1;
+        }
+        submodule->modparams = submodule_modparams;
+
+        // append to the slave's submodule list, preserving XML order
+        if (last_submodule == NULL) {
+          slave->submodules = submodule;
+        } else {
+          last_submodule->next = submodule;
+        }
+        last_submodule = submodule;
         break;
 
       case lcecConfTypeDcConf:
@@ -887,18 +937,39 @@ int lcec_parse_config(void) {
           goto fail2;
         }
 
-        if (modparams == NULL) {
-          rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "modparams is nullg\n");
-          goto fail2;
+        // Route to the current submodule while it still has unfilled slots,
+        // otherwise to the slave.  A submodule's modparams are serialized
+        // directly after its <subModule> record, so consuming exactly
+        // modParamCount of them correctly attributes any slave-level modparams
+        // that appear before or after a <subModule>.
+        if (submodule != NULL && submodule_mp_remaining > 0) {
+          if (submodule_modparams == NULL) {
+            rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "submodule modparams is null\n");
+            goto fail2;
+          }
+
+          // copy attributes
+          submodule_modparams->id = modparam_conf->id;
+          submodule_modparams->value = modparam_conf->value;
+          submodule_modparams->name = modparam_conf->name;
+
+          // next entry
+          submodule_modparams++;
+          submodule_mp_remaining--;
+        } else {
+          if (modparams == NULL) {
+            rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "modparams is null\n");
+            goto fail2;
+          }
+
+          // copy attributes
+          modparams->id = modparam_conf->id;
+          modparams->value = modparam_conf->value;
+          modparams->name = modparam_conf->name;
+
+          // next entry
+          modparams++;
         }
-
-        // copy attributes
-        modparams->id = modparam_conf->id;
-        modparams->value = modparam_conf->value;
-        modparams->name = modparam_conf->name;
-
-        // next entry
-        modparams++;
         break;
 
       default:

--- a/src/lcec_modparam.c
+++ b/src/lcec_modparam.c
@@ -103,3 +103,33 @@ lcec_modparam_desc_t *lcec_modparam_desc_merge_docs(lcec_modparam_desc_t const *
 
   return c;
 }
+
+/// @brief Find a configured submodule on a slave by its slot id.
+lcec_slave_submodule_t *lcec_submodule_find(lcec_slave_t *slave, uint8_t id) {
+  lcec_slave_submodule_t *s;
+
+  for (s = slave->submodules; s != NULL; s = s->next) {
+    if (s->id == id) {
+      return s;
+    }
+  }
+
+  return NULL;
+}
+
+/// @brief Get a modparam value from a submodule by its numeric id.
+LCEC_CONF_MODPARAM_VAL_T *lcec_submodule_modparam_get(lcec_slave_submodule_t *submodule, int id) {
+  lcec_slave_modparam_t *p;
+
+  if (submodule == NULL || submodule->modparams == NULL) {
+    return NULL;
+  }
+
+  for (p = submodule->modparams; p->id >= 0; p++) {
+    if (p->id == id) {
+      return &p->value;
+    }
+  }
+
+  return NULL;
+}


### PR DESCRIPTION
## Add `<subModule>` XML support and a Leadshine R2EC/R3EC modular coupler driver

## Summary

Building upon the work of https://github.com/linuxcnc-ethercat/linuxcnc-ethercat/pull/479 . I have decided to take a modular approach based on the working of the EtherCAT coupler. From my understanding of https://github.com/linuxcnc-ethercat/linuxcnc-ethercat/issues/434 , many other i/o couplers use the same method of operation as the leadshine coupler. so this PR adds the following:

1. **`<subModule>` support in the XML config layer** — a reusable way to describe a single EtherCAT slave that hosts multiple independently-configured sub-devices (modular bus couplers).
2. **Leadshine R2EC/R3EC Coupler driver**: currently only supporting digital io / analog io / encoder modules.

## Motivation

The Leadshine R2EC/R3EC is one EtherCAT slave that carries up to 32 (R2EC) / 64 (R3EC) I/O modules on a passive backplane. There was no way to express "a slave with N sub-modules, each with its own settings" in the config, so I added a `<subModule>` element (with nested `<modParam>`s) inside `<slave>`.

## What's new in the config layer

- A `<slave>` may now contain `<subModule id="..." ident="..." name="...">` elements, each of which may contain its own `<modParam>` tags.
- The parser validates everything against the device driver:
  - `<subModule>` is rejected for slave types that aren't modular,
  - an unknown `ident` is rejected,
  - a `<modParam>` is validated against **that submodule type's** parameter list (not the coupler's).
- A device declares support with a single table on its typelist (`lcec_typelist_t.modules`), mirroring how `modparams` already works.
- At runtime the config is reconstructed into a `slave->submodules` linked list, and drivers read values with two new helpers, `lcec_submodule_find()` and `lcec_submodule_modparam_get()`.

This is **fully additive / non-breaking**: new enum values and struct fields are appended, and existing configs (no `<subModule>`) parse and run exactly as before.

## The Leadshine driver

- Registers `R2EC` and `R3EC`, auto-building the submodule table from a single module table (one source of truth).
- Walks the configured slots and builds a **dynamic PDO / sync-manager layout**, exports per-slot HAL pins via the existing `lcec_class_din/dout/ain/aout` + `class_enc` helpers, and applies each module's `<modParam>`s over SDO.
- Writes the configured module ident list (`0xF030`) and performs an explicit SM PDO assignment (`0x1C12`/`0x1C13`), which this coupler needs for its inputs to come up.
- All CoE/PDO addresses are taken from the R3EC ESI.

## Usage

Each populated backplane slot is a `<subModule>`. `id` is the slot (0-based), `ident` is the module type, `name` is used for HAL pin names.

**Digital I/O:**
```xml
<slave idx="0" type="R2EC" name="io">
  <subModule id="0" ident="0x61100025" name="in0">   <!-- 16-ch DI -->
    <modParam name="inputFilter0" value="20"/>       <!-- filter for ch 0-7, ms -->
    <modParam name="inputFilter1" value="20"/>       <!-- filter for ch 8-15 -->
  </subModule>
  <subModule id="1" ident="0x61100205" name="out0">  <!-- 16-ch DO -->
    <modParam name="safeState" value="0"/>           <!-- outputs on link loss -->
  </subModule>
</slave>
```
This gives HAL pins like:
```
lcec.0.io.in0-din-0 … in0-din-15   (+ …-not)
lcec.0.io.out0-dout-0 … out0-dout-15
```

**Analog + encoder:**
```xml
<slave idx="1" type="R3EC" name="mix">
  <subModule id="0" ident="0x61000025" name="ain0">   <!-- 4-ch analog in -->
    <modParam name="ch0Config" value="2"/>            <!-- per-channel range/mode -->
  </subModule>
  <subModule id="1" ident="0x61300025" name="enc0">   <!-- 2-ch encoder -->
    <modParam name="encoderMode" value="0"/>
    <modParam name="encoderFilter" value="2"/>
  </subModule>
</slave>
```
→ `lcec.0.mix.ain0-ain-0-val …`, `lcec.0.mix.enc0-enc-0-pos …`, etc.

**Available `<modParam>`s per module family:**
- Digital: `safeState`, `inputFilter0`–`inputFilter3`
- Analog: `ch0Config`–`ch3Config`
- Encoder: `encoderMode`, `abPhase`, `minValue`, `maxValue`, `countMode`, `encoderFilter`

Unknown idents or modparam names are rejected at config-parse time with a clear error.

## Supported submodules

The driver currently recognizes **55 modules** across both the legacy (`0x81…`) and V20 (`0x61…`) families. Each is used via `<subModule ident="…">`.

<details>
<summary><b>Digital input</b> (12)</summary>

| Ident | Module | Channels |
|---|---|---|
| `0x61100025` | PM-1600 | 16 DI |
| `0x61100026` | R3-1600-V20 | 16 DI |
| `0x81100025` | R3-1600 | 16 DI |
| `0x61100045` | PM-3200 | 32 DI |
| `0x61100046` | R3-3200-V20 | 32 DI |
| `0x61101045` | PM-3200-1 | 32 DI |
| `0x61101046` | R3-3200-1-V20 | 32 DI |
| `0x61102045` | PM-3200-2 | 32 DI |
| `0x61102046` | R3-3200-2-V20 | 32 DI |
| `0x81100045` | R3-3200 | 32 DI |
| `0x81101045` | R3-3200-1 | 32 DI |
| `0x81102045` | R3-3200-2 | 32 DI |
</details>

<details>
<summary><b>Digital output</b> — incl. relay (22)</summary>

| Ident | Module | Channels |
|---|---|---|
| `0x61100205` | PM-0016-N | 16 DO |
| `0x61100206` | R3-0016-N-V20 | 16 DO |
| `0x81100205` | R3-0016-N | 16 DO |
| `0x61110205` | PM-0016-P | 16 DO |
| `0x61110206` | R3-0016-P-V20 | 16 DO |
| `0x81110205` | R3-0016-P | 16 DO |
| `0x61100405` | PM-0032-N | 32 DO |
| `0x61100406` | R3-0032-N-V20 | 32 DO |
| `0x61101405` | PM-0032-N-1 | 32 DO |
| `0x61101406` | R3-0032-N-1-V20 | 32 DO |
| `0x61102405` | PM-0032-N-2 | 32 DO |
| `0x61102406` | R3-0032-N-2-V20 | 32 DO |
| `0x81100405` | R3-0032-N | 32 DO |
| `0x81101405` | R3-0032-N-1 | 32 DO |
| `0x81102405` | R3-0032-N-2 | 32 DO |
| `0x61110406` | R3-0032-P-V20 | 32 DO |
| `0x81110405` | R3-0032-P | 32 DO |
| `0x61900106` | R3-0008-R-V20 | 8 relay |
| `0x81900105` | R3-0008-R | 8 relay |
| `0x61900205` | PM-0016-R | 16 relay |
| `0x61900206` | R3-0016-R-V20 | 16 relay |
| `0x81900205` | R3-0016-R | 16 relay |
</details>

<details>
<summary><b>Digital in/out</b> (9)</summary>

| Ident | Module | Channels |
|---|---|---|
| `0x61100116` | R3-0808-N-V20 | 8 DI + 8 DO |
| `0x81100115` | R3-0808-N | 8 DI + 8 DO |
| `0x61100225` | PM-1616-N | 16 DI + 16 DO |
| `0x61100226` | R3-1616-N-V20 | 16 DI + 16 DO |
| `0x81100225` | R3-1616-N | 16 DI + 16 DO |
| `0x61110226` | R3-1616-P-V20 | 16 DI + 16 DO |
| `0x81110225` | R3-1616-P | 16 DI + 16 DO |
| `0x61101446` | R3-3232-N-1-V20 | 32 DI + 32 DO |
| `0x81101445` | R3-3232-N-1 | 32 DI + 32 DO |
</details>

<details>
<summary><b>Analog input</b> (3)</summary>

| Ident | Module | Channels |
|---|---|---|
| `0x61000025` | PM-A0400-IV | 4 AI |
| `0x61000026` | R3-A0400-IV-V20 | 4 AI |
| `0x81000025` | R3-A0400-IV | 4 AI |
</details>

<details>
<summary><b>Analog output</b> (3)</summary>

| Ident | Module | Channels |
|---|---|---|
| `0x61000205` | PM-A0004-IV | 4 AO |
| `0x61000206` | R3-A0004-IV-V20 | 4 AO |
| `0x81000205` | R3-A0004-IV | 4 AO |
</details>

<details>
<summary><b>Encoder</b> (6)</summary>

| Ident | Module | Channels |
|---|---|---|
| `0x61300025` | PM-E0200-S | 2 enc |
| `0x61300026` | R3-E0200-S-V20 | 2 enc |
| `0x81300025` | R3-E0200-S | 2 enc |
| `0x61300125` | PM-E0200-D | 2 enc |
| `0x61300126` | R3-E0200-D-V20 | 2 enc |
| `0x81300125` | R3-E0200-D | 2 enc |
</details>

## My Testing

- Verified the parser accepts a valid coupler config and rejects an unknown `ident` and an out-of-family `<modParam>`.
- On hardware I've confirmed digital I/O (inputs and outputs) working; analog/encoder are implemented from the ESI and still being validated on real modules. I have ordered new modules and will test them. 

## Notes / follow-ups

- Digital modules use the default bit-wise PDO mapping; packed-word mode isn't wired up yet.
- Encoder support maps the position/error PDOs; the module's additional mandatory latch/compare PDOs aren't mapped yet and may need adding for those advanced features.