### PR TITLE
fix(main): double-step pll_err fold for startup cycle

### DIFF
--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -1696,9 +1696,14 @@ void lcec_write_master(void *arg, long period) {
 
     // Fold pll_err into (-period/2, period/2]. drift jumps a full period
     // when app_phase crosses zero; raw_offset is physical and cannot
-    // follow. One conditional step suffices once the resync below keeps
-    // |raw_offset| under one period (#501).
+    // follow. Two steps handle the startup cycle where the sum can exceed
+    // 1.5 periods in one pass (#501).
     int32_t pll_err = raw_offset + drift;
+    if (pll_err > app_period / 2) {
+      pll_err -= app_period;
+    } else if (pll_err < -(app_period / 2)) {
+      pll_err += app_period;
+    }
     if (pll_err > app_period / 2) {
       pll_err -= app_period;
     } else if (pll_err < -(app_period / 2)) {


### PR DESCRIPTION
## Follow-up to #502: stable pll_err fold at startup

On a 9-servo N100 PREEMPT_RT bench (1 ms M2R), #502 still showed resync bursts at startup.

### Mechanism

The single conditional fold in #502 can leave `pll_err` outside `(-period/2, period/2]` on the startup cycle, because `raw_offset + drift` can exceed 1.5 periods in one pass. The fold then inverts `pll_out`'s sign at the boundary, the controller pumps the wrong direction, `raw_offset` swings across the watchdog threshold, and resyncs fire in clusters.

### Fix

A second conditional fold step lands `pll_err` inside the interval in the same cycle. `pll_out` sign stays stable, the controller regulates correctly, and the burst mechanism doesn't engage.

### Scope

No new HAL surface, no change to the `pll-max-err` threshold, no change to the resync removal arithmetic.

### Tested

9-servo N100 PREEMPT_RT bench, 1 ms M2R: no resync bursts, startup lock-in stable.