### PR TITLE
fix(main): skip the DC reference-clock read when the master runs free

### DIFF
--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -1514,9 +1514,19 @@ void lcec_write_master(void *arg, long period) {
 
   // Read DC reference clock time (must be before sync_slave_clocks which
   // re-queues the sync datagram and overwrites the received data)
+  //
+  // Skipped when the master runs free, i.e. when no DC sync is configured in
+  // either direction. The ioctl fails there, and the userspace library prints
+  // the failure to stderr from this thread on every cycle. Both terms are
+  // needed: R2M (syncToRefClock=0, refClockSyncCycles>0) is a DC mode and also
+  // has sync_to_ref_clock == 0, so the direction flag alone does not
+  // distinguish it from free running.
 #ifdef RTAPI_TASK_PLL_SUPPORT
   uint32_t dc_time = 0;
-  int dc_time_valid = (ecrt_master_reference_clock_time(master->master, &dc_time) == 0);
+  int dc_time_valid = 0;
+  if (master->sync_to_ref_clock || master->sync_ref_cycles) {
+    dc_time_valid = (ecrt_master_reference_clock_time(master->master, &dc_time) == 0);
+  }
 #endif
 
   // sync ref clock to master


### PR DESCRIPTION
`lcec_write_master` calls `ecrt_master_reference_clock_time()` on every cycle,
including in the free-running configuration (`syncToRefClock=0`,
`refClockSyncCycles=0`). There the ioctl fails, and the IgH library prints the
failure **from the calling thread** — `lib/master.c:771`, an unconditional
`fprintf`, at that line in 1.6.0 through 1.6.10 and on `stable-1.6`.

With stderr on a writeback filesystem, which is the default under `halrun`, that
print blocks. A `function_graph` trace on the cycle thread caught 8.7 ms in one
`write()`:

```
 7) # 8571.208 us |         } /* io_schedule */
 7) # 8575.875 us |        } /* __folio_lock */
 7) # 8581.125 us |      } /* ext4_da_write_begin */
 7) # 8712.666 us |   } /* vfs_write */
```

`schedstat` `block_max` jumped 121 µs → 2.8 ms in the same window; with stderr on
tmpfs it stays 0 over ~1.8 M cycles.

**Both terms are needed.** Per `lcec_conf.c:312-314`, R2M is
`syncToRefClock=0, refClockSyncCycles>0` — a DC mode with
`sync_to_ref_clock == 0` — so the direction flag alone would skip the read there
too. Free running is the case where both are zero. Same shape as the
`dc_sync_monitor` guard fifteen lines below.

**One pin changes.** `<master>.pll-err` reads a constant 0 when the master runs
free. It was not zero before — the read succeeds in 99.93 % of cycles and the pin
carried 1.0 … 2.1 ms — but with no DC sync it compares application time against
an unsynchronised bus clock, so the value was unusable rather than unused. It
never reached the control path: the `dc_phased` latch needs
`|pll_err| < appTimePeriod/10` = 100 µs, the smallest non-zero sample in 150 000
cycles was 1 000 439 ns, and all 105 sub-threshold samples were exactly the zero
left by a failed read. M2R and R2M are untouched.

**Testing.** Debian Trixie, LinuxCNC 2.9.4: `make build` clean, `make test`
passes, `clang-format` returns the file unchanged, and the HAL surface is
identical to an unpatched build of the same commit (`lcec.so.ver` byte-identical,
682 format strings, `lcec_devices` 326 lines). Not built on bullseye or
bookworm. On the bench — seven slaves, RK3588, PREEMPT_RT, IgH 1.6.10, 1 ms
cycle, free running — library stderr goes from **0.42 lines/s to 0** over a timed
200 s window, with 7/7 slaves in OP and no Tx errors or lost frames either side.

The library side is arguably the real defect. IgH's `devel` branch already
suppresses these error codes, but `devel` is not an ancestor of `stable-1.6` and
it never came across; I intend to report it there. This patch stands either way
— the call is pointless in this configuration regardless.
