### PR TITLE
fix(main): guard lcec_read_master against unactivated master

### DIFF
--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -1173,6 +1173,18 @@ void lcec_read_master(void *arg, long period) {
   lcec_slave_t *slave;
   int check_states;
 
+  // Master not yet activated: process_data is NULL until lcec_activate_master()
+  // runs. On new (initf-capable) linuxcnc loaded with a legacy .hal that omits
+  // `initf lcec.activate <thread>`, lcec_write_master() inline-activates as a
+  // fallback -- but read-all is conventionally addf'd *before* write-all, so
+  // without this bail the slave proc_read below dereferences the NULL
+  // process_data and SIGSEGVs the whole realtime before write-all ever runs.
+  // Skip this cycle; write_master activates the master and reads resume on the
+  // next tick. This keeps `initf` optional and old configs crash-free.
+  if (!master->activated) {
+    return;
+  }
+
   // check period. If the XML omitted appTimePeriod, master->app_time_period
   // is 0 and the modulo at lcec_main.c:1258 would SIGFPE on the first cycle;
   // adopt the actual HAL servo period so the XML attribute is optional.


### PR DESCRIPTION
## Problem

A user on LinuxCNC 2.10.0~pre1 with `linuxcnc-ethercat 1.41.1-3+deb13u1` hit `LinuxCNC Ethercat crashed with signal 11` running a legacy generic-slave config. Disassembly of the exact shipped `lcec.so` puts the fault in `lcec_generic_read` (HAL_BIT branch) reading `master->process_data[offset>>3]` with `process_data == NULL`.

## Root cause

`initf` is optional by design: `hal_init_funct_to_thread` is a `#pragma weak` symbol, resolved at load time. Under 2.9 it binds NULL (legacy inline activation); under 2.10 it binds non-NULL, so lcec defers `ecrt_master_activate` to the `lcec.activate` funct. A legacy `.hal` that omits `initf lcec.activate <thread>` never activates the master, leaving `process_data == NULL`.

`lcec_write_master` already has a "forgot to initf" fallback that inline-activates and warns. But `lcec_read_master` had no such guard, and `read-all` is conventionally `addf`'d before `write-all`. So read ran first, `proc_read` dereferenced the NULL `process_data`, and the whole realtime SIGSEGV'd before the write-side fallback could ever run.

## Fix

Bail out of `lcec_read_master` early when `master->activated` is false. Whichever cycle `write-all` first runs, it inline-activates the master (with the existing warning); reads resume on the next tick. `write_master` remains the sole activator, so DC-phasing/activation semantics are unchanged.

Result: `initf` stays optional and legacy configs run again instead of crashing.

## Testing

Not built locally (no EtherLab `ecrt.h` on the dev box; same reason CI builds against a full LinuxCNC tree). The change is a single early `return` using `master->activated`, already read elsewhere in this file. Suggest CI build + a smoke test: a legacy `.hal` without `initf` under 2.10 should now warn and run instead of `signal 11`.