### PR TITLE
Two small cleanups: the parameter descriptor's comments, and a SIGKILL handler that cannot fire

### DIFF
--- a/src/lcec.h
+++ b/src/lcec.h
@@ -378,12 +378,12 @@ typedef struct {
   const char *fmt;    ///< Format string for generating pin names via sprintf().
 } lcec_pindesc_t;
 
-/// @brief HAL pin description.
+/// @brief HAL parameter description.
 typedef struct {
-  hal_type_t type;      ///< HAL type of this pin (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
-  hal_param_dir_t dir;  ///< Direction for this pin (`HAL_IN`, `HAL_OUT`, or `HAL_IO`).
-  int offset;           ///< Offset for this pin's data in `hal_data`.
-  const char *fmt;      ///< Format string for generating pin names via sprintf().
+  hal_type_t type;      ///< HAL type of this parameter (`HAL_BIT`, `HAL_FLOAT`, `HAL_S32`, or `HAL_U32`).
+  hal_param_dir_t dir;  ///< Direction for this parameter (`HAL_RO` or `HAL_RW`).
+  int offset;           ///< Offset for this parameter's data in `hal_data`.
+  const char *fmt;      ///< Format string for generating parameter names via sprintf().
 } lcec_paramdesc_t;
 
 /// @brief Sync manager configuration.

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -184,7 +184,6 @@ int rtapi_app_main(void) {
   sigaction(SIGSEGV, &handler, NULL);
   sigaction(SIGBUS, &handler, NULL);
   sigaction(SIGFPE, &handler, NULL);
-  sigaction(SIGKILL, &handler, NULL);
 #endif
 
   // connect to the HAL


### PR DESCRIPTION
Two independent one-hunk changes, one commit each. Neither changes behaviour.

1. `lcec_paramdesc_t` is documented as a pin descriptor.** Its doc comments
were copied from `lcec_pindesc_t` above it and still describe pins. The `dir`
line is the one that can mislead: it lists `HAL_IN`, `HAL_OUT` and `HAL_IO`,
while the field is a `hal_param_dir_t` whose valid values are `HAL_RO` and
`HAL_RW`. A reader who follows the comment writes a pin direction into a
parameter direction and gets no diagnostic from the compiler. Comments only.

2. `sigaction(SIGKILL, ...)` in `rtapi_app_main` cannot be installed.**
`SIGKILL` cannot be caught, blocked or ignored, so the call returns `EINVAL`
and does nothing. The return value is not checked, which is why the failure has
never been visible. Removing it takes out a no-op — it does not change which
failures are handled. `SIGSEGV`, `SIGBUS` and `SIGFPE` are untouched, and the
list now says what it does.

**Checks.** Built and tested in a clean Debian 13 chroot. The exported HAL
surface is unchanged at 682 entries. For the second change, the number of
`sigaction` calls in the built `lcec.so` drops from five to four and nothing
else in the disassembly moves. `clang-format` (22.1.8) returns both files
unchanged.
I built the Debian 13 leg of the CI matrix only. Neither change has a library
or version dependency, so I do not expect 11 or 12 to differ.
The two are separate commits, so either can be dropped without the other.