### PR TITLE
fix(cia402): swPositionLimitMax writes 0x607D:02, not :01

### DIFF
--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -572,7 +572,7 @@ static const lcec_modparam_desc_t per_channel_modparams[] = {
     {"positionLimitMin", CIA402_MP_POSLIMIT_MIN, MODPARAM_TYPE_S32},
     {"positionLimitMax", CIA402_MP_POSLIMIT_MAX, MODPARAM_TYPE_S32},
     {"swPositionLimitMin", CIA402_MP_SWPOSLIMIT_MIN, MODPARAM_TYPE_S32},
-    {"swPositionLimitMax", CIA402_MP_SWPOSLIMIT_MIN, MODPARAM_TYPE_S32},
+    {"swPositionLimitMax", CIA402_MP_SWPOSLIMIT_MAX, MODPARAM_TYPE_S32},
     {"homeOffset", CIA402_MP_HOME_OFFSET, MODPARAM_TYPE_S32},
     {"homeMethod", CIA402_MP_HOME_METHOD, MODPARAM_TYPE_S32},
     {"quickDecel", CIA402_MP_QUICKDECEL, MODPARAM_TYPE_U32},


### PR DESCRIPTION
While commissioning my drive, I noticed the following:

The modparam table maps swPositionLimitMax to CIA402_MP_SWPOSLIMIT_MIN, so both limits write 0x607D:01 and the MAX case in the SDO writer is dead code. Setting an upper software limit silently moves the lower one instead.

Verified on a STEPPERONLINE A6-EC: configured min -1000000 and max 2000000, the drive read back 0x607D:01 = 2000000 with :02 unchanged; with this fix, :01 = -1000000 and :02 = 2000000.