### PR TITLE
feat(main): add domain WKC and DC synchrony monitoring pins to master

### DIFF
--- a/documentation/distributed-clocks.md
+++ b/documentation/distributed-clocks.md
@@ -102,6 +102,11 @@ If `pll-reset-count` increases, the difference in speed between
 the clocks is large. Increasing `pll-step` might help. `pll-step` is limited
 to 1% of appTimePeriod.
 
+To verify that the slaves' clocks themselves are in sync (as opposed
+to the servo thread tracking the reference clock), see the
+`dc-sync-diff` / `dc-sync-converged` pins in
+[Master HAL Pins](master-pins.md#dc-synchrony-monitoring).
+
 
 ## Slave settings
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -8,6 +8,7 @@
 
 - [Configuration Reference](configuration-reference.md)
 - [Distributed Clocks](distributed-clocks.md)
+- [Master HAL Pins](master-pins.md)
 
 ## Development Documentation
 

--- a/documentation/master-pins.md
+++ b/documentation/master-pins.md
@@ -1,0 +1,72 @@
+# Master HAL Pins
+
+Each master exports a set of HAL pins named `lcec.<master>.<pin>`
+(e.g. `lcec.0.wkc`) that report the health of the EtherCAT bus as a
+whole.  These complement the per-slave `slave-online` / `slave-oper` /
+`slave-state-*` pins and the global `lcec.*` pins.
+
+## State pins
+
+| Pin | Type | Dir | Meaning |
+|---|---|---|---|
+| `lcec.<m>.slaves-responding` | u32 | OUT | Number of slaves responding on the bus |
+| `lcec.<m>.state-init` / `state-preop` / `state-safeop` / `state-op` | bit | OUT | At least one slave is in this AL state |
+| `lcec.<m>.all-op` | bit | OUT | Every slave is in OP |
+| `lcec.<m>.link-up` | bit | OUT | Ethernet link is up |
+
+## Working counter monitoring
+
+Every cyclic exchange carries a working counter (WKC) that each slave
+increments as it processes the datagram.  A WKC below the expected
+value means one or more slaves did not exchange process data that
+cycle.  Before these pins existed, WKC problems were only visible as
+kernel log messages (`Domain 0: Working counter changed ...`).
+
+| Pin | Type | Dir | Meaning |
+|---|---|---|---|
+| `lcec.<m>.wkc` | u32 | OUT | Working counter of the last domain exchange |
+| `lcec.<m>.wkc-state` | s32 | OUT | Interpretation of the WKC: 0 = no data exchanged, 1 = some slaves exchanged, 2 = complete exchange (`ec_wc_state_t`) |
+| `lcec.<m>.wkc-min` | u32 | OUT | Lowest WKC seen since the domain first reached a complete exchange |
+| `lcec.<m>.wkc-change-count` | u32 | OUT | Number of times the WKC changed since the domain first reached a complete exchange |
+
+`wkc-min` and `wkc-change-count` only start tracking once the domain
+first reaches a complete exchange (`wkc-state` = 2), so the normal
+ramp-up during bring-up does not pollute them.  On a healthy bus,
+`wkc` is constant, `wkc-min` equals `wkc`, and `wkc-change-count`
+stays 0.  A rising change count with `wkc-min` dipping below the
+steady-state value means a slave is intermittently dropping out of
+the exchange — a marginal cable, connector, or an overloaded slave.
+These transients last a cycle or two and are easy to miss by polling;
+the counter catches them between samples, and netting `wkc` into
+halscope or a recorder shows exactly when they happen.
+
+Nothing is logged from the realtime thread when the WKC changes (a
+flapping bus would log at cycle rate); the change counter is the log.
+
+## DC synchrony monitoring
+
+These pins report how tightly the slaves' distributed clocks agree
+with each other, using the same mechanism as the `ethercat master`
+CLI: a broadcast read of the "system time difference" register
+(0x092C), which yields an upper estimate of the largest deviation
+between any slave clock and the reference clock.  See [Distributed
+Clocks](distributed-clocks.md) for what DC is and how to configure it.
+
+| Pin/Param | Type | Kind | Meaning |
+|---|---|---|---|
+| `lcec.<m>.dc-sync-diff` | u32 | pin OUT | Upper estimate of the worst slave clock deviation, in ns |
+| `lcec.<m>.dc-sync-converged` | bit | pin OUT | TRUE while `dc-sync-diff` is below `dc-sync-max` |
+| `lcec.<m>.dc-sync-max` | u32 | param RW | Convergence threshold in ns.  Default: `appTimePeriod / 25` (4% of the period) |
+| `lcec.<m>.dc-sync-monitor` | bit | param RW | Enables the monitor (default 1).  Set to 0 to skip the per-cycle broadcast datagram entirely |
+
+After a cold start, `dc-sync-diff` is large while the master
+distributes the reference time, then converges; a DC-synchronized bus
+typically settles in the tens-of-nanoseconds range.  If
+`dc-sync-converged` never turns TRUE, check that your slaves actually
+have DC enabled (`<dcConf/>`, see [Distributed
+Clocks](distributed-clocks.md)) and that the servo thread PLL is
+locked (`pll-err` small, `pll-reset-count` stable).
+
+The monitor costs one broadcast datagram per cycle.  If you do not
+use these pins, `setp lcec.0.dc-sync-monitor 0` reduces the cost to a
+single branch.

--- a/documentation/master-pins.md
+++ b/documentation/master-pins.md
@@ -28,6 +28,7 @@ kernel log messages (`Domain 0: Working counter changed ...`).
 | `lcec.<m>.wkc-state` | s32 | OUT | Interpretation of the WKC: 0 = no data exchanged, 1 = some slaves exchanged, 2 = complete exchange (`ec_wc_state_t`) |
 | `lcec.<m>.wkc-min` | u32 | OUT | Lowest WKC seen since the domain first reached a complete exchange |
 | `lcec.<m>.wkc-change-count` | u32 | OUT | Number of times the WKC changed since the domain first reached a complete exchange |
+| `lcec.<m>.wkc-reset` | bit | IO | Set to 1 to clear `wkc-min` / `wkc-change-count`; self-clears on the next cycle |
 
 `wkc-min` and `wkc-change-count` only start tracking once the domain
 first reaches a complete exchange (`wkc-state` = 2), so the normal
@@ -43,6 +44,11 @@ halscope or a recorder shows exactly when they happen.
 Nothing is logged from the realtime thread when the WKC changes (a
 flapping bus would log at cycle rate); the change counter is the log.
 
+Setting `wkc-reset` to 1 clears both stats and re-arms the
+first-complete-exchange gate, so `wkc-min` re-anchors on the next
+complete exchange.  The pin clears itself once the reset is applied
+(the same idiom as `encoder.N.reset`).
+
 ## DC synchrony monitoring
 
 These pins report how tightly the slaves' distributed clocks agree
@@ -54,8 +60,8 @@ Clocks](distributed-clocks.md) for what DC is and how to configure it.
 
 | Pin/Param | Type | Kind | Meaning |
 |---|---|---|---|
-| `lcec.<m>.dc-sync-diff` | u32 | pin OUT | Upper estimate of the worst slave clock deviation, in ns |
-| `lcec.<m>.dc-sync-converged` | bit | pin OUT | TRUE while `dc-sync-diff` is below `dc-sync-max` |
+| `lcec.<m>.dc-sync-diff` | u32 | pin OUT | Upper estimate of the worst slave clock deviation, in ns.  Reads `0xffffffff` while no monitor responses are arriving |
+| `lcec.<m>.dc-sync-converged` | bit | pin OUT | TRUE while `dc-sync-diff` is below `dc-sync-max`.  Forced FALSE after ~10 consecutive missing monitor responses (communication loss) |
 | `lcec.<m>.dc-sync-max` | u32 | param RW | Convergence threshold in ns.  Default: `appTimePeriod / 25` (4% of the period) |
 | `lcec.<m>.dc-sync-monitor` | bit | param RW | Enables the monitor (default 1).  Set to 0 to skip the per-cycle broadcast datagram entirely |
 
@@ -67,6 +73,14 @@ have DC enabled (`<dcConf/>`, see [Distributed
 Clocks](distributed-clocks.md)) and that the servo thread PLL is
 locked (`pll-err` small, `pll-reset-count` stable).
 
+On communication loss (cable pulled, all slaves dead), the monitor
+datagram stops returning.  A few consecutive misses are tolerated
+(single datagram timeouts happen), after which `dc-sync-converged` is
+forced FALSE and `dc-sync-diff` reads `0xffffffff` until responses
+resume, so a dead bus can never keep showing a stale "converged"
+state.
+
 The monitor costs one broadcast datagram per cycle.  If you do not
 use these pins, `setp lcec.0.dc-sync-monitor 0` reduces the cost to a
-single branch.
+single branch (the dc-sync pins then hold their last values and
+should be ignored).

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -73,6 +73,10 @@ extern "C" {
 // State update period (ns)
 #define LCEC_STATE_UPDATE_PERIOD 1000000000LL
 
+// Consecutive missing DC sync monitor datagrams tolerated before the
+// dc-sync pins are invalidated (see lcec_read_master)
+#define LCEC_DC_SYNC_MISS_MAX 10
+
 // IDN builder
 #define LCEC_IDN_TYPE_P 0x8000
 #define LCEC_IDN_TYPE_S 0x0000
@@ -200,6 +204,7 @@ typedef struct lcec_master_data {
   hal_u32_t *wkc_min;         // Output: min WKC since first complete exchange
   hal_u32_t *wkc_change_cnt;  // Output: WKC change count since first complete exchange
   hal_s32_t *wkc_state;       // Output: 0=zero, 1=incomplete, 2=complete (ec_wc_state_t)
+  hal_bit_t *wkc_reset;       // IO: set to 1 to clear min/change stats; self-clears
   uint32_t wkc_last;          // Internal: previous WKC value
   int wkc_full_seen;          // Internal: domain reached EC_WC_COMPLETE at least once
   // DC synchrony monitoring (broadcast read of 0x092C system time difference)
@@ -207,6 +212,7 @@ typedef struct lcec_master_data {
   hal_bit_t *dc_sync_converged;  // Output: dc_sync_diff below dc-sync-max threshold
   hal_u32_t dc_sync_max;         // Param: convergence threshold (ns)
   hal_bit_t dc_sync_monitor;     // Param: enable the per-cycle monitor datagram (default on)
+  int dc_sync_miss_cnt;          // Internal: consecutive cycles without a monitor response
   // Phase calibration for sync_to_ref_clock=false mode
   int32_t phase_measure_cnt;       // Internal: measurement cycle counter
   int32_t phase_min;               // Internal: minimum app_phase during measurement

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -195,6 +195,18 @@ typedef struct lcec_master_data {
   hal_s32_t *pll_final;            // Output: final PLL correction value sent to rtapi (ns)
   int32_t auto_drift_delay;        // Internal: auto-drift delay counter
 #endif
+  // Domain working counter monitoring
+  hal_u32_t *wkc;             // Output: current domain working counter
+  hal_u32_t *wkc_min;         // Output: min WKC since first complete exchange
+  hal_u32_t *wkc_change_cnt;  // Output: WKC change count since first complete exchange
+  hal_s32_t *wkc_state;       // Output: 0=zero, 1=incomplete, 2=complete (ec_wc_state_t)
+  uint32_t wkc_last;          // Internal: previous WKC value
+  int wkc_full_seen;          // Internal: domain reached EC_WC_COMPLETE at least once
+  // DC synchrony monitoring (broadcast read of 0x092C system time difference)
+  hal_u32_t *dc_sync_diff;       // Output: upper estimate of max slave time diff (ns)
+  hal_bit_t *dc_sync_converged;  // Output: dc_sync_diff below dc-sync-max threshold
+  hal_u32_t dc_sync_max;         // Param: convergence threshold (ns)
+  hal_bit_t dc_sync_monitor;     // Param: enable the per-cycle monitor datagram (default on)
   // Phase calibration for sync_to_ref_clock=false mode
   int32_t phase_measure_cnt;       // Internal: measurement cycle counter
   int32_t phase_min;               // Internal: minimum app_phase during measurement

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -70,6 +70,12 @@ static const lcec_pindesc_t master_pins[] = {
     {HAL_S32, HAL_IN, offsetof(lcec_master_data_t, pll_drift), "%s.pll-drift"},
     {HAL_S32, HAL_OUT, offsetof(lcec_master_data_t, pll_final), "%s.pll-final"},
 #endif
+    {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, wkc), "%s.wkc"},
+    {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, wkc_min), "%s.wkc-min"},
+    {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, wkc_change_cnt), "%s.wkc-change-count"},
+    {HAL_S32, HAL_OUT, offsetof(lcec_master_data_t, wkc_state), "%s.wkc-state"},
+    {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, dc_sync_diff), "%s.dc-sync-diff"},
+    {HAL_BIT, HAL_OUT, offsetof(lcec_master_data_t, dc_sync_converged), "%s.dc-sync-converged"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
 };
 
@@ -79,6 +85,8 @@ static const lcec_paramdesc_t master_params[] = {
     {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, pll_step), "%s.pll-step"},
     {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, pll_max_err), "%s.pll-max-err"},
 #endif
+    {HAL_U32, HAL_RW, offsetof(lcec_master_data_t, dc_sync_max), "%s.dc-sync-max"},
+    {HAL_BIT, HAL_RW, offsetof(lcec_master_data_t, dc_sync_monitor), "%s.dc-sync-monitor"},
     {HAL_TYPE_UNSPECIFIED},
 };
 
@@ -310,6 +318,12 @@ int rtapi_app_main(void) {
     // Initialize auto-drift delay counter (wait 100 cycles before applying)
     master->hal_data->auto_drift_delay = 100;
 #endif
+    // DC synchrony convergence threshold: 4% of period (10 us at 4 kHz);
+    // app_time_period can be 0 here when the XML omits appTimePeriod.
+    master->hal_data->dc_sync_max = (master->app_time_period != 0) ? master->app_time_period / 25 : 10000;
+    // Monitor on by default (one broadcast datagram per cycle); setp to 0
+    // for zero overhead when the dc-sync pins are unused.
+    master->hal_data->dc_sync_monitor = 1;
 
     // Activate master (only when initf is unavailable; otherwise lcec.activate
     // funct does it from RT context after the user's `initf lcec.activate <thread>`).
@@ -1210,9 +1224,13 @@ void lcec_read_master(void *arg, long period) {
   }
 
   // receive process data & master state
+  ec_domain_state_t domain_state;
+  uint32_t dc_sync_diff;
   rtapi_mutex_get(&master->mutex);
   ecrt_master_receive(master->master);
   ecrt_domain_process(master->domain);
+  ecrt_domain_state(master->domain, &domain_state);
+  dc_sync_diff = master->hal_data->dc_sync_monitor ? ecrt_master_sync_monitor_process(master->master) : 0xffffffffu;
   if (check_states) {
     ecrt_master_state(master->master, &master->ms);
   }
@@ -1220,6 +1238,40 @@ void lcec_read_master(void *arg, long period) {
 
   // update state pins
   lcec_update_master_hal(master->hal_data, &master->ms);
+
+  // update working counter pins; min/change tracking starts once the domain
+  // first reaches a complete exchange (EC_WC_COMPLETE), so bring-up ramping
+  // does not pollute the stats
+  {
+    lcec_master_data_t *hd = master->hal_data;
+    uint32_t wkc_now = domain_state.working_counter;
+    *(hd->wkc) = wkc_now;
+    *(hd->wkc_state) = (hal_s32_t)domain_state.wc_state;
+    if (!hd->wkc_full_seen) {
+      if (domain_state.wc_state == EC_WC_COMPLETE) {
+        hd->wkc_full_seen = 1;
+        *(hd->wkc_min) = wkc_now;
+        *(hd->wkc_change_cnt) = 0;
+      }
+    } else {
+      if (wkc_now < *(hd->wkc_min)) {
+        *(hd->wkc_min) = wkc_now;
+      }
+      // no rtapi_print here: a flapping bus would emit at cycle rate from the
+      // RT thread; the change counter pin + recorder are the log
+      if (wkc_now != hd->wkc_last) {
+        (*(hd->wkc_change_cnt))++;
+      }
+    }
+    hd->wkc_last = wkc_now;
+
+    // DC synchrony: broadcast read of system time difference (0x092C);
+    // 0xffffffff means the monitor datagram was not received this cycle
+    if (dc_sync_diff != 0xffffffffu) {
+      *(hd->dc_sync_diff) = dc_sync_diff;
+      *(hd->dc_sync_converged) = (dc_sync_diff < hd->dc_sync_max);
+    }
+  }
 
   // update global state
   global_ms.slaves_responding += master->ms.slaves_responding;
@@ -1328,6 +1380,12 @@ void lcec_write_master(void *arg, long period) {
 
   // sync slaves to ref clock
   ecrt_master_sync_slave_clocks(master->master);
+
+  // queue DC synchrony monitor datagram (broadcast read of 0x092C),
+  // processed next cycle in lcec_read_master
+  if (master->hal_data->dc_sync_monitor) {
+    ecrt_master_sync_monitor_queue(master->master);
+  }
 
   // send domain data
   ecrt_master_send(master->master);

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -74,6 +74,7 @@ static const lcec_pindesc_t master_pins[] = {
     {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, wkc_min), "%s.wkc-min"},
     {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, wkc_change_cnt), "%s.wkc-change-count"},
     {HAL_S32, HAL_OUT, offsetof(lcec_master_data_t, wkc_state), "%s.wkc-state"},
+    {HAL_BIT, HAL_IO, offsetof(lcec_master_data_t, wkc_reset), "%s.wkc-reset"},
     {HAL_U32, HAL_OUT, offsetof(lcec_master_data_t, dc_sync_diff), "%s.dc-sync-diff"},
     {HAL_BIT, HAL_OUT, offsetof(lcec_master_data_t, dc_sync_converged), "%s.dc-sync-converged"},
     {HAL_TYPE_UNSPECIFIED, HAL_DIR_UNSPECIFIED, -1, NULL},
@@ -1245,6 +1246,16 @@ void lcec_read_master(void *arg, long period) {
   {
     lcec_master_data_t *hd = master->hal_data;
     uint32_t wkc_now = domain_state.working_counter;
+
+    // user-requested stats reset: clear min/change tracking and re-arm the
+    // first-complete-exchange gate so wkc-min re-anchors; pin self-clears
+    if (*(hd->wkc_reset)) {
+      *(hd->wkc_reset) = 0;
+      hd->wkc_full_seen = 0;
+      *(hd->wkc_min) = 0;
+      *(hd->wkc_change_cnt) = 0;
+    }
+
     *(hd->wkc) = wkc_now;
     *(hd->wkc_state) = (hal_s32_t)domain_state.wc_state;
     if (!hd->wkc_full_seen) {
@@ -1266,10 +1277,20 @@ void lcec_read_master(void *arg, long period) {
     hd->wkc_last = wkc_now;
 
     // DC synchrony: broadcast read of system time difference (0x092C);
-    // 0xffffffff means the monitor datagram was not received this cycle
-    if (dc_sync_diff != 0xffffffffu) {
-      *(hd->dc_sync_diff) = dc_sync_diff;
-      *(hd->dc_sync_converged) = (dc_sync_diff < hd->dc_sync_max);
+    // 0xffffffff means the monitor datagram was not received this cycle.
+    // Tolerate a few consecutive misses (startup, single datagram timeouts),
+    // then invalidate so a dead bus cannot keep showing stale-converged.
+    if (hd->dc_sync_monitor) {
+      if (dc_sync_diff != 0xffffffffu) {
+        hd->dc_sync_miss_cnt = 0;
+        *(hd->dc_sync_diff) = dc_sync_diff;
+        *(hd->dc_sync_converged) = (dc_sync_diff < hd->dc_sync_max);
+      } else if (hd->dc_sync_miss_cnt < LCEC_DC_SYNC_MISS_MAX) {
+        hd->dc_sync_miss_cnt++;
+      } else {
+        *(hd->dc_sync_converged) = 0;
+        *(hd->dc_sync_diff) = 0xffffffffu;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Adds per-master HAL pins for bus health diagnostics that are currently only visible via kernel log scraping or the `ethercat` CLI:

- `<master>.wkc` / `<master>.wkc-state` — current domain working counter and its `ec_wc_state_t` interpretation, from `ecrt_domain_state()` after `ecrt_domain_process()`
- `<master>.wkc-min` / `<master>.wkc-change-count` — minimum WKC and number of WKC changes, tracked from the moment the domain first reaches a complete exchange (`EC_WC_COMPLETE`), so bring-up ramping does not pollute the stats
- `<master>.dc-sync-diff` / `<master>.dc-sync-converged` — upper estimate (ns) of slave clock divergence from a per-cycle broadcast read of the 0x092C system time difference register (`ecrt_master_sync_monitor_queue()` in the write path, `ecrt_master_sync_monitor_process()` in the read path), with a `<master>.dc-sync-max` RW threshold param (default `appTimePeriod/25`)
- `<master>.dc-sync-monitor` RW bit param (default 1) gates the monitor datagram: `setp lcec.0.dc-sync-monitor 0` drops the per-cycle cost to a single branch for users who do not net the dc-sync pins

## Motivation

A marginal bus (a slave intermittently dropping out of the exchange, DC drift after a topology change) is invisible from HAL today: WKC changes only appear as dmesg warnings, and DC synchrony requires polling the CLI. As pins, these can be netted into any HAL-level dashboard, halscope, or recorder, and change counters catch transients between samples.

Deliberately not logged from the RT thread: a flapping bus would emit at cycle rate, so the change counter pin is the log.

## Testing

Running on a live 5-slave bus (CiA402 drives + modular IO, generic slaves) at 4 kHz with DC sync0 active on the drives: WKC tracks 15/15 with state 2, `dc-sync-diff` reads 15-31 ns steady-state and `dc-sync-converged` behaves correctly through cold boots (holds FALSE until the monitor datagram returns sane values). No behavior change when the pins are unnetted; changed hunks are clean under the repo's `.clang-format`.

## Cost

One `ecrt_domain_state()` call per cycle, plus one queued BRD datagram per cycle when `dc-sync-monitor` is enabled (default). Disabled: one branch.