### PR TITLE
fix(cia402): 0x6077 actual_torque is 16 bits

### DIFF
--- a/src/devices/lcec_class_cia402_opt.h
+++ b/src/devices/lcec_class_cia402_opt.h
@@ -297,7 +297,7 @@
 #define PDO_BITS_actual_current            16
 #define PDO_BITS_actual_following_error    32
 #define PDO_BITS_actual_position           32
-#define PDO_BITS_actual_torque             32
+#define PDO_BITS_actual_torque             16
 #define PDO_BITS_actual_velocity           32
 #define PDO_BITS_actual_velocity_sensor    32
 #define PDO_BITS_actual_vl                 16


### PR DESCRIPTION
While commissioning my drive, I noticed the following:

0x6077 is INT16 in CiA 402, like 0x6071 target_torque already mapped as 16 a few lines below. Mapping it as 32 does not fail loudly: the drive accepts the mapping, delivers 16 bits, and every TxPDO entry after it reads two bytes off -- plausible-looking garbage.

Found on a STEPPERONLINE A6-EC with enableActualTorque set: opmode display read 0 instead of 8, velocity -2029977601 instead of -1622, error code 8 instead of 0x8700. Verified both ways against SDO reads of the same objects: with 32 everything after 0x6077 disagrees, with 16 everything agrees, and the drive read back consistently across restarts.