### PR TITLE
fix(main): fold pll_err in the M2R branch; resync removes only whole periods

### DIFF
--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -1694,7 +1694,20 @@ void lcec_write_master(void *arg, long period) {
     }
     // Mode 1 or other: use manual pll-drift value
 
-    *(hal_data->pll_err) = raw_offset + drift;
+    // A phase error is modular: on a 1 ms cycle, +994 us is -6 us. drift is
+    // modular by construction and jumps a full period when app_phase crosses
+    // zero, while raw_offset is physical and cannot follow -- unfolded, the
+    // sum reports ~±1 period for exactly one cycle at a crossing (#501).
+    // One conditional step is enough (no modulo on the cyclic path): the
+    // resync below keeps |raw_offset| under one period and drift is in
+    // [0, period), so the sum stays where a single step reduces it.
+    int32_t pll_err = raw_offset + drift;
+    if (pll_err > app_period / 2) {
+      pll_err -= app_period;
+    } else if (pll_err < -(app_period / 2)) {
+      pll_err += app_period;
+    }
+    *(hal_data->pll_err) = pll_err;
 
     // PLL is considered phased if error is within 10% of period
     int32_t lock_threshold = master->app_time_period / 10;
@@ -1706,10 +1719,22 @@ void lcec_write_master(void *arg, long period) {
     // When sync_to_ref_clock = false, master is the clock source, DC syncs to us
     // When sync_to_ref_clock = true, DC is the clock source, we sync to DC
     if (master->sync_to_ref_clock) {
-      // check for invalid error values
-      if (abs(*(hal_data->pll_err)) > hal_data->pll_max_err) {
+      // The watchdog tests the physical offset, not the folded error: folded,
+      // |pll_err| <= period/2 could never reach the default threshold, and a
+      // genuine whole-period displacement would stand undetected. At the
+      // default (pll-max-err = one period) this fires exactly when a whole
+      // period is there to remove -- and removes only the whole periods,
+      // leaving the sub-period remainder to the controller, which drives it
+      // to the same point every start. Lowering pll-max-err restores the
+      // previous jump-resync at runtime.
+      if (abs(raw_offset) > hal_data->pll_max_err) {
+        int32_t resync_corr = raw_offset;
+        if (raw_offset >= app_period || raw_offset <= -app_period) {
+          // the division runs only on the cycle a resync fires
+          resync_corr = (raw_offset / app_period) * app_period;
+        }
         // force resync of master time
-        master->dc_ref -= *(hal_data->pll_err);
+        master->dc_ref -= resync_corr;
         // skip next control cycle to allow resync
         dc_time_valid = 0;
         // increment reset counter to document this event
@@ -1719,7 +1744,7 @@ void lcec_write_master(void *arg, long period) {
           hal_data->auto_drift_delay = 100;
         }
       } else {
-        *(hal_data->pll_out) = (*(hal_data->pll_err) < 0) ? -(hal_data->pll_step) : (hal_data->pll_step);
+        *(hal_data->pll_out) = (pll_err < 0) ? -(hal_data->pll_step) : (hal_data->pll_step);
       }
     }
     // Note: When sync_to_ref_clock = false, pll_out is set in the phase calibration code above


### PR DESCRIPTION
See issue #501

The sync_to_ref_clock branch reports raw_offset + drift unfolded. drift is modular and jumps a full period when app_phase crosses zero; raw_offset is physical and cannot follow, so pll-err spikes ~one full period for exactly one cycle at a crossing -- and with pll-max-err at its default that spike can trigger a resync that displaces the master by a full period for about a second.

Fold the reported error into (-period/2, period/2] with one conditional step -- no modulo on the cyclic path -- and key the resync on the physical offset: the folded value could never reach the default threshold again, and a genuine whole-period displacement would stand undetected. The resync removes only the whole-period part; the sub-period remainder is left to the controller, which drives it to the same point every start. At the default (pll-max-err = one period) the resync fires exactly when a whole period is there to remove; lowering pll-max-err restores the previous jump-resync at runtime. The division runs only on the cycle a resync fires.

Measured against builds of both forms on an RK3588 bench (1 ms cycle, r8169 and generic, seven digital I/O slaves plus a CiA 402 servo in csp): the lock-in lands 14-16 us from the DC clock on every start instead of scattering over the period, a boundary lock-in no longer produces false resyncs, and the servo's sync-loss counter and enabled standstill following error are unchanged against the unpatched build. HAL surface unchanged.