### PR TITLE
fix(syncs): bounds-check dynamic PDO layout and report overflow

### DIFF
--- a/documentation/pdos-and-syncs.md
+++ b/documentation/pdos-and-syncs.md
@@ -174,6 +174,36 @@ per PDO.  By using `autoflow`, we can transparently map a handful of
 PDO entries into a many PDOs as required without needing to modify any
 higher-level code.
 
+### Checking for overflow
+
+The layout buffers are fixed size (`LCEC_MAX_SYNC_COUNT`,
+`LCEC_MAX_PDO_INFO_COUNT`, `LCEC_MAX_PDO_ENTRY_COUNT`).  A static driver
+knows its layout at compile time and cannot overflow them, so it can
+ignore this.  A driver that builds a layout from *configuration* (for
+example a modular bus coupler that maps a variable set of `<subModule>`s)
+can exceed them, and needs to notice.
+
+`lcec_syncs_add_sync()`, `lcec_syncs_add_pdo_info()`, and
+`lcec_syncs_add_pdo_entry()` return `0` on success and `-1` when the
+corresponding buffer is full (in which case nothing is added).  The
+failure is also recorded stickily in `syncs->error`, so you don't have to
+check every call -- build the whole layout in a loop and check once:
+
+```c
+  lcec_syncs_init(slave, syncs);
+  lcec_syncs_add_sync(syncs, EC_DIR_OUTPUT, EC_WD_DEFAULT);
+  // ... add PDOs/entries for each configured channel in a loop ...
+  if (syncs->error) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "%s: too many PDOs/entries for the configured layout\n", slave->name);
+    return -EINVAL;
+  }
+  slave->sync_info = &syncs->syncs[0];
+```
+
+Failing `_init` this way turns an over-sized configuration into a clear
+startup error instead of a silently truncated (and previously
+memory-corrupting) PDO map.
+
 ## Performance
 
 If we don't explicitly set `sync_info`, then the Etherlab EtherCAT

--- a/src/devices/lcec_class_ain.c
+++ b/src/devices/lcec_class_ain.c
@@ -273,6 +273,8 @@ void lcec_ain_read_all(lcec_slave_t *slave, lcec_class_ain_channels_t *channels)
   for (int i = 0; i < channels->count; i++) {
     lcec_class_ain_channel_t *channel = channels->channels[i];
 
-    lcec_ain_read(slave, channel);
+    if (channel != NULL) {
+      lcec_ain_read(slave, channel);
+    }
   }
 }

--- a/src/devices/lcec_class_aout.c
+++ b/src/devices/lcec_class_aout.c
@@ -218,6 +218,8 @@ void lcec_aout_write_all(lcec_slave_t *slave, lcec_class_aout_channels_t *channe
   for (int i = 0; i < channels->count; i++) {
     lcec_class_aout_channel_t *channel = channels->channels[i];
 
-    lcec_aout_write(slave, channel);
+    if (channel != NULL) {
+      lcec_aout_write(slave, channel);
+    }
   }
 }

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -363,6 +363,10 @@ typedef struct {
   int pdo_entry_limit;  ///< Device limit on the number of PDO entries per PDO
   int pdo_limit;        ///< Device limit on the number of PDOs per sync.
   int pdo_increment;    ///< Number to increment PDO number when overflowing.
+
+  int error;  ///< Sticky overflow flag: set nonzero when any `lcec_syncs_add_*` call could not fit.
+              ///< Drivers that build a layout from configuration (e.g. modular couplers) can make all
+              ///< the add calls and then check this once, instead of the return value of every call.
 } lcec_syncs_t;
 
 /// @brief Lookup table mapping string to int
@@ -406,9 +410,18 @@ int lcec_param_newf_list(void *base, const lcec_paramdesc_t *list, ...);
 void copy_fsoe_data(lcec_slave_t *slave, unsigned int slave_offset, unsigned int master_offset) __attribute__((nonnull));
 void lcec_syncs_init(lcec_slave_t *slave, lcec_syncs_t *syncs) __attribute__((nonnull));
 void lcec_syncs_enable_autoflow(lcec_slave_t *slave, lcec_syncs_t *syncs, int pdo_limit, int pdo_entry_limit, int pdo_increment);
-void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode);
-void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
-void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);
+/// @brief Append a sync manager / PDO / PDO entry to a `lcec_syncs_t` layout.
+///
+/// Each returns 0 on success and -1 when the corresponding fixed buffer
+/// (`LCEC_MAX_SYNC_COUNT` / `LCEC_MAX_PDO_INFO_COUNT` / `LCEC_MAX_PDO_ENTRY_COUNT`)
+/// is full, in which case nothing is added.  The failure is also recorded
+/// stickily in `syncs->error`, so a driver that builds a variable-sized layout
+/// in a loop may ignore the individual return values and check `syncs->error`
+/// once after building.  Callers that ignore both (the common static case, which
+/// cannot overflow) keep their previous behavior.
+int lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode);
+int lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index);
+int lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length);
 
 const lcec_typelist_t *lcec_findslavetype(const char *name) __attribute__((nonnull));
 void lcec_addtype(lcec_typelist_t *type, const char *sourcefile) __attribute__((nonnull));

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -78,25 +78,40 @@ void lcec_syncs_enable_autoflow(lcec_slave_t *slave, lcec_syncs_t *syncs, int pd
 }
 
 /// @brief Add a new EtherCAT sync manager configuration.
-void lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode) {
+int lcec_syncs_add_sync(lcec_syncs_t *syncs, ec_direction_t dir, ec_watchdog_mode_t watchdog_mode) {
+  // Reject before touching the buffer: the last slot is reserved for the 0xff
+  // terminator written below.
+  if (syncs->sync_count >= LCEC_MAX_SYNC_COUNT) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "lcec_syncs_add_sync: WARNING: sync full for slave %s.%s, not adding more.  Expect failure.\n",
+        syncs->slave->master->name, syncs->slave->name);
+    syncs->error = 1;
+    return -1;
+  }
+
   syncs->curr_sync = &syncs->syncs[syncs->sync_count];
 
   syncs->curr_sync->index = syncs->sync_count;
   syncs->curr_sync->dir = dir;
   syncs->curr_sync->watchdog_mode = watchdog_mode;
 
-  if (syncs->sync_count > LCEC_MAX_SYNC_COUNT) {
-    rtapi_print_msg(RTAPI_MSG_ERR,
-        LCEC_MSG_PFX "lcec_syncs_add_sync: WARNING: sync full for slave %s.%s, not adding more.  Expect failure.\n",
-        syncs->slave->master->name, syncs->slave->name);
-  } else {
-    (syncs->sync_count)++;
-  }
+  (syncs->sync_count)++;
   syncs->syncs[syncs->sync_count].index = 0xff;
+  return 0;
 }
 
 /// @brief Add a new PDO to an existing sync manager.
-void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
+int lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
+  // Reject before writing so we never index past the buffer.  `>` (not `>=`)
+  // keeps the pre-existing usable capacity; only the out-of-bounds write is removed.
+  if (syncs->pdo_info_count > LCEC_MAX_PDO_INFO_COUNT) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s, not adding more.  Expect failure.\n",
+        syncs->slave->master->name, syncs->slave->name);
+    syncs->error = 1;
+    return -1;
+  }
+
   syncs->curr_pdo_info = &syncs->pdo_infos[syncs->pdo_info_count];
 
   if (syncs->curr_sync->pdos == NULL) {
@@ -106,19 +121,18 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
 
   syncs->curr_pdo_info->index = index;
 
-  if (syncs->pdo_info_count > LCEC_MAX_PDO_INFO_COUNT) {
-    rtapi_print_msg(RTAPI_MSG_ERR,
-        LCEC_MSG_PFX "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s, not adding more.  Expect failure.\n",
-        syncs->slave->master->name, syncs->slave->name);
-  } else if (syncs->autoflow && (syncs->pdo_info_count > syncs->pdo_limit)) {
+  if (syncs->autoflow && (syncs->pdo_info_count > syncs->pdo_limit)) {
     rtapi_print_msg(RTAPI_MSG_ERR,
         LCEC_MSG_PFX
         "lcec_syncs_add_pdo_info: WARNING: pdo_info full for slave %s.%s has reached the configured limit of %d, not adding more.  Expect "
         "failure.\n",
         syncs->slave->master->name, syncs->slave->name, syncs->pdo_limit);
-  } else {
-    (syncs->pdo_info_count)++;
+    syncs->error = 1;
+    return -1;
   }
+
+  (syncs->pdo_info_count)++;
+  return 0;
 }
 
 /// @brief Add a new PDO entry to an existing PDO.
@@ -126,7 +140,17 @@ void lcec_syncs_add_pdo_info(lcec_syncs_t *syncs, uint16_t index) {
 /// If `autoflow` is turned on for this syhnc, then this *may* close
 /// out one PDO and open up another one, if we've hit the
 /// pdo_entry_limit specified in `lcec_syncs_enable_autoflow`.
-void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length) {
+int lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subindex, uint8_t bit_length) {
+  // Reject before writing so we never index past the buffer.  `>` (not `>=`)
+  // keeps the pre-existing usable capacity; only the out-of-bounds write is removed.
+  if (syncs->pdo_entry_count > LCEC_MAX_PDO_ENTRY_COUNT) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "lcec_syncs_add_pdo_entry: WARNING: pdo_entries full for slave %s.%s, not adding more.  Expect failure.\n",
+        syncs->slave->master->name, syncs->slave->name);
+    syncs->error = 1;
+    return -1;
+  }
+
   syncs->curr_pdo_entry = &syncs->pdo_entries[syncs->pdo_entry_count];
 
   if (syncs->curr_pdo_info->entries == NULL) {
@@ -134,7 +158,8 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
   }
   (syncs->curr_pdo_info->n_entries)++;
   if (syncs->autoflow && (syncs->curr_pdo_info->n_entries >= syncs->pdo_entry_limit)) {
-    // Open up a new PDO, because this one is full.
+    // Open up a new PDO, because this one is full.  On overflow this sets
+    // syncs->error; the entry below still lands in a valid slot (guarded above).
     lcec_syncs_add_pdo_info(syncs, syncs->curr_pdo_info->index + syncs->pdo_increment);
     syncs->curr_pdo_entry = &syncs->pdo_entries[syncs->pdo_entry_count];
   }
@@ -143,13 +168,8 @@ void lcec_syncs_add_pdo_entry(lcec_syncs_t *syncs, uint16_t index, uint8_t subin
   syncs->curr_pdo_entry->subindex = subindex;
   syncs->curr_pdo_entry->bit_length = bit_length;
 
-  if (syncs->pdo_entry_count > LCEC_MAX_PDO_ENTRY_COUNT) {
-    rtapi_print_msg(RTAPI_MSG_ERR,
-        LCEC_MSG_PFX "lcec_syncs_add_pdo_entry: WARNING: pdo_entries full for slave %s.%s, not adding more.  Expect failure.\n",
-        syncs->slave->master->name, syncs->slave->name);
-  } else {
-    (syncs->pdo_entry_count)++;
-  }
+  (syncs->pdo_entry_count)++;
+  return 0;
 }
 
 /// @brief Read an SDO configuration from a slave device.


### PR DESCRIPTION
`lcec_syncs_add_sync`/`add_pdo_info`/`add_pdo_entry` wrote the current slot and bumped `n_pdos`/`n_entries` before checking the buffer limit, so a layout larger than `LCEC_MAX_*` (e.g. a modular coupler mapping many sub-devices from config) wrote one element past the fixed arrays and left the counts overcounted for downstream consumers.

Changes:
- Move the limit check ahead of the write; only advance the count on success.
- The three functions now return `0`/`-1` and set a sticky `syncs->error`, so a driver that builds a variable-sized layout can check once after building. Callers that ignore the result (static layouts, which cannot overflow) are unaffected: `pdo_info`/`pdo_entry` keep their prior usable capacity (`>` guard), `add_sync` uses `>=` because its last slot holds the `0xff` terminator.
- NULL-guard `lcec_ain_read_all`/`lcec_aout_write_all` to match the existing `din`/`dout` guards, so a failed channel registration cannot segfault the servo thread.
- Document the return/error contract in `documentation/pdos-and-syncs.md`.

Non-breaking: all 85 existing call sites ignore the (new) return value and are bare statements; enables clean overflow handling for dynamic drivers (modular couplers).