### PR TITLE
fix(conf): terminate type_name after strncpy

### DIFF
--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -415,6 +415,7 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
     // set slave type_name
     if (strcmp(name, "type") == 0) {
       strncpy(p->type_name, val, LCEC_CONF_STR_MAXLEN);
+      p->type_name[LCEC_CONF_STR_MAXLEN - 1] = 0;
       continue;
     }
 


### PR DESCRIPTION
`parseSlaveAttrs` copies the `type=` attribute and stops there:
```c
strncpy(p->type_name, val, LCEC_CONF_STR_MAXLEN);
```
`strncpy` writes a terminator only when the source is shorter than the field, so a `type=` of 48 characters or more leaves `type_name` unterminated. It is then read by `strcmp(slave_conf->type_name, "generic")` and `lcec_findslavetype()`, both of which run past the end of the field into the rest of `LCEC_CONF_SLAVE_T`.

The two copies immediately below it in the same function, `name` and `syncUnit`, both terminate explicitly on the following line, and so do both `halPin` copies further down the file. This is the only one that does not, which is why I read it as an oversight rather than a decision.

The observed consequence is a misparsed type name rather than a crash — the adjacent fields hold zeros soon enough that the read stops — and no configuration in `examples/` comes close to 48 characters. So this is undefined behaviour with a mild outcome, not a defect anyone has hit. One line, matching the two beside it.

**Checks.** Built and tested in a clean Debian 13 chroot. `lcec.so` and `lcec_devices` come out byte-identical to an unpatched build of the same commit, and the exported HAL surface is unchanged at 682 entries; only `lcec_conf` differs, which is the program this line is in. `clang-format` (22.1.8, the tree's own `.clang-format`) returns the file unchanged. I built the Debian 13 leg of the CI matrix only. The change is plain C with no library or version dependency, so I do not expect 11 or 12 to differ.