### PR TITLE
Implement sync unit management and add documentation for process data

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ A [reference guide to LinuxCNC-Ethercat's XML
 configuration](documentation/configuration-reference.md) file is
 available.
 
+Slaves can also be grouped into named process-data Sync Units when one master
+must exchange different groups at different integer-multiple cycle times. See
+the [distributed-clock and Sync Unit guide](documentation/distributed-clocks.md#process-data-sync-units).
+
 Several examples are available in the [`examples/`](examples/)
 directory, but they're somewhat dated.  The [LinuxCNC
 Forum](https://forum.linuxcnc.org/ethercat) is a better place to

--- a/documentation/configuration-reference.md
+++ b/documentation/configuration-reference.md
@@ -99,6 +99,13 @@ device:
 - `name="<name>"`: (optional but strongly recommended, defaults to the
   value of `idx`): The name of the device.  This is used in naming HAL
   pins in LinuxCNC.
+- `syncUnit="<name>"`: (optional, defaults to `default`): Places the slave
+  in a named process-data Sync Unit. Each Sync Unit owns a separate EtherCAT
+  domain. Slaves with the same Sync Unit name must use the same cycle.
+- `syncUnitCycle="<time|*N>"`: (optional, defaults to the master cycle):
+  Process-data exchange period for this Sync Unit. It must be a positive
+  integer multiple of the master's `appTimePeriod`; for example, `*2` means
+  every second master cycle.
 -  `vid="<vid>"`: (required for generic, usable but not recommended for others): the Vendor ID for the
    device.  You can determine this via `ethercat slaves -v`.
 - `pid="<pid>"`: (required for generic, usable but not recommended for others): the product ID for the

--- a/documentation/distributed-clocks.md
+++ b/documentation/distributed-clocks.md
@@ -181,6 +181,37 @@ Presumably shifting various devices slightly could result in reduced
 jitter and less contention on the network, although it's not clear
 that it really matters to us.  Many examples seem to just use 0.
 
+## Process-data Sync Units
+
+Distributed Clock cycles and process-data exchange cycles are separate.
+The optional `syncUnit` and `syncUnitCycle` slave attributes group slaves into
+separate EtherCAT domains that may be queued at different integer multiples of
+the master cycle:
+
+```xml
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="-1">
+    <slave idx="0" type="generic" vid="00000002" pid="00000001"
+           syncUnit="slow" syncUnitCycle="*2">
+      ...
+    </slave>
+    <slave idx="1" type="generic" vid="00000002" pid="00000002"
+           syncUnit="fast" syncUnitCycle="*1">
+      ...
+    </slave>
+  </master>
+```
+
+Here the master still runs every 1 ms, but the `slow` domain is exchanged every
+2 ms and the `fast` domain every 1 ms. All domains are exchanged every master
+cycle during startup until the master reaches OP once. Omitting both attributes
+keeps the previous behavior: the slave belongs to the `default` domain and is
+exchanged every master cycle.
+
+For a DC-capable slave, configure `dcConf` independently and keep its hardware
+cycle consistent with the Sync Unit cycle. Slaves that exchange coupled data,
+including an FSoE logic device and its safety slaves, should remain in the same
+Sync Unit.
+
 ## Drivers and DC Clocks
 
 Some devices (like RTelligent stepper drives) *only* seem to work in

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,6 @@
 include ../config.mk
 
-SUBDIRS = generic-complex swm-fm45a
+SUBDIRS = generic-complex swm-fm45a sync-units
 
 install-examples:
 	mkdir -p $(DESTDIR)$(EMC2_HOME)/share/linuxcnc-ethercat/examples

--- a/examples/sync-units/README
+++ b/examples/sync-units/README
@@ -1,0 +1,13 @@
+Sync Unit example
+=================
+
+This example splits one 1 ms EtherCAT master into two process-data domains:
+
+- "slow" is exchanged every 2 ms.
+- "fast" is exchanged every 1 ms.
+
+All slaves sharing a syncUnit name must specify the same syncUnitCycle. If both
+attributes are omitted, the slave uses the default Sync Unit at the master rate.
+
+Replace the placeholder slave types and IDs in ethercat-conf.xml with the actual
+devices and PDO mappings.

--- a/examples/sync-units/ethercat-conf.xml
+++ b/examples/sync-units/ethercat-conf.xml
@@ -1,0 +1,21 @@
+<masters>
+  <master idx="0" appTimePeriod="1000000" refClockSyncCycles="-1">
+
+    <!-- Slave 1: its PDO datagram is queued every second master cycle. -->
+    <slave idx="0" type="generic"
+           vid="00000002" pid="00000001"
+           name="slow-slave"
+           syncUnit="slow" syncUnitCycle="*2">
+      <!-- Add this slave's sync managers and PDO mapping here. -->
+    </slave>
+
+    <!-- Slave 2: its PDO datagram is queued every master cycle. -->
+    <slave idx="1" type="generic"
+           vid="00000002" pid="00000002"
+           name="fast-slave"
+           syncUnit="fast" syncUnitCycle="*1">
+      <!-- Add this slave's sync managers and PDO mapping here. -->
+    </slave>
+
+  </master>
+</masters>

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -191,13 +191,13 @@ typedef struct lcec_master_data {
   hal_u32_t pll_max_err;
   hal_u32_t *pll_reset_cnt;
   hal_u32_t dc_phase_max_err;
-  hal_s32_t *app_phase;            // Our execution phase in local cycle (ns, real-time)
-  hal_bit_t *dc_phased;           // PLL lock status indicator
-  hal_s32_t *phase_jitter_out;     // Output: measured app_phase jitter amplitude (ns)
-  hal_s32_t *drift_mode;            // Input: 0=simple, 1=manual
-  hal_s32_t *pll_drift;            // Input: debug offset added to PLL correction (ns)
-  hal_s32_t *pll_final;            // Output: final PLL correction value sent to rtapi (ns)
-  int32_t auto_drift_delay;        // Internal: auto-drift delay counter
+  hal_s32_t *app_phase;         // Our execution phase in local cycle (ns, real-time)
+  hal_bit_t *dc_phased;         // PLL lock status indicator
+  hal_s32_t *phase_jitter_out;  // Output: measured app_phase jitter amplitude (ns)
+  hal_s32_t *drift_mode;        // Input: 0=simple, 1=manual
+  hal_s32_t *pll_drift;         // Input: debug offset added to PLL correction (ns)
+  hal_s32_t *pll_final;         // Output: final PLL correction value sent to rtapi (ns)
+  int32_t auto_drift_delay;     // Internal: auto-drift delay counter
 #endif
   // Domain working counter monitoring
   hal_u32_t *wkc;             // Output: current domain working counter
@@ -214,13 +214,13 @@ typedef struct lcec_master_data {
   hal_bit_t dc_sync_monitor;     // Param: enable the per-cycle monitor datagram (default on)
   int dc_sync_miss_cnt;          // Internal: consecutive cycles without a monitor response
   // Phase calibration for sync_to_ref_clock=false mode
-  int32_t phase_measure_cnt;       // Internal: measurement cycle counter
-  int32_t phase_min;               // Internal: minimum app_phase during measurement
-  int32_t phase_max;               // Internal: maximum app_phase during measurement
-  int32_t phase_last;              // Internal: last app_phase value (for boundary detection)
-  int32_t phase_jitter;            // Internal: calculated jitter amplitude
-  int32_t phase_target;            // Internal: target app_phase position
-  int32_t phase_calibrated;        // Internal: 0=measuring, 1=calibrated
+  int32_t phase_measure_cnt;  // Internal: measurement cycle counter
+  int32_t phase_min;          // Internal: minimum app_phase during measurement
+  int32_t phase_max;          // Internal: maximum app_phase during measurement
+  int32_t phase_last;         // Internal: last app_phase value (for boundary detection)
+  int32_t phase_jitter;       // Internal: calculated jitter amplitude
+  int32_t phase_target;       // Internal: target app_phase position
+  int32_t phase_calibrated;   // Internal: 0=measuring, 1=calibrated
 } lcec_master_data_t;
 
 typedef struct lcec_slave_state {
@@ -280,14 +280,15 @@ typedef struct lcec_master {
   int sync_to_ref_clock;
   long long state_update_timer;
   ec_master_state_t ms;
-  int activated;                    // Flag: master has been activated (0=not yet, 1=activated)
-  int initf_activated;              // Flag: activation happened via initf path (clean RT-context); when set, BANG-BANG PLL trim is skipped because app_phase was born stable
-  int forgot_warned;                // One-shot guard for the "user forgot initf lcec.activate" warning in lcec_write_master
+  int activated;        // Flag: master has been activated (0=not yet, 1=activated)
+  int initf_activated;  // Flag: activation happened via initf path (clean RT-context); when set, BANG-BANG PLL trim is skipped because
+                        // app_phase was born stable
+  int forgot_warned;    // One-shot guard for the "user forgot initf lcec.activate" warning in lcec_write_master
 #ifdef RTAPI_TASK_PLL_SUPPORT
   uint64_t dc_ref;
-  uint64_t dc_ref_time;          // DC reference time (epoch) - set on first app_time call
+  uint64_t dc_ref_time;  // DC reference time (epoch) - set on first app_time call
   uint32_t app_time_last;
-  int dc_time_valid_last;         // Previous cycle's dc_time_valid (for detecting consecutive valid reads)
+  int dc_time_valid_last;  // Previous cycle's dc_time_valid (for detecting consecutive valid reads)
 #endif
 } lcec_master_t;
 
@@ -332,40 +333,40 @@ typedef struct {
 
 /// @brief EtherCAT slave.
 typedef struct lcec_slave {
-  lcec_slave_t *prev;                        ///< Next slave
-  lcec_slave_t *next;                        ///< Previous slave
-  lcec_master_t *master;                     ///< Master for this slave
-  lcec_sync_unit_t *sync_unit;               ///< Process-data Sync Unit containing this slave.
-  int index;                                 ///< Index of this slave.
-  char name[LCEC_CONF_STR_MAXLEN];           ///< Slave name.
-  char sync_unit_name[LCEC_CONF_STR_MAXLEN]; ///< Configured Sync Unit name.
-  uint32_t sync_unit_cycle;                  ///< Configured process-data cycle in ns.
-  uint32_t vid;                              ///< Slave's vendor ID
-  uint32_t pid;                              ///< Slave's EtherCAT PID/device ID.
-  ec_sync_info_t *sync_info;                 ///< Sync Manager configuration.
-  ec_slave_config_t *config;                 ///< Configuration data.
-  ec_slave_config_state_t state;             ///< Slave state.
-  lcec_slave_dc_t *dc_conf;                  ///< Distributed Clock configuration.
-  lcec_slave_watchdog_t *wd_conf;            ///< Watchdog configuration.
-  lcec_slave_preinit_t proc_preinit;         ///< Callback for pre-init, if any.
-  lcec_slave_init_t proc_init;               ///< Callback for initializing device.
-  lcec_slave_cleanup_t proc_cleanup;         ///< Calback for cleaning up the device.
-  lcec_slave_rw_t proc_read;                 ///< Callback for reading from the device.
-  lcec_slave_rw_t proc_write;                ///< Callback for writing to the device.
-  lcec_slave_state_t *hal_state_data;        ///< HAL state data.
-  void *hal_data;                            ///< HAL data, device driver specific.
-  int generic_pdo_entry_count;               ///< The number of generic PDO entries.
-  ec_pdo_entry_info_t *generic_pdo_entries;  ///< Generic PDO entries.
-  ec_pdo_info_t *generic_pdos;               ///< Generic PDOs.
-  ec_sync_info_t *generic_sync_managers;     ///< Generic sync managers.
-  lcec_slave_sdoconf_t *sdo_config;          ///< SDO config.
-  lcec_slave_idnconf_t *idn_config;          ///< IDN config.
-  lcec_slave_modparam_t *modparams;          ///< modParams.
-  const LCEC_CONF_FSOE_T *fsoeConf;          ///< Safety config.
-  int is_fsoe_logic;                         ///< Device supports FSoE safety logic.
-  unsigned int *fsoe_slave_offset;           ///< FSoE slave offset.
-  unsigned int *fsoe_master_offset;          ///< FSoE master offset.
-  uint64_t flags;                            ///< Flags, as defined by the driver itself.
+  lcec_slave_t *prev;                         ///< Next slave
+  lcec_slave_t *next;                         ///< Previous slave
+  lcec_master_t *master;                      ///< Master for this slave
+  lcec_sync_unit_t *sync_unit;                ///< Process-data Sync Unit containing this slave.
+  int index;                                  ///< Index of this slave.
+  char name[LCEC_CONF_STR_MAXLEN];            ///< Slave name.
+  char sync_unit_name[LCEC_CONF_STR_MAXLEN];  ///< Configured Sync Unit name.
+  uint32_t sync_unit_cycle;                   ///< Configured process-data cycle in ns.
+  uint32_t vid;                               ///< Slave's vendor ID
+  uint32_t pid;                               ///< Slave's EtherCAT PID/device ID.
+  ec_sync_info_t *sync_info;                  ///< Sync Manager configuration.
+  ec_slave_config_t *config;                  ///< Configuration data.
+  ec_slave_config_state_t state;              ///< Slave state.
+  lcec_slave_dc_t *dc_conf;                   ///< Distributed Clock configuration.
+  lcec_slave_watchdog_t *wd_conf;             ///< Watchdog configuration.
+  lcec_slave_preinit_t proc_preinit;          ///< Callback for pre-init, if any.
+  lcec_slave_init_t proc_init;                ///< Callback for initializing device.
+  lcec_slave_cleanup_t proc_cleanup;          ///< Calback for cleaning up the device.
+  lcec_slave_rw_t proc_read;                  ///< Callback for reading from the device.
+  lcec_slave_rw_t proc_write;                 ///< Callback for writing to the device.
+  lcec_slave_state_t *hal_state_data;         ///< HAL state data.
+  void *hal_data;                             ///< HAL data, device driver specific.
+  int generic_pdo_entry_count;                ///< The number of generic PDO entries.
+  ec_pdo_entry_info_t *generic_pdo_entries;   ///< Generic PDO entries.
+  ec_pdo_info_t *generic_pdos;                ///< Generic PDOs.
+  ec_sync_info_t *generic_sync_managers;      ///< Generic sync managers.
+  lcec_slave_sdoconf_t *sdo_config;           ///< SDO config.
+  lcec_slave_idnconf_t *idn_config;           ///< IDN config.
+  lcec_slave_modparam_t *modparams;           ///< modParams.
+  const LCEC_CONF_FSOE_T *fsoeConf;           ///< Safety config.
+  int is_fsoe_logic;                          ///< Device supports FSoE safety logic.
+  unsigned int *fsoe_slave_offset;            ///< FSoE slave offset.
+  unsigned int *fsoe_master_offset;           ///< FSoE master offset.
+  uint64_t flags;                             ///< Flags, as defined by the driver itself.
   lcec_pdo_entry_reg_t *regs;
 } lcec_slave_t;
 

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -232,6 +232,29 @@ typedef struct lcec_slave_state {
   hal_bit_t *state_op;      ///< Is the device in state `OP`?  Equivalant to the `.slave-state-op` HAL pin.
 } lcec_slave_state_t;
 
+typedef struct lcec_pdo_entry_reg {
+  int current;
+  int max;
+  ec_pdo_entry_reg_t *pdo_entry_regs;
+} lcec_pdo_entry_reg_t;
+
+typedef struct lcec_sync_unit {
+  struct lcec_sync_unit *prev;
+  struct lcec_sync_unit *next;
+  char name[LCEC_CONF_STR_MAXLEN];
+  uint32_t cycle_time;
+  unsigned int cycle_divider;
+  unsigned int cycle_counter;
+  int pdo_entry_count;
+  lcec_pdo_entry_reg_t *regs;
+  ec_domain_t *domain;
+  uint8_t *process_data;
+  int process_data_len;
+  int queued;
+  int process;
+  int write;
+} lcec_sync_unit_t;
+
 typedef struct lcec_master {
   lcec_master_t *prev;              ///< Next master.
   lcec_master_t *next;              ///< Previous master.
@@ -243,6 +266,9 @@ typedef struct lcec_master {
   ec_domain_t *domain;
   uint8_t *process_data;
   int process_data_len;
+  lcec_sync_unit_t *first_sync_unit;
+  lcec_sync_unit_t *last_sync_unit;
+  int sync_units_started;
   lcec_slave_t *first_slave;
   lcec_slave_t *last_slave;
   lcec_master_data_t *hal_data;
@@ -264,12 +290,6 @@ typedef struct lcec_master {
   int dc_time_valid_last;         // Previous cycle's dc_time_valid (for detecting consecutive valid reads)
 #endif
 } lcec_master_t;
-
-typedef struct lcec_pdo_entry_reg {
-  int current;
-  int max;
-  ec_pdo_entry_reg_t *pdo_entry_regs;
-} lcec_pdo_entry_reg_t;
 
 /// @brief Slave Distributed Clock configuration.
 typedef struct {
@@ -315,8 +335,11 @@ typedef struct lcec_slave {
   lcec_slave_t *prev;                        ///< Next slave
   lcec_slave_t *next;                        ///< Previous slave
   lcec_master_t *master;                     ///< Master for this slave
+  lcec_sync_unit_t *sync_unit;               ///< Process-data Sync Unit containing this slave.
   int index;                                 ///< Index of this slave.
   char name[LCEC_CONF_STR_MAXLEN];           ///< Slave name.
+  char sync_unit_name[LCEC_CONF_STR_MAXLEN]; ///< Configured Sync Unit name.
+  uint32_t sync_unit_cycle;                  ///< Configured process-data cycle in ns.
   uint32_t vid;                              ///< Slave's vendor ID
   uint32_t pid;                              ///< Slave's EtherCAT PID/device ID.
   ec_sync_info_t *sync_info;                 ///< Sync Manager configuration.

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -368,6 +368,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
 
 static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **attr) {
   const lcec_typelist_t *slaveType;
+  int syncUnitCycle;
 
   LCEC_CONF_XML_STATE_T *state = (LCEC_CONF_XML_STATE_T *)inst;
 
@@ -378,6 +379,8 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
   }
 
   p->confType = lcecConfTypeSlave;
+  strncpy(p->syncUnit, "default", LCEC_CONF_STR_MAXLEN);
+  p->syncUnitCycle = state->currMaster->appTimePeriod;
 
   int valid = 0;
 
@@ -429,6 +432,23 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
       continue;
     }
 
+    if (strcmp(name, "syncUnit") == 0) {
+      strncpy(p->syncUnit, val, LCEC_CONF_STR_MAXLEN);
+      p->syncUnit[LCEC_CONF_STR_MAXLEN - 1] = 0;
+      continue;
+    }
+
+    if (strcmp(name, "syncUnitCycle") == 0) {
+      syncUnitCycle = parseSyncCycle(state, val);
+      if (syncUnitCycle <= 0) {
+        fprintf(stderr, "%s: ERROR: Invalid syncUnitCycle %s\n", modname, val);
+        XML_StopParser(inst->parser, 0);
+        return;
+      }
+      p->syncUnitCycle = syncUnitCycle;
+      continue;
+    }
+
     if (strcmp(name, "vid") == 0) {
       p->vid = strtol(val, NULL, 16);
       continue;
@@ -459,6 +479,20 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
   // set default name
   if (p->name[0] == 0) {
     snprintf(p->name, LCEC_CONF_STR_MAXLEN, "%d", p->index);
+  }
+
+  if (p->syncUnit[0] == 0) {
+    fprintf(stderr, "%s: ERROR: Slave %s has empty syncUnit attribute\n", modname, p->name);
+    XML_StopParser(inst->parser, 0);
+    return;
+  }
+
+  if (p->syncUnitCycle == 0 || state->currMaster->appTimePeriod == 0 ||
+      (p->syncUnitCycle % state->currMaster->appTimePeriod) != 0) {
+    fprintf(stderr, "%s: ERROR: Slave %s syncUnitCycle %u is not a positive multiple of appTimePeriod %u\n", modname, p->name,
+        p->syncUnitCycle, state->currMaster->appTimePeriod);
+    XML_StopParser(inst->parser, 0);
+    return;
   }
 
   // type is required

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -295,10 +295,10 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
 
     // parse syncToRefClock
     if (strcmp(name, "syncToRefClock") == 0) {
-      p->syncToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1; // -1 = Need to know if option was given
-      continue; // TODO: A general function that can handle four states: yes, no, not given, wrong. Recognize yes/on/true/1/enabled as true
+      p->syncToRefClock = (strcasecmp(val, "true") == 0) ? 1 : -1;  // -1 = Need to know if option was given
+      continue;  // TODO: A general function that can handle four states: yes, no, not given, wrong. Recognize yes/on/true/1/enabled as true
     }
- 
+
     // handle error
     fprintf(stderr, "%s: ERROR: Invalid master attribute %s\n", modname, name);
     XML_StopParser(inst->parser, 0);
@@ -317,8 +317,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
   int given_cycles = p->refClockSyncCycles;
 
   if (given_cycles < -1) {
-    fprintf(stderr, "%s: ERROR: refClockSyncCycles=%d invalid, only -1, 0, or positive values allowed\n",
-        modname, given_cycles);
+    fprintf(stderr, "%s: ERROR: refClockSyncCycles=%d invalid, only -1, 0, or positive values allowed\n", modname, given_cycles);
     XML_StopParser(inst->parser, 0);
     return;
   }
@@ -333,8 +332,8 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
       fprintf(stderr, "%s: WARNING: syncToRefClock=\"true\" with refClockSyncCycles=%d is redundant, just use refClockSyncCycles=\"-1\"\n",
           modname, given_cycles);
     } else if (given_cycles > 0) {
-      fprintf(stderr, "%s: ERROR: syncToRefClock=\"true\" conflicts with refClockSyncCycles=%d (positive = R2M mode)\n",
-          modname, given_cycles);
+      fprintf(
+          stderr, "%s: ERROR: syncToRefClock=\"true\" conflicts with refClockSyncCycles=%d (positive = R2M mode)\n", modname, given_cycles);
       XML_StopParser(inst->parser, 0);
       return;
     }
@@ -344,8 +343,8 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
   } else {
     // syncToRefClock="false"
     if (given_cycles < 0) {
-      fprintf(stderr, "%s: ERROR: syncToRefClock=\"false\" conflicts with refClockSyncCycles=%d (negative = M2R mode)\n",
-          modname, given_cycles);
+      fprintf(stderr, "%s: ERROR: syncToRefClock=\"false\" conflicts with refClockSyncCycles=%d (negative = M2R mode)\n", modname,
+          given_cycles);
       XML_StopParser(inst->parser, 0);
       return;
     }
@@ -356,7 +355,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
     p->syncToRefClock = 0;
     // refClockSyncCycles already >= 0, keep as-is
   }
-  
+
   // set default name
   if (p->name[0] == 0) {
     snprintf(p->name, LCEC_CONF_STR_MAXLEN, "%d", p->index);
@@ -487,8 +486,7 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
     return;
   }
 
-  if (p->syncUnitCycle == 0 || state->currMaster->appTimePeriod == 0 ||
-      (p->syncUnitCycle % state->currMaster->appTimePeriod) != 0) {
+  if (p->syncUnitCycle == 0 || state->currMaster->appTimePeriod == 0 || (p->syncUnitCycle % state->currMaster->appTimePeriod) != 0) {
     fprintf(stderr, "%s: ERROR: Slave %s syncUnitCycle %u is not a positive multiple of appTimePeriod %u\n", modname, p->name,
         p->syncUnitCycle, state->currMaster->appTimePeriod);
     XML_StopParser(inst->parser, 0);

--- a/src/lcec_conf.h
+++ b/src/lcec_conf.h
@@ -92,6 +92,8 @@ typedef struct {
   size_t sdoConfigLength;
   size_t idnConfigLength;
   unsigned int modParamCount;
+  uint32_t syncUnitCycle;
+  char syncUnit[LCEC_CONF_STR_MAXLEN];
   char name[LCEC_CONF_STR_MAXLEN];
 } LCEC_CONF_SLAVE_T;
 

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -128,18 +128,54 @@ void lcec_read_master(void *arg, long period);
 void lcec_write_master(void *arg, long period);
 static int lcec_activate_master(lcec_master_t *master);
 static void lcec_activate(void *arg, long period);
+static lcec_sync_unit_t *lcec_master_get_sync_unit(lcec_master_t *master, const char *name, uint32_t cycle_time);
+static int lcec_master_all_op(lcec_master_t *master);
 
 static void sigsegv_handler(int sig);
+
+static lcec_sync_unit_t *lcec_master_get_sync_unit(lcec_master_t *master, const char *name, uint32_t cycle_time) {
+  lcec_sync_unit_t *sync_unit;
+
+  if (cycle_time == 0 || master->app_time_period == 0 || (cycle_time % master->app_time_period) != 0) {
+    rtapi_print_msg(RTAPI_MSG_ERR,
+        LCEC_MSG_PFX "master %s syncUnit %s cycle %u is not a positive multiple of appTimePeriod %u\n", master->name, name, cycle_time,
+        master->app_time_period);
+    return NULL;
+  }
+
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    if (strncmp(sync_unit->name, name, LCEC_CONF_STR_MAXLEN) == 0) {
+      if (sync_unit->cycle_time != cycle_time) {
+        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s cycle mismatch (%u != %u)\n", master->name, name,
+            sync_unit->cycle_time, cycle_time);
+        return NULL;
+      }
+      return sync_unit;
+    }
+  }
+
+  sync_unit = LCEC_ALLOCATE(lcec_sync_unit_t);
+  strncpy(sync_unit->name, name, LCEC_CONF_STR_MAXLEN);
+  sync_unit->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+  sync_unit->cycle_time = cycle_time;
+  sync_unit->cycle_divider = cycle_time / master->app_time_period;
+  sync_unit->queued = 1;
+  LCEC_LIST_APPEND(master->first_sync_unit, master->last_sync_unit, sync_unit);
+
+  return sync_unit;
+}
+
+static int lcec_master_all_op(lcec_master_t *master) { return master->ms.al_states == 0x08; }
 
 /// @brief Main entrypoint from LinuxCNC
 int rtapi_app_main(void) {
   int slave_count;
   lcec_master_t *master;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
   char name[HAL_NAME_LEN + 1];
   lcec_slave_sdoconf_t *sdo_config;
   lcec_slave_idnconf_t *idn_config;
-  int pdo_entry_count = 0;
 
 #ifndef __KERNEL
   struct sigaction handler;
@@ -193,10 +229,16 @@ int rtapi_app_main(void) {
     ecrt_master_callbacks(master->master, lcec_request_lock, lcec_release_lock, master);
 #endif
 
-    // create domain
-    if (!(master->domain = ecrt_master_create_domain(master->master))) {
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s domain creation failed\n", master->name);
-      goto fail2;
+    // create one process-data domain per Sync Unit
+    for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+      if (!(sync_unit->domain = ecrt_master_create_domain(master->master))) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s domain creation failed\n", master->name, sync_unit->name);
+        goto fail2;
+      }
+      if (master->domain == NULL) {
+        master->domain = sync_unit->domain;
+      }
     }
 
     // initialize slaves
@@ -257,6 +299,13 @@ int rtapi_app_main(void) {
 
       // configure dc for this slave
       if (slave->dc_conf != NULL) {
+        if (slave->sync_unit->cycle_divider > 1 && slave->dc_conf->sync0Cycle > 0 &&
+            slave->dc_conf->sync0Cycle != slave->sync_unit->cycle_time) {
+          rtapi_print_msg(RTAPI_MSG_WARN,
+              LCEC_MSG_PFX "slave %s.%s syncUnit %s cycle=%u ns but DC sync0Cycle=%u ns; set dcConf sync0Cycle to the slave "
+                           "hardware cycle or keep this slave in a matching syncUnit\n",
+              master->name, slave->name, slave->sync_unit->name, slave->sync_unit->cycle_time, slave->dc_conf->sync0Cycle);
+        }
         ecrt_slave_config_dc(slave->config, slave->dc_conf->assignActivate, slave->dc_conf->sync0Cycle, slave->dc_conf->sync0Shift,
             slave->dc_conf->sync1Cycle, slave->dc_conf->sync1Shift);
         rtapi_print_msg(RTAPI_MSG_DBG,
@@ -286,22 +335,31 @@ int rtapi_app_main(void) {
         goto fail2;
       }
 
-      pdo_entry_count += lcec_pdo_entry_reg_len(slave->regs);
+      slave->sync_unit->pdo_entry_count += lcec_pdo_entry_reg_len(slave->regs);
     }
 
-    lcec_pdo_entry_reg_t *master_regs = lcec_allocate_pdo_entry_reg(pdo_entry_count + 1);
-    for (slave = master->first_slave; slave != NULL; slave = slave->next) {
-      if (lcec_append_pdo_entry_reg(master_regs, slave->regs) < 0) {
-        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failure to append PDO entries for slave %s.%s\n", master->name, slave->name);
+    // collect and register PDO entries separately for every Sync Unit/domain
+    for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+      sync_unit->regs = lcec_allocate_pdo_entry_reg(sync_unit->pdo_entry_count + 1);
+      if (sync_unit->regs == NULL) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, LCEC_MSG_PFX "failure allocating PDO entries for syncUnit %s.%s\n", master->name, sync_unit->name);
         goto fail2;
       }
-    }
 
-    // register PDO entries
-    rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "register PDO entries\n");
-    if (ecrt_domain_reg_pdo_entry_list(master->domain, master_regs->pdo_entry_regs)) {
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s PDO entry registration failed\n", master->name);
-      goto fail2;
+      for (slave = master->first_slave; slave != NULL; slave = slave->next) {
+        if (slave->sync_unit == sync_unit && lcec_append_pdo_entry_reg(sync_unit->regs, slave->regs) < 0) {
+          rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failure to append PDO entries for slave %s.%s\n", master->name, slave->name);
+          goto fail2;
+        }
+      }
+
+      rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "register PDO entries for syncUnit %s.%s\n", master->name, sync_unit->name);
+      if (ecrt_domain_reg_pdo_entry_list(sync_unit->domain, sync_unit->regs->pdo_entry_regs)) {
+        rtapi_print_msg(
+            RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s PDO entry registration failed\n", master->name, sync_unit->name);
+        goto fail2;
+      }
     }
 
     // init hal data
@@ -550,7 +608,15 @@ int lcec_parse_config(void) {
         slave->index = slave_conf->index;
         strncpy(slave->name, slave_conf->name, LCEC_CONF_STR_MAXLEN);
         slave->name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+        strncpy(slave->sync_unit_name, slave_conf->syncUnit, LCEC_CONF_STR_MAXLEN);
+        slave->sync_unit_name[LCEC_CONF_STR_MAXLEN - 1] = 0;
+        slave->sync_unit_cycle = slave_conf->syncUnitCycle;
         slave->master = master;
+
+        slave->sync_unit = lcec_master_get_sync_unit(master, slave->sync_unit_name, slave->sync_unit_cycle);
+        if (slave->sync_unit == NULL) {
+          goto fail2;
+        }
 
         // add slave to list
         LCEC_LIST_APPEND(master->first_slave, master->last_slave, slave);
@@ -1123,6 +1189,7 @@ static void lcec_activate(void *arg, long period) {
 /// minimizing the delay between activation and cyclic communication.
 static int lcec_activate_master(lcec_master_t *master) {
   struct timeval tv;
+  lcec_sync_unit_t *sync_unit;
   
   uint64_t initial_app_time;
   
@@ -1172,9 +1239,17 @@ static int lcec_activate_master(lcec_master_t *master) {
     return -1;
   }
   
-  // Get internal process data for domain
-  master->process_data = ecrt_domain_data(master->domain);
-  master->process_data_len = ecrt_domain_size(master->domain);
+  // Get internal process data for every Sync Unit domain.
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    sync_unit->process_data = ecrt_domain_data(sync_unit->domain);
+    sync_unit->process_data_len = ecrt_domain_size(sync_unit->domain);
+    if (master->process_data == NULL) {
+      master->process_data = sync_unit->process_data;
+      master->process_data_len = sync_unit->process_data_len;
+    }
+    rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "master %s syncUnit %s cycle=%u ns divider=%u process_data_len=%d\n", master->name,
+        sync_unit->name, sync_unit->cycle_time, sync_unit->cycle_divider, sync_unit->process_data_len);
+  }
   
   master->activated = 1;
   rtapi_print_msg(RTAPI_MSG_INFO, LCEC_MSG_PFX "Master %s activated successfully\n", master->name);
@@ -1186,6 +1261,7 @@ static int lcec_activate_master(lcec_master_t *master) {
 void lcec_read_master(void *arg, long period) {
   lcec_master_t *master = (lcec_master_t *)arg;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
   int check_states;
 
   // Master not yet activated: process_data is NULL until lcec_activate_master()
@@ -1216,7 +1292,10 @@ void lcec_read_master(void *arg, long period) {
   }
 
   // get state check flag
-  if (master->state_update_timer > 0) {
+  if (!master->sync_units_started) {
+    check_states = 1;
+    master->state_update_timer = 0;
+  } else if (master->state_update_timer > 0) {
     check_states = 0;
     master->state_update_timer -= period;
   } else {
@@ -1224,16 +1303,42 @@ void lcec_read_master(void *arg, long period) {
     master->state_update_timer = LCEC_STATE_UPDATE_PERIOD;
   }
 
-  // receive process data & master state
+// receive process data & master state
   ec_domain_state_t domain_state;
+  int all_domains_zero = 1;
+  int all_domains_complete = 1;
   uint32_t dc_sync_diff;
   rtapi_mutex_get(&master->mutex);
   ecrt_master_receive(master->master);
-  ecrt_domain_process(master->domain);
-  ecrt_domain_state(master->domain, &domain_state);
+  domain_state.working_counter = 0;
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    ec_domain_state_t sync_unit_state;
+
+    sync_unit->process = sync_unit->queued;
+    if (sync_unit->process) {
+      ecrt_domain_process(sync_unit->domain);
+      sync_unit->queued = 0;
+    }
+
+    // Aggregate the most recent state of every Sync Unit so the master WKC
+    // pins continue to describe the complete process image. Domains that are
+    // not scheduled this cycle retain their last reported state.
+    ecrt_domain_state(sync_unit->domain, &sync_unit_state);
+    domain_state.working_counter += sync_unit_state.working_counter;
+    if (sync_unit_state.wc_state != EC_WC_ZERO) {
+      all_domains_zero = 0;
+    }
+    if (sync_unit_state.wc_state != EC_WC_COMPLETE) {
+      all_domains_complete = 0;
+    }
+  }
+  domain_state.wc_state = all_domains_complete ? EC_WC_COMPLETE : (all_domains_zero ? EC_WC_ZERO : EC_WC_INCOMPLETE);
   dc_sync_diff = master->hal_data->dc_sync_monitor ? ecrt_master_sync_monitor_process(master->master) : 0xffffffffu;
   if (check_states) {
     ecrt_master_state(master->master, &master->ms);
+  }
+  if (!master->sync_units_started && lcec_master_all_op(master)) {
+    master->sync_units_started = 1;
   }
   rtapi_mutex_give(&master->mutex);
 
@@ -1312,8 +1417,10 @@ void lcec_read_master(void *arg, long period) {
     }
 
     // process read function
-    if (slave->proc_read != NULL) {
-      slave->proc_read(slave, period);
+    if (slave->sync_unit->process && slave->proc_read != NULL) {
+      master->process_data = slave->sync_unit->process_data;
+      master->process_data_len = slave->sync_unit->process_data_len;
+      slave->proc_read(slave, slave->sync_unit->cycle_time);
     }
   }
 }
@@ -1322,6 +1429,8 @@ void lcec_read_master(void *arg, long period) {
 void lcec_write_master(void *arg, long period) {
   lcec_master_t *master = (lcec_master_t *)arg;
   lcec_slave_t *slave;
+  lcec_sync_unit_t *sync_unit;
+  int force_cycle;
   uint64_t app_time;
   long long now;
 #ifdef RTAPI_TASK_PLL_SUPPORT
@@ -1349,10 +1458,28 @@ void lcec_write_master(void *arg, long period) {
     }
   }
 
+  // Keep all domains cycling during startup. Once OP has been reached, run
+  // each Sync Unit at its configured integer divider.
+  force_cycle = !master->sync_units_started;
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    if (force_cycle) {
+      sync_unit->write = 1;
+      sync_unit->cycle_counter = 0;
+    } else if (sync_unit->cycle_counter == 0) {
+      sync_unit->write = 1;
+      sync_unit->cycle_counter = sync_unit->cycle_divider - 1;
+    } else {
+      sync_unit->write = 0;
+      sync_unit->cycle_counter--;
+    }
+  }
+
   // process slaves
   for (slave = master->first_slave; slave != NULL; slave = slave->next) {
-    if (slave->proc_write != NULL) {
-      slave->proc_write(slave, period);
+    if (slave->sync_unit->write && slave->proc_write != NULL) {
+      master->process_data = slave->sync_unit->process_data;
+      master->process_data_len = slave->sync_unit->process_data_len;
+      slave->proc_write(slave, slave->sync_unit->cycle_time);
     }
   }
 
@@ -1363,7 +1490,12 @@ void lcec_write_master(void *arg, long period) {
 
   // send process data
   rtapi_mutex_get(&master->mutex);
-  ecrt_domain_queue(master->domain);
+  for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
+    if (sync_unit->write) {
+      ecrt_domain_queue(sync_unit->domain);
+      sync_unit->queued = 1;
+    }
+  }
 
   // update application time
   now = rtapi_get_time();

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -28,7 +28,7 @@
 #include "devices/lcec_generic.h"
 #include "lcec.h"
 #include "rtapi_app.h"
-//#include <linuxcnc/rtapi_mutex.h>
+// #include <linuxcnc/rtapi_mutex.h>
 
 MODULE_LICENSE("GPL")
 MODULE_AUTHOR("Sascha Ittner <sascha.ittner@modusoft.de>")
@@ -39,8 +39,7 @@ MODULE_DESCRIPTION("Driver for EtherCAT devices")
    work against both old and new linuxcnc, with automatic fallback to legacy
    inline activation when the new API is missing. */
 #pragma weak hal_init_funct_to_thread
-extern int hal_init_funct_to_thread(const char *funct_name,
-    const char *thread_name, int position);
+extern int hal_init_funct_to_thread(const char *funct_name, const char *thread_name, int position);
 
 /* Set in rtapi_app_main from the weak-symbol probe. */
 static int initf_supported = 0;
@@ -137,9 +136,8 @@ static lcec_sync_unit_t *lcec_master_get_sync_unit(lcec_master_t *master, const 
   lcec_sync_unit_t *sync_unit;
 
   if (cycle_time == 0 || master->app_time_period == 0 || (cycle_time % master->app_time_period) != 0) {
-    rtapi_print_msg(RTAPI_MSG_ERR,
-        LCEC_MSG_PFX "master %s syncUnit %s cycle %u is not a positive multiple of appTimePeriod %u\n", master->name, name, cycle_time,
-        master->app_time_period);
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s cycle %u is not a positive multiple of appTimePeriod %u\n",
+        master->name, name, cycle_time, master->app_time_period);
     return NULL;
   }
 
@@ -165,7 +163,7 @@ static lcec_sync_unit_t *lcec_master_get_sync_unit(lcec_master_t *master, const 
   return sync_unit;
 }
 
-static int lcec_master_all_op(lcec_master_t *master) { return master->ms.al_states == 0x08; }
+static int lcec_master_all_op(lcec_master_t *master) { return master->ms.al_states == EC_AL_STATE_OP; }
 
 /// @brief Main entrypoint from LinuxCNC
 int rtapi_app_main(void) {
@@ -232,8 +230,7 @@ int rtapi_app_main(void) {
     // create one process-data domain per Sync Unit
     for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
       if (!(sync_unit->domain = ecrt_master_create_domain(master->master))) {
-        rtapi_print_msg(
-            RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s domain creation failed\n", master->name, sync_unit->name);
+        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s domain creation failed\n", master->name, sync_unit->name);
         goto fail2;
       }
       if (master->domain == NULL) {
@@ -254,7 +251,7 @@ int rtapi_app_main(void) {
       // initialize sdos
       if (slave->sdo_config != NULL) {
         for (sdo_config = slave->sdo_config; sdo_config->index != 0xffff;
-             sdo_config = (lcec_slave_sdoconf_t *)&sdo_config->data[sdo_config->length]) {
+            sdo_config = (lcec_slave_sdoconf_t *)&sdo_config->data[sdo_config->length]) {
           if (sdo_config->subindex == LCEC_CONF_SDO_COMPLETE_SUBIDX) {
             if (ecrt_slave_config_complete_sdo(slave->config, sdo_config->index, &sdo_config->data[0], sdo_config->length) != 0) {
               rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failed to configure slave %s.%s sdo %04x (complete)\n", master->name,
@@ -272,7 +269,7 @@ int rtapi_app_main(void) {
       // initialize idns
       if (slave->idn_config != NULL) {
         for (idn_config = slave->idn_config; idn_config->state != 0;
-             idn_config = (lcec_slave_idnconf_t *)&idn_config->data[idn_config->length]) {
+            idn_config = (lcec_slave_idnconf_t *)&idn_config->data[idn_config->length]) {
           if (ecrt_slave_config_idn(
                   slave->config, idn_config->drive, idn_config->idn, idn_config->state, &idn_config->data[0], idn_config->length) != 0) {
             rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "fail to configure slave %s.%s drive %d idn %c-%d-%d (state %d, length %u)\n",
@@ -302,8 +299,9 @@ int rtapi_app_main(void) {
         if (slave->sync_unit->cycle_divider > 1 && slave->dc_conf->sync0Cycle > 0 &&
             slave->dc_conf->sync0Cycle != slave->sync_unit->cycle_time) {
           rtapi_print_msg(RTAPI_MSG_WARN,
-              LCEC_MSG_PFX "slave %s.%s syncUnit %s cycle=%u ns but DC sync0Cycle=%u ns; set dcConf sync0Cycle to the slave "
-                           "hardware cycle or keep this slave in a matching syncUnit\n",
+              LCEC_MSG_PFX
+              "slave %s.%s syncUnit %s cycle=%u ns but DC sync0Cycle=%u ns; set dcConf sync0Cycle to the slave "
+              "hardware cycle or keep this slave in a matching syncUnit\n",
               master->name, slave->name, slave->sync_unit->name, slave->sync_unit->cycle_time, slave->dc_conf->sync0Cycle);
         }
         ecrt_slave_config_dc(slave->config, slave->dc_conf->assignActivate, slave->dc_conf->sync0Cycle, slave->dc_conf->sync0Shift,
@@ -342,8 +340,7 @@ int rtapi_app_main(void) {
     for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
       sync_unit->regs = lcec_allocate_pdo_entry_reg(sync_unit->pdo_entry_count + 1);
       if (sync_unit->regs == NULL) {
-        rtapi_print_msg(
-            RTAPI_MSG_ERR, LCEC_MSG_PFX "failure allocating PDO entries for syncUnit %s.%s\n", master->name, sync_unit->name);
+        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failure allocating PDO entries for syncUnit %s.%s\n", master->name, sync_unit->name);
         goto fail2;
       }
 
@@ -356,8 +353,7 @@ int rtapi_app_main(void) {
 
       rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "register PDO entries for syncUnit %s.%s\n", master->name, sync_unit->name);
       if (ecrt_domain_reg_pdo_entry_list(sync_unit->domain, sync_unit->regs->pdo_entry_regs)) {
-        rtapi_print_msg(
-            RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s PDO entry registration failed\n", master->name, sync_unit->name);
+        rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "master %s syncUnit %s PDO entry registration failed\n", master->name, sync_unit->name);
         goto fail2;
       }
     }
@@ -1190,19 +1186,19 @@ static void lcec_activate(void *arg, long period) {
 static int lcec_activate_master(lcec_master_t *master) {
   struct timeval tv;
   lcec_sync_unit_t *sync_unit;
-  
+
   uint64_t initial_app_time;
-  
+
   if (master->activated) {
     return 0;  // Already activated
   }
-  
+
   rtapi_print_msg(RTAPI_MSG_INFO, LCEC_MSG_PFX "Activating master %s (delayed activation in RT thread)\n", master->name);
-  
+
   // Initialize application time base (now we're in the RT thread context)
   lcec_gettimeofday(&tv);
   master->app_time_base = EC_TIMEVAL2NANO(tv);
-  
+
 #ifdef RTAPI_TASK_PLL_SUPPORT
   master->dc_time_valid_last = 0;
   master->dc_ref = 0;
@@ -1238,7 +1234,7 @@ static int lcec_activate_master(lcec_master_t *master) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failed to activate master %s\n", master->name);
     return -1;
   }
-  
+
   // Get internal process data for every Sync Unit domain.
   for (sync_unit = master->first_sync_unit; sync_unit != NULL; sync_unit = sync_unit->next) {
     sync_unit->process_data = ecrt_domain_data(sync_unit->domain);
@@ -1250,10 +1246,10 @@ static int lcec_activate_master(lcec_master_t *master) {
     rtapi_print_msg(RTAPI_MSG_DBG, LCEC_MSG_PFX "master %s syncUnit %s cycle=%u ns divider=%u process_data_len=%d\n", master->name,
         sync_unit->name, sync_unit->cycle_time, sync_unit->cycle_divider, sync_unit->process_data_len);
   }
-  
+
   master->activated = 1;
   rtapi_print_msg(RTAPI_MSG_INFO, LCEC_MSG_PFX "Master %s activated successfully\n", master->name);
-  
+
   return 0;
 }
 
@@ -1282,8 +1278,8 @@ void lcec_read_master(void *arg, long period) {
   if (period != master->period_last) {
     master->period_last = period;
     if (master->app_time_period == 0) {
-      rtapi_print_msg(RTAPI_MSG_INFO, LCEC_MSG_PFX "appTimePeriod not set for master %s, using HAL thread period %ld ns\n", master->name,
-          period);
+      rtapi_print_msg(
+          RTAPI_MSG_INFO, LCEC_MSG_PFX "appTimePeriod not set for master %s, using HAL thread period %ld ns\n", master->name, period);
       master->app_time_period = period;
     } else if (master->app_time_period != period) {
       rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "Invalid appTimePeriod of %u for master %s (should be %ld).\n", master->app_time_period,
@@ -1303,7 +1299,7 @@ void lcec_read_master(void *arg, long period) {
     master->state_update_timer = LCEC_STATE_UPDATE_PERIOD;
   }
 
-// receive process data & master state
+  // receive process data & master state
   ec_domain_state_t domain_state;
   int all_domains_zero = 1;
   int all_domains_complete = 1;
@@ -1447,7 +1443,8 @@ void lcec_write_master(void *arg, long period) {
   if (!master->activated) {
     if (!master->forgot_warned) {
       master->forgot_warned = 1;
-      rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX
+      rtapi_print_msg(RTAPI_MSG_ERR,
+          LCEC_MSG_PFX
           "master '%s' not activated via initf. "
           "Add `initf %s.activate <thread>` to your .hal file before `start`. "
           "Falling back to inline activation; DC phasing will trim via PLL.\n",
@@ -1551,7 +1548,7 @@ void lcec_write_master(void *arg, long period) {
   *(hal_data->pll_err) = 0;
   *(hal_data->pll_out) = 0;
   *(hal_data->dc_phased) = 0;
-  
+
   // Calculate app_phase: our execution position in local cycle
   // This is relative to dc_ref_time (the time we set at activation)
   // app_phase = (app_time - dc_ref_time) % period
@@ -1559,12 +1556,12 @@ void lcec_write_master(void *arg, long period) {
   int32_t current_app_phase = (int32_t)((app_time - master->dc_ref_time) % master->app_time_period);
   *(hal_data->app_phase) = current_app_phase;
   int32_t app_period = (int32_t)master->app_time_period;
-  
+
   // When sync_to_ref_clock = false: adjust app_phase to a stable position using PLL
   // This is needed because app_phase is random at startup
   if (!master->sync_to_ref_clock) {
-    #define PHASE_MEASURE_CYCLES 100
-    
+#define PHASE_MEASURE_CYCLES 100
+
     if (!hal_data->phase_calibrated) {
       // Phase 1: Measure app_phase jitter over PHASE_MEASURE_CYCLES cycles
       if (hal_data->phase_measure_cnt == 0) {
@@ -1577,7 +1574,7 @@ void lcec_write_master(void *arg, long period) {
         // Detect boundary crossing: if difference > app_period/2, phase wrapped around
         int32_t diff = current_app_phase - hal_data->phase_last;
         int32_t adjusted_phase = current_app_phase;
-        
+
         // Unwrap: if phase jumped by more than half period, adjust for continuity
         if (diff > app_period / 2) {
           // Jumped from low to high (e.g., 10000 -> 990000), adjust down
@@ -1586,7 +1583,7 @@ void lcec_write_master(void *arg, long period) {
           // Jumped from high to low (e.g., 990000 -> 10000), adjust up
           adjusted_phase = current_app_phase + app_period;
         }
-        
+
         // Update min/max with adjusted phase
         if (adjusted_phase < hal_data->phase_min) {
           hal_data->phase_min = adjusted_phase;
@@ -1594,28 +1591,28 @@ void lcec_write_master(void *arg, long period) {
         if (adjusted_phase > hal_data->phase_max) {
           hal_data->phase_max = adjusted_phase;
         }
-        
+
         hal_data->phase_last = current_app_phase;
         hal_data->phase_measure_cnt++;
       } else {
         // Phase 2: Calculate jitter and target position
         hal_data->phase_jitter = hal_data->phase_max - hal_data->phase_min;
         *(hal_data->phase_jitter_out) = hal_data->phase_jitter;  // Output jitter for debugging
-        
+
         // Target position: jitter + jitter/2 = jitter * 1.5
         int32_t target = hal_data->phase_jitter + hal_data->phase_jitter / 2;
-        
+
         // Limit target to app_period/8
         int32_t max_target = app_period / 8;
         if (target > max_target) {
           target = max_target;
         }
-        
+
         hal_data->phase_target = target;
         hal_data->phase_calibrated = 1;
-        
-        rtapi_print_msg(RTAPI_MSG_INFO, LCEC_MSG_PFX "Phase calibration complete: jitter=%d target=%d\n",
-            hal_data->phase_jitter, hal_data->phase_target);
+
+        rtapi_print_msg(RTAPI_MSG_INFO, LCEC_MSG_PFX "Phase calibration complete: jitter=%d target=%d\n", hal_data->phase_jitter,
+            hal_data->phase_target);
       }
     } else if (!master->initf_activated) {
       // Phase 3: Use PLL to move app_phase towards target.
@@ -1627,21 +1624,21 @@ void lcec_write_master(void *arg, long period) {
       // Positive error (app_phase > target) means we need to speed up to reduce app_phase
       // Negative error (app_phase < target) means we need to slow down to increase app_phase
       int32_t phase_error = current_app_phase - hal_data->phase_target;
-      
+
       // Set pll_err for monitoring
       //*(hal_data->pll_err) = raw_offset + drift;
-      
+
       // Check if locked (within 10% of jitter or 1% of app_period, whichever is larger)
-      int32_t lock_threshold = 0;//hal_data->phase_jitter;
+      int32_t lock_threshold = 0;  // hal_data->phase_jitter;
       if (lock_threshold < app_period / 100) {
         lock_threshold = app_period / 100;
       }
-      if (abs(phase_error) < abs(hal_data->pll_step) * 3 ) {
+      if (abs(phase_error) < abs(hal_data->pll_step) * 3) {
         *(hal_data->dc_phased) = 1;
-      } else if (abs(phase_error) > abs(hal_data->pll_step) * 20 ) {
+      } else if (abs(phase_error) > abs(hal_data->pll_step) * 20) {
         *(hal_data->dc_phased) = 0;
       }
-      
+
       // BANG-BANG control: small steps to move towards target
       // Positive pll_out = slow down = app_phase increases
       // Negative pll_out = speed up = app_phase decreases
@@ -1664,12 +1661,12 @@ void lcec_write_master(void *arg, long period) {
       *(hal_data->dc_phased) = 1;
     }
   }
-  
+
   // the first read dc_time value seems to be invalid, so wait for two successive successful reads
   if (dc_time_valid && master->dc_time_valid_last) {
     // Raw offset between app_time and dc_time (this is what varies at each startup)
     int32_t raw_offset = master->app_time_last - dc_time;
-    
+
     // Apply drift compensation based on drift-mode:
     //   0 = simple: (app_period - app_phase) % app_period
     //   1 = manual: use pll-drift pin value
@@ -1689,15 +1686,15 @@ void lcec_write_master(void *arg, long period) {
       }
     }
     // Mode 1 or other: use manual pll-drift value
-    
+
     *(hal_data->pll_err) = raw_offset + drift;
-    
+
     // PLL is considered phased if error is within 10% of period
     int32_t lock_threshold = master->app_time_period / 10;
     if (abs(*(hal_data->pll_err)) < lock_threshold) {
       *(hal_data->dc_phased) = 1;
     }
-    
+
     // Only run automatic PLL adjustment when sync_to_ref_clock is enabled
     // When sync_to_ref_clock = false, master is the clock source, DC syncs to us
     // When sync_to_ref_clock = true, DC is the clock source, we sync to DC
@@ -1715,7 +1712,7 @@ void lcec_write_master(void *arg, long period) {
           hal_data->auto_drift_delay = 100;
         }
       } else {
-          *(hal_data->pll_out) = (*(hal_data->pll_err) < 0) ? -(hal_data->pll_step) : (hal_data->pll_step);
+        *(hal_data->pll_out) = (*(hal_data->pll_err) < 0) ? -(hal_data->pll_step) : (hal_data->pll_step);
       }
     }
     // Note: When sync_to_ref_clock = false, pll_out is set in the phase calibration code above
@@ -1737,15 +1734,14 @@ void lcec_write_master(void *arg, long period) {
       pll_correction = *(hal_data->pll_out) + *(hal_data->pll_drift);
     }
   }
-  
+
   *(hal_data->pll_final) = pll_correction;
   rtapi_task_pll_set_correction(pll_correction);
-  
+
   master->app_time_last = (uint32_t)app_time;
   master->dc_time_valid_last = dc_time_valid;
 #endif
 }
-
 
 #ifndef __KERNEL__
 #define BACKTRACE_SIZE 100


### PR DESCRIPTION
solution of issue #489 

This PR adds Sync Unit support so slaves on the same EtherCAT master can be grouped into separate process-data domains and exchanged at different integer-multiple update rates.

What changed:
- Added `syncUnit` and `syncUnitCycle` slave XML attributes.
- Slaves with the same `syncUnit` share one EtherCAT domain.
- Each Sync Unit is queued/processed only on its configured cycle divider.
- Existing configs keep the old behavior via default `syncUnit="default"` and `syncUnitCycle="*1"`.
- Added documentation and an `examples/sync-units` XML example.

Notes:
- `syncUnitCycle` must be a positive multiple of `appTimePeriod`.
- All slaves in the same Sync Unit must use the same cycle.
- This does not replace DC configuration; DC-capable slaves should still use `<dcConf>` aligned with their intended hardware update period.