### PR TITLE
hal: dual-support the LinuxCNC getter/setter HAL API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
                   # often sorts below the canonical changelog version).
                   ver=$(git describe --tags --always | sed 's/^v//')
                   if [ "${HAL_API}" = "next" ]; then
-                      ver=$(echo "${ver}" | sed 's/-/+getset-/')
+                      ver=$(echo "${ver}" | sed 's/\(-\|$\)/+getset\1/')
                   fi
                   dch -b --newversion "${ver}+ci" --distribution stable "CI build ${ver} (${HAL_API} HAL)"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,11 @@ jobs:
                   # installable on new-API systems.
                   base_ver=$(dpkg-parsechangelog --show-field Version)
                   if [ "${HAL_API}" = "next" ]; then
-                      base_ver=$(echo "${base_ver}" | sed 's/-/+getset-/')
+                      # Insert +getset after the upstream part; handles both
+                  # 1.42.2-1 -> 1.42.2+getset-1 and a revision-less
+                  # 1.42.2 -> 1.42.2+getset (plain s/-// would no-op and
+                  # collide with the legacy build's filename).
+                  base_ver=$(echo "${base_ver}" | sed 's/\(-\|$\)/+getset\1/')
                   fi
                   new_ver="${base_ver}+${{ matrix.deb_rev }}"
                   dch --newversion "${new_ver}" \

--- a/src/devices/lcec_ax5805.c
+++ b/src/devices/lcec_ax5805.c
@@ -172,18 +172,18 @@ static void lcec_ax5805_read(lcec_slave_t *slave, long period) {
 
   copy_fsoe_data(slave, hal_data->fsoe_slave_cmd_os, hal_data->fsoe_master_cmd_os);
 
-  *(hal_data->fsoe_master_cmd) = EC_READ_U8(&pd[hal_data->fsoe_master_cmd_os]);
-  *(hal_data->fsoe_master_connid) = EC_READ_U16(&pd[hal_data->fsoe_master_connid_os]);
-  *(hal_data->fsoe_slave_cmd) = EC_READ_U8(&pd[hal_data->fsoe_slave_cmd_os]);
-  *(hal_data->fsoe_slave_connid) = EC_READ_U16(&pd[hal_data->fsoe_slave_connid_os]);
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_cmd, EC_READ_U8(&pd[hal_data->fsoe_master_cmd_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_connid, EC_READ_U16(&pd[hal_data->fsoe_master_connid_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_cmd, EC_READ_U8(&pd[hal_data->fsoe_slave_cmd_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_connid, EC_READ_U16(&pd[hal_data->fsoe_slave_connid_os]));
 
-  *(hal_data->fsoe_master_crc0) = EC_READ_U16(&pd[hal_data->fsoe_master_crc0_os]);
-  *(hal_data->fsoe_slave_crc0) = EC_READ_U16(&pd[hal_data->fsoe_slave_crc0_os]);
-  *(hal_data->fsoe_in_sto0) = EC_READ_BIT(&pd[hal_data->fsoe_in_sto0_os], hal_data->fsoe_in_sto0_bp);
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_crc0, EC_READ_U16(&pd[hal_data->fsoe_master_crc0_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_crc0, EC_READ_U16(&pd[hal_data->fsoe_slave_crc0_os]));
+  LCEC_PIN_BIT_SET(hal_data->fsoe_in_sto0, EC_READ_BIT(&pd[hal_data->fsoe_in_sto0_os], hal_data->fsoe_in_sto0_bp));
 
   if (slave->fsoeConf->data_channels >= 2) {
-    *(hal_data->fsoe_master_crc1) = EC_READ_U16(&pd[hal_data->fsoe_master_crc1_os]);
-    *(hal_data->fsoe_slave_crc1) = EC_READ_U16(&pd[hal_data->fsoe_slave_crc1_os]);
-    *(hal_data->fsoe_in_sto1) = EC_READ_BIT(&pd[hal_data->fsoe_in_sto1_os], hal_data->fsoe_in_sto1_bp);
+    LCEC_PIN_U32_SET(hal_data->fsoe_master_crc1, EC_READ_U16(&pd[hal_data->fsoe_master_crc1_os]));
+    LCEC_PIN_U32_SET(hal_data->fsoe_slave_crc1, EC_READ_U16(&pd[hal_data->fsoe_slave_crc1_os]));
+    LCEC_PIN_BIT_SET(hal_data->fsoe_in_sto1, EC_READ_BIT(&pd[hal_data->fsoe_in_sto1_os], hal_data->fsoe_in_sto1_bp));
   }
 }

--- a/src/devices/lcec_basic_cia402.c
+++ b/src/devices/lcec_basic_cia402.c
@@ -292,7 +292,7 @@ static void lcec_basic_cia402_read(lcec_slave_t *slave, long period) {
   // XXXX: If you need to read device-specific PDOs and set pins, then you should do this here.
   //
   // uint8_t *pd = slave->master->process_data;
-  // *(hal_data->alarm_code) = EC_READ_U16(&pd[hal_data->alarm_code_os]);
+  // LCEC_PIN_U32_SET(hal_data->alarm_code, EC_READ_U16(&pd[hal_data->alarm_code_os]));
 
   lcec_cia402_read_all(slave, hal_data->cia402);
 }

--- a/src/devices/lcec_class_ain.c
+++ b/src/devices/lcec_class_ain.c
@@ -213,10 +213,10 @@ lcec_class_ain_channel_t *lcec_ain_register_channel(lcec_slave_t *slave, int id,
   }
 
   // Set default values for scale and bias.
-  *(data->scale) = 1.0;
-  if (is_temperature) *(data->scale) = 0.1;
-  if (opt->default_scale != 0) *(data->scale) = opt->default_scale;
-  if (opt->default_bias != 0) *(data->bias) = opt->default_bias;
+  LCEC_PIN_FLOAT_SET(data->scale, 1.0);
+  if (is_temperature) LCEC_PIN_FLOAT_SET(data->scale, 0.1);
+  if (opt->default_scale != 0) LCEC_PIN_FLOAT_SET(data->scale, opt->default_scale);
+  if (opt->default_bias != 0) LCEC_PIN_FLOAT_SET(data->bias, opt->default_bias);
 
   return data;
 }
@@ -235,14 +235,14 @@ void lcec_ain_read(lcec_slave_t *slave, lcec_class_ain_channel_t *data) {
 
   // Update status bits, if enabled
   if (!data->options->valueonly) {
-    *(data->overrange) = EC_READ_BIT(&pd[data->ovr_pdo_os], data->ovr_pdo_bp);
-    *(data->underrange) = EC_READ_BIT(&pd[data->udr_pdo_os], data->udr_pdo_bp);
-    *(data->error) = EC_READ_BIT(&pd[data->error_pdo_os], data->error_pdo_bp);
+    LCEC_PIN_BIT_SET(data->overrange, EC_READ_BIT(&pd[data->ovr_pdo_os], data->ovr_pdo_bp));
+    LCEC_PIN_BIT_SET(data->underrange, EC_READ_BIT(&pd[data->udr_pdo_os], data->udr_pdo_bp));
+    LCEC_PIN_BIT_SET(data->error, EC_READ_BIT(&pd[data->error_pdo_os], data->error_pdo_bp));
   }
 
   // Update sync error, if present
   if (data->options->has_sync) {
-    *(data->sync_err) = EC_READ_BIT(&pd[data->sync_err_pdo_os], data->sync_err_pdo_bp);
+    LCEC_PIN_BIT_SET(data->sync_err, EC_READ_BIT(&pd[data->sync_err_pdo_os], data->sync_err_pdo_bp));
   }
 
   // update value
@@ -251,17 +251,17 @@ void lcec_ain_read(lcec_slave_t *slave, lcec_class_ain_channel_t *data) {
   } else {
     value = EC_READ_S16(&pd[data->val_pdo_os]);
   }
-  *(data->raw_val) = value;
+  LCEC_PIN_S32_SET(data->raw_val, value);
   if (data->options->is_temperature) {
     // Temperature uses different value calculations than regular analog sensors.
-    *(data->val) = *(data->scale) * (double)value;
+    LCEC_PIN_FLOAT_SET(data->val, LCEC_PIN_FLOAT_GET(data->scale) * (double)value);
   } else {
     // Normal analog sensors return a value between -1.0 and 1.0 (or 0
     // and 1.0, depending on the sensor type), where 1.0 is the
     // largest possible input value.
     //
     // Then, the result is multipled by `scale` (default: 1.0) and `bias` is added (default 0).
-    *(data->val) = *(data->bias) + *(data->scale) * (double)value * ((double)1 / (double)max_value);
+    LCEC_PIN_FLOAT_SET(data->val, LCEC_PIN_FLOAT_GET(data->bias) + LCEC_PIN_FLOAT_GET(data->scale) * (double)value * ((double)1 / (double)max_value));
   }
 }
 

--- a/src/devices/lcec_class_aout.c
+++ b/src/devices/lcec_class_aout.c
@@ -120,13 +120,13 @@ lcec_class_aout_channel_t *lcec_aout_register_channel(lcec_slave_t *slave, int i
   }
 
   // Set default values for scale and bias.
-  *(data->scale) = 1.0;
-  if (opt->default_scale != 0) *(data->scale) = opt->default_scale;
-  if (opt->default_offset != 0) *(data->offset) = opt->default_offset;
-  *(data->max_dc) = 1.0;
-  *(data->min_dc) = -1.0;
-  data->old_scale = *(data->scale) + 1.0;
-  data->scale_recip = 1.0 / *(data->scale);
+  LCEC_PIN_FLOAT_SET(data->scale, 1.0);
+  if (opt->default_scale != 0) LCEC_PIN_FLOAT_SET(data->scale, opt->default_scale);
+  if (opt->default_offset != 0) LCEC_PIN_FLOAT_SET(data->offset, opt->default_offset);
+  LCEC_PIN_FLOAT_SET(data->max_dc, 1.0);
+  LCEC_PIN_FLOAT_SET(data->min_dc, -1.0);
+  data->old_scale = LCEC_PIN_FLOAT_GET(data->scale) + 1.0;
+  data->scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(data->scale);
 
   return data;
 }
@@ -145,53 +145,53 @@ void lcec_aout_write(lcec_slave_t *slave, lcec_class_aout_channel_t *data) {
 
   // validate duty cycle limits, both limits must be between
   // 0.0 and 1.0 (inclusive) and max must be greater then min
-  if (*(data->max_dc) > 1.0) {
-    *(data->max_dc) = 1.0;
+  if (LCEC_PIN_FLOAT_GET(data->max_dc) > 1.0) {
+    LCEC_PIN_FLOAT_SET(data->max_dc, 1.0);
   }
-  if (*(data->min_dc) > *(data->max_dc)) {
-    *(data->min_dc) = *(data->max_dc);
+  if (LCEC_PIN_FLOAT_GET(data->min_dc) > LCEC_PIN_FLOAT_GET(data->max_dc)) {
+    LCEC_PIN_FLOAT_SET(data->min_dc, LCEC_PIN_FLOAT_GET(data->max_dc));
   }
-  if (*(data->min_dc) < -1.0) {
-    *(data->min_dc) = -1.0;
+  if (LCEC_PIN_FLOAT_GET(data->min_dc) < -1.0) {
+    LCEC_PIN_FLOAT_SET(data->min_dc, -1.0);
   }
-  if (*(data->max_dc) < *(data->min_dc)) {
-    *(data->max_dc) = *(data->min_dc);
+  if (LCEC_PIN_FLOAT_GET(data->max_dc) < LCEC_PIN_FLOAT_GET(data->min_dc)) {
+    LCEC_PIN_FLOAT_SET(data->max_dc, LCEC_PIN_FLOAT_GET(data->min_dc));
   }
 
   // do scale calcs only when scale changes
-  if (*(data->scale) != data->old_scale) {
+  if (LCEC_PIN_FLOAT_GET(data->scale) != data->old_scale) {
     // validate the new scale value
-    if ((*(data->scale) < 1e-20) && (*(data->scale) > -1e-20)) {
+    if ((LCEC_PIN_FLOAT_GET(data->scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(data->scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      *(data->scale) = 1.0;
+      LCEC_PIN_FLOAT_SET(data->scale, 1.0);
     }
     // get ready to detect future scale changes
-    data->old_scale = *(data->scale);
+    data->old_scale = LCEC_PIN_FLOAT_GET(data->scale);
     // we will need the reciprocal
-    data->scale_recip = 1.0 / *(data->scale);
+    data->scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(data->scale);
   }
 
   // get command
-  tmpval = *(data->value);
-  if (*(data->absmode) && (tmpval < 0)) {
+  tmpval = LCEC_PIN_FLOAT_GET(data->value);
+  if (LCEC_PIN_BIT_GET(data->absmode) && (tmpval < 0)) {
     tmpval = -tmpval;
   }
 
   // convert value command to duty cycle
-  tmpdc = tmpval * data->scale_recip + *(data->offset);
-  if (tmpdc < *(data->min_dc)) {
-    tmpdc = *(data->min_dc);
+  tmpdc = tmpval * data->scale_recip + LCEC_PIN_FLOAT_GET(data->offset);
+  if (tmpdc < LCEC_PIN_FLOAT_GET(data->min_dc)) {
+    tmpdc = LCEC_PIN_FLOAT_GET(data->min_dc);
   }
-  if (tmpdc > *(data->max_dc)) {
-    tmpdc = *(data->max_dc);
+  if (tmpdc > LCEC_PIN_FLOAT_GET(data->max_dc)) {
+    tmpdc = LCEC_PIN_FLOAT_GET(data->max_dc);
   }
 
   // set output values
-  if (*(data->enable) == 0) {
+  if (LCEC_PIN_BIT_GET(data->enable) == 0) {
     raw_val = 0;
-    *(data->pos) = 0;
-    *(data->neg) = 0;
-    *(data->curr_dc) = 0;
+    LCEC_PIN_BIT_SET(data->pos, 0);
+    LCEC_PIN_BIT_SET(data->neg, 0);
+    LCEC_PIN_FLOAT_SET(data->curr_dc, 0);
   } else {
     raw_val = (double)max_value * tmpdc;
     if (raw_val > (double)max_value) {
@@ -200,14 +200,14 @@ void lcec_aout_write(lcec_slave_t *slave, lcec_class_aout_channel_t *data) {
     if (raw_val < (double)-max_value) {
       raw_val = (double)-max_value;
     }
-    *(data->pos) = (*(data->value) > 0);
-    *(data->neg) = (*(data->value) < 0);
-    *(data->curr_dc) = tmpdc;
+    LCEC_PIN_BIT_SET(data->pos, (LCEC_PIN_FLOAT_GET(data->value) > 0));
+    LCEC_PIN_BIT_SET(data->neg, (LCEC_PIN_FLOAT_GET(data->value) < 0));
+    LCEC_PIN_FLOAT_SET(data->curr_dc, tmpdc);
   }
 
   // update value
   EC_WRITE_S16(&pd[data->val_pdo_os], (int16_t)raw_val);
-  *(data->raw_val) = (int32_t)raw_val;
+  LCEC_PIN_S32_SET(data->raw_val, (int32_t)raw_val);
 }
 
 /// @brief Writess data to all analog out ports.

--- a/src/devices/lcec_class_ax5.c
+++ b/src/devices/lcec_class_ax5.c
@@ -199,31 +199,31 @@ void lcec_class_ax5_read(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
   if (!slave->state.operational) {
     chan->enc.do_init = 1;
     chan->enc_fb2.do_init = 1;
-    *(chan->fault) = 1;
-    *(chan->enabled) = 0;
-    *(chan->halted) = 0;
+    LCEC_PIN_BIT_SET(chan->fault, 1);
+    LCEC_PIN_BIT_SET(chan->enabled, 0);
+    LCEC_PIN_BIT_SET(chan->halted, 0);
     return;
   }
 
   // check inputs
   lcec_class_ax5_check_scales(chan);
 
-  *(chan->status) = EC_READ_U16(&pd[chan->status_pdo_os]);
+  LCEC_PIN_U32_SET(chan->status, EC_READ_U16(&pd[chan->status_pdo_os]));
 
   // check fault
-  *(chan->fault) = 0;
+  LCEC_PIN_BIT_SET(chan->fault, 0);
   // check error shut off status
-  if (((*(chan->status) >> 13) & 1) != 0) {
-    *(chan->fault) = 1;
+  if (((LCEC_PIN_U32_GET(chan->status) >> 13) & 1) != 0) {
+    LCEC_PIN_BIT_SET(chan->fault, 1);
   }
   // check ready-to-operate value
-  if (((*(chan->status) >> 14) & 3) == 0) {
-    *(chan->fault) = 1;
+  if (((LCEC_PIN_U32_GET(chan->status) >> 14) & 3) == 0) {
+    LCEC_PIN_BIT_SET(chan->fault, 1);
   }
 
   // check status
-  *(chan->enabled) = (((*(chan->status) >> 14) & 3) == 3);
-  *(chan->halted) = (((*(chan->status) >> 3) & 1) != 1);
+  LCEC_PIN_BIT_SET(chan->enabled, (((LCEC_PIN_U32_GET(chan->status) >> 14) & 3) == 3));
+  LCEC_PIN_BIT_SET(chan->halted, (((LCEC_PIN_U32_GET(chan->status) >> 3) & 1) != 1));
 
   // update position feedback
   pos_cnt = EC_READ_U32(&pd[chan->pos_fb_pdo_os]);
@@ -235,10 +235,10 @@ void lcec_class_ax5_read(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
   }
 
   if (chan->diag_enabled) {
-    *(chan->diag) = EC_READ_U32(&pd[chan->diag_pdo_os]);
+    LCEC_PIN_U32_SET(chan->diag, EC_READ_U32(&pd[chan->diag_pdo_os]));
   }
 
-  *(chan->torque_fb_pct) = ((double)EC_READ_S16(&pd[chan->torque_fb_pdo_os])) * 0.1;
+  LCEC_PIN_FLOAT_SET(chan->torque_fb_pct, ((double)EC_READ_S16(&pd[chan->torque_fb_pdo_os])) * 0.1);
 }
 
 void lcec_class_ax5_write(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
@@ -252,19 +252,19 @@ void lcec_class_ax5_write(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
   if (chan->toggle) {
     ctrl |= (1 << 10);  // sync
   }
-  if (*(chan->enable)) {
-    if (!(*(chan->halt))) {
+  if (LCEC_PIN_BIT_GET(chan->enable)) {
+    if (!(LCEC_PIN_BIT_GET(chan->halt))) {
       ctrl |= (1 << 13);  // halt/restart
     }
     ctrl |= (1 << 14);  // enable
-    if (!(*(chan->drive_off))) {
+    if (!(LCEC_PIN_BIT_GET(chan->drive_off))) {
       ctrl |= (1 << 15);  // drive on
     }
   }
   EC_WRITE_U16(&pd[chan->ctrl_pdo_os], ctrl);
 
   // set velo command
-  velo_cmd_raw = *(chan->velo_cmd) * chan->scale * chan->vel_output_scale;
+  velo_cmd_raw = LCEC_PIN_FLOAT_GET(chan->velo_cmd) * chan->scale * chan->vel_output_scale;
   if (velo_cmd_raw > (double)0x7fffffff) {
     velo_cmd_raw = (double)0x7fffffff;
   }

--- a/src/devices/lcec_class_ax5.c
+++ b/src/devices/lcec_class_ax5.c
@@ -148,13 +148,13 @@ int lcec_class_ax5_init(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan, int in
   }
 
   // init parameters
-  chan->scale = 1.0;
-  chan->scale_fb2 = 1.0;
-  chan->vel_scale = ((double)idn_vel_scale) * pow(10.0, (double)idn_vel_exp);
-  chan->pos_resolution = idn_pos_resolution;
+  LCEC_PARAM_FLOAT_SET(chan->scale, 1.0);
+  LCEC_PARAM_FLOAT_SET(chan->scale_fb2, 1.0);
+  LCEC_PARAM_FLOAT_SET(chan->vel_scale, ((double)idn_vel_scale) * pow(10.0, (double)idn_vel_exp));
+  LCEC_PARAM_U32_SET(chan->pos_resolution, idn_pos_resolution);
 
-  if (chan->vel_scale > 0.0) {
-    chan->vel_output_scale = 60.0 / chan->vel_scale;
+  if (LCEC_PARAM_FLOAT_GET(chan->vel_scale) > 0.0) {
+    chan->vel_output_scale = 60.0 / LCEC_PARAM_FLOAT_GET(chan->vel_scale);
   } else {
     chan->vel_output_scale = 0.0;
   }
@@ -164,29 +164,29 @@ int lcec_class_ax5_init(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan, int in
 
 void lcec_class_ax5_check_scales(lcec_class_ax5_chan_t *chan) {
   // check for change in scale value
-  if (chan->scale != chan->scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(chan->scale) != chan->scale_old) {
     // scale value has changed, test and update it
-    if ((chan->scale < 1e-20) && (chan->scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(chan->scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(chan->scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      chan->scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(chan->scale, 1.0);
     }
     // save new scale to detect future changes
-    chan->scale_old = chan->scale;
+    chan->scale_old = LCEC_PARAM_FLOAT_GET(chan->scale);
     // we actually want the reciprocal
-    chan->scale_rcpt = 1.0 / chan->scale;
+    chan->scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(chan->scale);
   }
 
   // check fb2 for change in scale value
-  if (chan->scale_fb2 != chan->scale_fb2_old) {
+  if (LCEC_PARAM_FLOAT_GET(chan->scale_fb2) != chan->scale_fb2_old) {
     // scale value has changed, test and update it
-    if ((chan->scale_fb2 < 1e-20) && (chan->scale_fb2 > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(chan->scale_fb2) < 1e-20) && (LCEC_PARAM_FLOAT_GET(chan->scale_fb2) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      chan->scale_fb2 = 1.0;
+      LCEC_PARAM_FLOAT_SET(chan->scale_fb2, 1.0);
     }
     // save new scale to detect future changes
-    chan->scale_fb2_old = chan->scale_fb2;
+    chan->scale_fb2_old = LCEC_PARAM_FLOAT_GET(chan->scale_fb2);
     // we actually want the reciprocal
-    chan->scale_fb2_rcpt = 1.0 / chan->scale_fb2;
+    chan->scale_fb2_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(chan->scale_fb2);
   }
 }
 
@@ -227,7 +227,7 @@ void lcec_class_ax5_read(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
 
   // update position feedback
   pos_cnt = EC_READ_U32(&pd[chan->pos_fb_pdo_os]);
-  class_enc_update(&chan->enc, chan->pos_resolution, chan->scale_rcpt, pos_cnt, 0, 0);
+  class_enc_update(&chan->enc, LCEC_PARAM_U32_GET(chan->pos_resolution), chan->scale_rcpt, pos_cnt, 0, 0);
 
   if (chan->fb2_enabled) {
     pos_cnt = EC_READ_U32(&pd[chan->pos_fb2_pdo_os]);
@@ -264,7 +264,7 @@ void lcec_class_ax5_write(lcec_slave_t *slave, lcec_class_ax5_chan_t *chan) {
   EC_WRITE_U16(&pd[chan->ctrl_pdo_os], ctrl);
 
   // set velo command
-  velo_cmd_raw = LCEC_PIN_FLOAT_GET(chan->velo_cmd) * chan->scale * chan->vel_output_scale;
+  velo_cmd_raw = LCEC_PIN_FLOAT_GET(chan->velo_cmd) * LCEC_PARAM_FLOAT_GET(chan->scale) * chan->vel_output_scale;
   if (velo_cmd_raw > (double)0x7fffffff) {
     velo_cmd_raw = (double)0x7fffffff;
   }

--- a/src/devices/lcec_class_ax5.h
+++ b/src/devices/lcec_class_ax5.h
@@ -54,10 +54,10 @@ typedef struct {
   unsigned int ctrl_pdo_os;
   unsigned int vel_cmd_pdo_os;
 
-  hal_float_t scale;
-  hal_float_t scale_fb2;
-  hal_float_t vel_scale;
-  hal_u32_t pos_resolution;
+  lcec_param_float_t scale;
+  lcec_param_float_t scale_fb2;
+  lcec_param_float_t vel_scale;
+  lcec_param_u32_t pos_resolution;
 
   lcec_class_enc_data_t enc;
   lcec_class_enc_data_t enc_fb2;

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -434,7 +434,7 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   uint32_t modes;
   lcec_read_sdo32(slave, base_idx + 0x502, 0, &modes);
 
-  LCEC_PIN_S32_SET(data->supported_modes, modes);
+  LCEC_PIN_U32_SET(data->supported_modes, modes);
   LCEC_PIN_BIT_SET(data->supports_mode_pp, modes & 1 << 0);
   LCEC_PIN_BIT_SET(data->supports_mode_vl, modes & 1 << 1);
   LCEC_PIN_BIT_SET(data->supports_mode_pv, modes & 1 << 2);

--- a/src/devices/lcec_class_cia402.c
+++ b/src/devices/lcec_class_cia402.c
@@ -434,16 +434,16 @@ lcec_class_cia402_channel_t *lcec_cia402_register_channel(
   uint32_t modes;
   lcec_read_sdo32(slave, base_idx + 0x502, 0, &modes);
 
-  *(data->supported_modes) = modes;
-  *(data->supports_mode_pp) = modes & 1 << 0;
-  *(data->supports_mode_vl) = modes & 1 << 1;
-  *(data->supports_mode_pv) = modes & 1 << 2;
-  *(data->supports_mode_tq) = modes & 1 << 3;
-  *(data->supports_mode_hm) = modes & 1 << 5;
-  *(data->supports_mode_ip) = modes & 1 << 6;
-  *(data->supports_mode_csp) = modes & 1 << 7;
-  *(data->supports_mode_csv) = modes & 1 << 8;
-  *(data->supports_mode_cst) = modes & 1 << 9;
+  LCEC_PIN_S32_SET(data->supported_modes, modes);
+  LCEC_PIN_BIT_SET(data->supports_mode_pp, modes & 1 << 0);
+  LCEC_PIN_BIT_SET(data->supports_mode_vl, modes & 1 << 1);
+  LCEC_PIN_BIT_SET(data->supports_mode_pv, modes & 1 << 2);
+  LCEC_PIN_BIT_SET(data->supports_mode_tq, modes & 1 << 3);
+  LCEC_PIN_BIT_SET(data->supports_mode_hm, modes & 1 << 5);
+  LCEC_PIN_BIT_SET(data->supports_mode_ip, modes & 1 << 6);
+  LCEC_PIN_BIT_SET(data->supports_mode_csp, modes & 1 << 7);
+  LCEC_PIN_BIT_SET(data->supports_mode_csv, modes & 1 << 8);
+  LCEC_PIN_BIT_SET(data->supports_mode_cst, modes & 1 << 9);
 
   /// @brief Initializes a pin's defaults using the current value of the backing SDO.
   ///
@@ -484,9 +484,9 @@ void lcec_cia402_read(lcec_slave_t *slave, lcec_class_cia402_channel_t *data) {
 
 #define READ_OPT(pin_name)              \
   if (data->enabled->enable_##pin_name) \
-  *(data->pin_name) = (SUBSTJOIN3(EC_READ_, PDO_SIGN_##pin_name, PDO_BITS_##pin_name)(&pd[data->pin_name##_os]))
+  LCEC_PIN_SET(data->pin_name, (SUBSTJOIN3(EC_READ_, PDO_SIGN_##pin_name, PDO_BITS_##pin_name)(&pd[data->pin_name##_os])))
 
-  *(data->statusword) = EC_READ_U16(&pd[data->statusword_os]);
+  LCEC_PIN_U32_SET(data->statusword, EC_READ_U16(&pd[data->statusword_os]));
 
   // Read from all readable PDOs.
   FOR_ALL_READ_PDOS_DO(READ_OPT);
@@ -507,7 +507,7 @@ void lcec_cia402_read_all(lcec_slave_t *slave, lcec_class_cia402_channels_t *cha
 }
 
 #define WRITE_OPT(name) \
-  if (data->enabled->enable_##name) SUBSTJOIN3(EC_WRITE_, PDO_SIGN_##name, PDO_BITS_##name)(&pd[data->name##_os], *(data->name))
+  if (data->enabled->enable_##name) SUBSTJOIN3(EC_WRITE_, PDO_SIGN_##name, PDO_BITS_##name)(&pd[data->name##_os], LCEC_PIN_GET(data->name))
 
 /// OK, this is kind of a mess.  It presents the same interface as
 /// WRITE_OPT(), but instead of writing to a mapped PDO entry, it
@@ -527,9 +527,9 @@ void lcec_cia402_read_all(lcec_slave_t *slave, lcec_class_cia402_channels_t *cha
 #define WRITE_OPT_SDO(name)                                                                   \
   do {                                                                                        \
     if (data->enabled->enable_##name) {                                                       \
-      if (*(data->name) != data->name##_old) {                                                \
+      if (LCEC_PIN_GET(data->name) != data->name##_old) {                                                \
         if (ecrt_sdo_request_state(data->name##_sdorequest) != EC_REQUEST_BUSY) {             \
-          data->name##_old = *(data->name);                                                   \
+          data->name##_old = LCEC_PIN_GET(data->name);                                                   \
           uint8_t *sdo_tmp = ecrt_sdo_request_data(data->name##_sdorequest);                  \
           SUBSTJOIN3(EC_WRITE_, PDO_SIGN_##name, PDO_BITS_##name)(sdo_tmp, data->name##_old); \
           ecrt_sdo_request_write(data->name##_sdorequest);                                    \
@@ -541,7 +541,7 @@ void lcec_cia402_read_all(lcec_slave_t *slave, lcec_class_cia402_channels_t *cha
 void lcec_cia402_write(lcec_slave_t *slave, lcec_class_cia402_channel_t *data) {
   uint8_t *pd = slave->master->process_data;
 
-  EC_WRITE_U16(&pd[data->controlword_os], (uint16_t)(*(data->controlword)));
+  EC_WRITE_U16(&pd[data->controlword_os], (uint16_t)LCEC_PIN_GET(data->controlword));
 
   // Write PDOs (mapped, auto-synced between slaves and the master)
   FOR_ALL_WRITE_PDOS_DO(WRITE_OPT);

--- a/src/devices/lcec_class_cia402.h
+++ b/src/devices/lcec_class_cia402.h
@@ -260,7 +260,7 @@ typedef struct {
   // In.
   PDO_PIN(statusword, hal_u32_t);
   PDO_PIN(opmode_display, hal_s32_t);
-  hal_s32_t *supported_modes;
+  hal_u32_t *supported_modes;
   hal_bit_t *supports_mode_pp, *supports_mode_vl, *supports_mode_pv, *supports_mode_tq, *supports_mode_hm, *supports_mode_ip,
       *supports_mode_csp, *supports_mode_csv, *supports_mode_cst;
 

--- a/src/devices/lcec_class_din.c
+++ b/src/devices/lcec_class_din.c
@@ -153,8 +153,8 @@ void lcec_din_read(lcec_slave_t *slave, lcec_class_din_channel_t *data) {
   }
 
   s = EC_READ_BIT(&pd[os], bp);
-  *(data->in) = s;
-  *(data->in_not) = !s;
+  LCEC_PIN_BIT_SET(data->in, s);
+  LCEC_PIN_BIT_SET(data->in_not, !s);
 }
 
 /// @brief reads data from all digital in ports.

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -161,7 +161,7 @@ void lcec_dout_write(lcec_slave_t *slave, lcec_class_dout_channel_t *data) {
     os += data->pdo_bp_packed >> 3;  // the data in pd[] is always little-endian.
   }
 
-  s = *(data->out);
+  s = LCEC_PIN_BIT_GET(data->out);
   if (data->invert) {
     s = !s;
   }

--- a/src/devices/lcec_class_dout.c
+++ b/src/devices/lcec_class_dout.c
@@ -162,7 +162,7 @@ void lcec_dout_write(lcec_slave_t *slave, lcec_class_dout_channel_t *data) {
   }
 
   s = LCEC_PIN_BIT_GET(data->out);
-  if (data->invert) {
+  if (LCEC_PARAM_BIT_GET(data->invert)) {
     s = !s;
   }
 

--- a/src/devices/lcec_class_dout.h
+++ b/src/devices/lcec_class_dout.h
@@ -26,7 +26,7 @@
 typedef struct {
   const char *name;            ///< Used for debugging only
   hal_bit_t *out;              ///< -dout-X pin in LinuxCNC
-  hal_bit_t invert;            ///< Is the value inverted?
+  lcec_param_bit_t invert;            ///< Is the value inverted?
   unsigned int pdo_os;         ///< Byte offset in PDO data struct
   unsigned int pdo_bp;         ///< Bit offset in PDO data byte
   unsigned int pdo_bp_packed;  ///< Controls is this is a packed-bit port, where more than one channel is found in a single PDO entry.

--- a/src/devices/lcec_class_enc.c
+++ b/src/devices/lcec_class_enc.c
@@ -68,11 +68,11 @@ int class_enc_init(lcec_slave_t *slave, lcec_class_enc_data_t *hal_data, int raw
   hal_data->index_sign = 0;
 
   hal_data->pprev_last = 0;
-  hal_data->pprev_scale = 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->pprev_scale, 1.0);
 
-  hal_data->raw_bits = raw_bits;
-  hal_data->raw_shift = 32 - hal_data->raw_bits;
-  hal_data->raw_mask = (1LL << hal_data->raw_bits) - 1;
+  LCEC_PARAM_U32_SET(hal_data->raw_bits, raw_bits);
+  hal_data->raw_shift = 32 - LCEC_PARAM_U32_GET(hal_data->raw_bits);
+  hal_data->raw_mask = (1LL << LCEC_PARAM_U32_GET(hal_data->raw_bits)) - 1;
 
   return 0;
 }
@@ -87,10 +87,10 @@ void class_enc_update(
   // calculate pos scale
   if (pprev > 0) {
     if (hal_data->do_init || hal_data->pprev_last != pprev) {
-      hal_data->pprev_scale = 1.0 / ((double)pprev);
+      LCEC_PARAM_FLOAT_SET(hal_data->pprev_scale, 1.0 / ((double)pprev));
       hal_data->index_sign = 0;
     }
-    pos_scale = hal_data->pprev_scale * scale;
+    pos_scale = LCEC_PARAM_FLOAT_GET(hal_data->pprev_scale) * scale;
   } else {
     pos_scale = scale;
   }
@@ -114,7 +114,7 @@ void class_enc_update(
   LCEC_PIN_FLOAT_SET(hal_data->pos_enc, ((double)pos) * pos_scale);
 
   // calculate home based abs pos
-  pos += raw_diff(hal_data->raw_shift, 0, hal_data->raw_home);
+  pos += raw_diff(hal_data->raw_shift, 0, LCEC_PARAM_U32_GET(hal_data->raw_home));
   LCEC_PIN_FLOAT_SET(hal_data->pos_abs, ((double)pos) * pos_scale);
   LCEC_PIN_BIT_SET(hal_data->on_home_neg, (pos <= 0));
   LCEC_PIN_BIT_SET(hal_data->on_home_pos, (pos >= 0));

--- a/src/devices/lcec_class_enc.c
+++ b/src/devices/lcec_class_enc.c
@@ -100,38 +100,38 @@ void class_enc_update(
   // this could be used to retain extrapolated multiturn tracking
   // IMPORTANT: hi/lo values need to be stored atomic
   if (hal_data->do_init) {
-    *(hal_data->raw) = *(hal_data->ext_lo) & hal_data->raw_mask;
+    LCEC_PIN_S32_SET(hal_data->raw, LCEC_PIN_U32_GET(hal_data->ext_lo) & hal_data->raw_mask);
   }
 
   // extrapolate to 64 bits
-  pos = ((long long)*(hal_data->ext_hi) << 32) | *(hal_data->ext_lo);
-  pos += raw_diff(hal_data->raw_shift, raw, *(hal_data->raw));
-  *(hal_data->raw) = raw;
-  *(hal_data->ext_hi) = (uint32_t)(pos >> 32);
-  *(hal_data->ext_lo) = (uint32_t)pos;
+  pos = ((long long)LCEC_PIN_U32_GET(hal_data->ext_hi) << 32) | LCEC_PIN_U32_GET(hal_data->ext_lo);
+  pos += raw_diff(hal_data->raw_shift, raw, LCEC_PIN_S32_GET(hal_data->raw));
+  LCEC_PIN_S32_SET(hal_data->raw, raw);
+  LCEC_PIN_U32_SET(hal_data->ext_hi, (uint32_t)(pos >> 32));
+  LCEC_PIN_U32_SET(hal_data->ext_lo, (uint32_t)pos);
 
   // set raw encoder pos
-  *(hal_data->pos_enc) = ((double)pos) * pos_scale;
+  LCEC_PIN_FLOAT_SET(hal_data->pos_enc, ((double)pos) * pos_scale);
 
   // calculate home based abs pos
   pos += raw_diff(hal_data->raw_shift, 0, hal_data->raw_home);
-  *(hal_data->pos_abs) = ((double)pos) * pos_scale;
-  *(hal_data->on_home_neg) = (pos <= 0);
-  *(hal_data->on_home_pos) = (pos >= 0);
+  LCEC_PIN_FLOAT_SET(hal_data->pos_abs, ((double)pos) * pos_scale);
+  LCEC_PIN_BIT_SET(hal_data->on_home_neg, (pos <= 0));
+  LCEC_PIN_BIT_SET(hal_data->on_home_pos, (pos >= 0));
 
   // handle index
-  if (*(hal_data->index_ena)) {
+  if (LCEC_PIN_BIT_GET(hal_data->index_ena)) {
     // get overflow detection window (pprev / 4)
     ovfl_win = pprev >> 2;
     if (ovfl_win == 0 || pprev > 0xffffffff) {
       // no useable singleturn bits -> just reset the position
-      *(hal_data->index_ena) = 0;
+      LCEC_PIN_BIT_SET(hal_data->index_ena, 0);
       set_ref(hal_data, pos);
     } else {
       mod = signed_mod_64(pos, pprev);
       sign = (mod >= 0) ? 1 : -1;
       if (hal_data->index_sign != 0 && sign != hal_data->index_sign && mod <= ovfl_win) {
-        *(hal_data->index_ena) = 0;
+        LCEC_PIN_BIT_SET(hal_data->index_ena, 0);
         set_ref(hal_data, pos - mod);
       }
       hal_data->index_sign = sign;
@@ -146,13 +146,13 @@ void class_enc_update(
   }
 
   // handle rel position init
-  if (hal_data->do_init || *(hal_data->pos_reset)) {
+  if (hal_data->do_init || LCEC_PIN_BIT_GET(hal_data->pos_reset)) {
     set_ref(hal_data, pos);
   }
 
   // calculate rel pos
-  pos -= ((long long)*(hal_data->ref_hi) << 32) | *(hal_data->ref_lo);
-  *(hal_data->pos) = ((double)pos) * pos_scale;
+  pos -= ((long long)LCEC_PIN_U32_GET(hal_data->ref_hi) << 32) | LCEC_PIN_U32_GET(hal_data->ref_lo);
+  LCEC_PIN_FLOAT_SET(hal_data->pos, ((double)pos) * pos_scale);
 
   hal_data->do_init = 0;
 }
@@ -160,8 +160,8 @@ void class_enc_update(
 static int32_t raw_diff(int shift, uint32_t a, uint32_t b) { return ((int32_t)(a << shift) - (int32_t)(b << shift)) >> shift; }
 
 static void set_ref(lcec_class_enc_data_t *hal_data, long long ref) {
-  *(hal_data->ref_hi) = (uint32_t)(ref >> 32);
-  *(hal_data->ref_lo) = (uint32_t)ref;
+  LCEC_PIN_U32_SET(hal_data->ref_hi, (uint32_t)(ref >> 32));
+  LCEC_PIN_U32_SET(hal_data->ref_lo, (uint32_t)ref);
 }
 
 static long long signed_mod_64(long long val, unsigned long div) {

--- a/src/devices/lcec_class_enc.h
+++ b/src/devices/lcec_class_enc.h
@@ -25,9 +25,9 @@
 #include "../lcec.h"
 
 typedef struct {
-  hal_s32_t raw_home;
-  hal_u32_t raw_bits;
-  hal_float_t pprev_scale;
+  lcec_param_u32_t raw_home;
+  lcec_param_u32_t raw_bits;
+  lcec_param_float_t pprev_scale;
 
   hal_s32_t *raw;
   hal_u32_t *ext_lo;

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -384,7 +384,7 @@ static int lcec_deasda_init(int comp_id, lcec_slave_t *slave) {
     if ((err = lcec_pin_newf_list(hal_data, slave_pins_csp, LCEC_MODULE_NAME, master->name, slave->name)) != 0) return err;
   }
 
-  *(hal_data->operation_mode) = operationmode;
+  LCEC_PIN_U32_SET(hal_data->operation_mode, operationmode);
   // export parameters
   if ((err = lcec_param_newf_list(hal_data, slave_params, LCEC_MODULE_NAME, master->name, slave->name)) != 0) return err;
 
@@ -447,18 +447,18 @@ static void lcec_deasda_read(lcec_slave_t *slave, long period) {
   uint32_t pos_cnt;
   // wait for slave to be operational
   if (!slave->state.operational) {
-    *(hal_data->ready) = 0;
-    *(hal_data->switched_on) = 0;
-    *(hal_data->oper_enabled) = 0;
-    *(hal_data->fault) = 1;
-    *(hal_data->volt_enabled) = 0;
-    *(hal_data->quick_stoped) = 0;
-    *(hal_data->on_disabled) = 0;
-    *(hal_data->warning) = 0;
-    *(hal_data->remote) = 0;
-    *(hal_data->at_speed) = 0;
-    *(hal_data->limit_active) = 0;
-    *(hal_data->zero_speed) = 0;
+    LCEC_PIN_BIT_SET(hal_data->ready, 0);
+    LCEC_PIN_BIT_SET(hal_data->switched_on, 0);
+    LCEC_PIN_BIT_SET(hal_data->oper_enabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->fault, 1);
+    LCEC_PIN_BIT_SET(hal_data->volt_enabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->quick_stoped, 0);
+    LCEC_PIN_BIT_SET(hal_data->on_disabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->warning, 0);
+    LCEC_PIN_BIT_SET(hal_data->remote, 0);
+    LCEC_PIN_BIT_SET(hal_data->at_speed, 0);
+    LCEC_PIN_BIT_SET(hal_data->limit_active, 0);
+    LCEC_PIN_BIT_SET(hal_data->zero_speed, 0);
     return;
   }
 
@@ -467,18 +467,18 @@ static void lcec_deasda_read(lcec_slave_t *slave, long period) {
 
   // read status word
   status = EC_READ_U16(&pd[hal_data->status_pdo_os]);
-  *(hal_data->ready) = (status >> 0) & 0x01;
-  *(hal_data->switched_on) = (status >> 1) & 0x01;
-  *(hal_data->oper_enabled) = (status >> 2) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->ready, (status >> 0) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->switched_on, (status >> 1) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->oper_enabled, (status >> 2) & 0x01);
   hal_data->internal_fault = (status >> 3) & 0x01;
-  *(hal_data->volt_enabled) = (status >> 4) & 0x01;
-  *(hal_data->quick_stoped) = !((status >> 5) & 0x01);
-  *(hal_data->on_disabled) = (status >> 6) & 0x01;
-  *(hal_data->warning) = (status >> 7) & 0x01;
-  *(hal_data->remote) = (status >> 9) & 0x01;
-  *(hal_data->at_speed) = (status >> 10) & 0x01;
-  *(hal_data->limit_active) = (status >> 11) & 0x01;
-  *(hal_data->zero_speed) = (status >> 12) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->volt_enabled, (status >> 4) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->quick_stoped, !((status >> 5) & 0x01));
+  LCEC_PIN_BIT_SET(hal_data->on_disabled, (status >> 6) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->warning, (status >> 7) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->remote, (status >> 9) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->at_speed, (status >> 10) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->limit_active, (status >> 11) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->zero_speed, (status >> 12) & 0x01);
 
   // clear pending fault reset if no fault
   if (!hal_data->internal_fault) hal_data->fault_reset_retry = 0;
@@ -494,17 +494,17 @@ static void lcec_deasda_read(lcec_slave_t *slave, long period) {
         hal_data->fault_reset_retry--;
       }
     }
-    *(hal_data->fault) = 0;
+    LCEC_PIN_BIT_SET(hal_data->fault, 0);
   } else {
-    *(hal_data->fault) = hal_data->internal_fault;
+    LCEC_PIN_BIT_SET(hal_data->fault, hal_data->internal_fault);
   }
 
   // read current speed
   speed_raw = EC_READ_S32(&pd[hal_data->currvel_pdo_os]);
   rpm = (double)speed_raw * DEASDA_RPM_FACTOR;
-  *(hal_data->vel_fb_rpm) = rpm;
-  *(hal_data->vel_fb_rpm_abs) = fabs(rpm);
-  *(hal_data->vel_fb) = rpm * DEASDA_RPM_DIV * hal_data->pos_scale;
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm, rpm);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(rpm));
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb, rpm * DEASDA_RPM_DIV * hal_data->pos_scale);
 
   // update raw position counter
   pos_cnt = EC_READ_U32(&pd[hal_data->currpos_pdo_os]);
@@ -515,21 +515,21 @@ static void lcec_deasda_read(lcec_slave_t *slave, long period) {
   class_enc_update(&hal_data->extenc, 1, hal_data->extenc_scale, pos_cnt, 0, 0);
 
   // read current
-  *(hal_data->torque) = (double)EC_READ_S16(&pd[hal_data->torque_pdo_os]) * 0.1;
+  LCEC_PIN_FLOAT_SET(hal_data->torque, (double)EC_READ_S16(&pd[hal_data->torque_pdo_os]) * 0.1);
 
   // read DI status word
   status_di = EC_READ_U32(&pd[hal_data->divalue_pdo_os]);
 
-  *(hal_data->neg_lim_switch) = (status_di >> 0) & 0x01;
-  *(hal_data->pos_lim_switch) = (status_di >> 1) & 0x01;
-  *(hal_data->home_switch) = (status_di >> 2) & 0x01;
-  *(hal_data->di_1) = (status_di >> 16) & 0x01;
-  *(hal_data->di_2) = (status_di >> 17) & 0x01;
-  *(hal_data->di_3) = (status_di >> 18) & 0x01;
-  *(hal_data->di_4) = (status_di >> 19) & 0x01;
-  *(hal_data->di_5) = (status_di >> 20) & 0x01;
-  *(hal_data->di_6) = (status_di >> 21) & 0x01;
-  *(hal_data->di_7) = (status_di >> 22) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->neg_lim_switch, (status_di >> 0) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->pos_lim_switch, (status_di >> 1) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->home_switch, (status_di >> 2) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_1, (status_di >> 16) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_2, (status_di >> 17) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_3, (status_di >> 18) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_4, (status_di >> 19) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_5, (status_di >> 20) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_6, (status_di >> 21) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->di_7, (status_di >> 22) & 0x01);
 }
 
 static void lcec_deasda_write_csv(lcec_slave_t *slave, long period) {
@@ -544,8 +544,8 @@ static void lcec_deasda_write_csv(lcec_slave_t *slave, long period) {
   if (hal_data->dout) lcec_dout_write_all(slave, hal_data->dout);
 
   // check for enable edge
-  switch_on_edge = *(hal_data->switch_on) && !hal_data->last_switch_on;
-  hal_data->last_switch_on = *(hal_data->switch_on);
+  switch_on_edge = LCEC_PIN_BIT_GET(hal_data->switch_on) && !hal_data->last_switch_on;
+  hal_data->last_switch_on = LCEC_PIN_BIT_GET(hal_data->switch_on);
 
   // check for autoreset
   if (hal_data->fault_autoreset_retries > 0 && hal_data->fault_autoreset_cycles > 0 && switch_on_edge && hal_data->internal_fault) {
@@ -560,25 +560,25 @@ static void lcec_deasda_write_csv(lcec_slave_t *slave, long period) {
   // write dev ctrl
   control = 0;
 
-  if (*(hal_data->enable_volt)) control |= (1 << 1);
-  if (!*(hal_data->quick_stop)) control |= (1 << 2);
-  if (*(hal_data->fault_reset)) control |= (1 << 7);
-  if (*(hal_data->halt)) control |= (1 << 8);
+  if (LCEC_PIN_BIT_GET(hal_data->enable_volt)) control |= (1 << 1);
+  if (!LCEC_PIN_BIT_GET(hal_data->quick_stop)) control |= (1 << 2);
+  if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) control |= (1 << 7);
+  if (LCEC_PIN_BIT_GET(hal_data->halt)) control |= (1 << 8);
 
   if (hal_data->fault_reset_retry > 0) {
     if (hal_data->fault_reset_state) control |= (1 << 7);
   } else {
-    if (*(hal_data->switch_on)) control |= (1 << 0);
-    if (*(hal_data->enable) && *(hal_data->switched_on)) control |= (1 << 3);
+    if (LCEC_PIN_BIT_GET(hal_data->switch_on)) control |= (1 << 0);
+    if (LCEC_PIN_BIT_GET(hal_data->enable) && LCEC_PIN_BIT_GET(hal_data->switched_on)) control |= (1 << 3);
   }
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // all of this is depeding on CSV/CSP
   // calculate rpm command
-  *(hal_data->vel_rpm) = *(hal_data->cmd_value) * hal_data->pos_scale_rcpt * DEASDA_RPM_MUL;
+  LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, LCEC_PIN_FLOAT_GET(hal_data->cmd_value) * hal_data->pos_scale_rcpt * DEASDA_RPM_MUL);
 
   // set RPM
-  speed_raw = *(hal_data->vel_rpm) * DEASDA_RPM_RCPT;
+  speed_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) * DEASDA_RPM_RCPT;
   if (speed_raw > (double)0x7fffffff) speed_raw = (double)0x7fffffff;
   if (speed_raw < (double)-0x7fffffff) speed_raw = (double)-0x7fffffff;
 
@@ -597,8 +597,8 @@ static void lcec_deasda_write_csp(lcec_slave_t *slave, long period) {
   if (hal_data->dout) lcec_dout_write_all(slave, hal_data->dout);
 
   // check for enable edge
-  switch_on_edge = *(hal_data->switch_on) && !hal_data->last_switch_on;
-  hal_data->last_switch_on = *(hal_data->switch_on);
+  switch_on_edge = LCEC_PIN_BIT_GET(hal_data->switch_on) && !hal_data->last_switch_on;
+  hal_data->last_switch_on = LCEC_PIN_BIT_GET(hal_data->switch_on);
 
   // check for autoreset
   if (hal_data->fault_autoreset_retries > 0 && hal_data->fault_autoreset_cycles > 0 && switch_on_edge && hal_data->internal_fault) {
@@ -612,23 +612,23 @@ static void lcec_deasda_write_csp(lcec_slave_t *slave, long period) {
 
   // write dev ctrl
   control = 0;
-  if (*(hal_data->enable_volt)) control |= (1 << 1);
-  if (!*(hal_data->quick_stop)) control |= (1 << 2);
-  if (*(hal_data->fault_reset)) control |= (1 << 7);
-  if (*(hal_data->halt)) control |= (1 << 8);
+  if (LCEC_PIN_BIT_GET(hal_data->enable_volt)) control |= (1 << 1);
+  if (!LCEC_PIN_BIT_GET(hal_data->quick_stop)) control |= (1 << 2);
+  if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) control |= (1 << 7);
+  if (LCEC_PIN_BIT_GET(hal_data->halt)) control |= (1 << 8);
 
   if (hal_data->fault_reset_retry > 0) {
     if (hal_data->fault_reset_state) control |= (1 << 7);
   } else {
-    if (*(hal_data->switch_on)) control |= (1 << 0);
-    if (*(hal_data->enable) && *(hal_data->switched_on)) control |= (1 << 3);
+    if (LCEC_PIN_BIT_GET(hal_data->switch_on)) control |= (1 << 0);
+    if (LCEC_PIN_BIT_GET(hal_data->enable) && LCEC_PIN_BIT_GET(hal_data->switched_on)) control |= (1 << 3);
   }
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // ASDA Drives expect target Position in PUU (Pulse per User Unit)
   // See https://www.deltaww.com/en-US/FAQ/228
   // Calculation accordingly based on pprev and pos_scale (i.e. pitch of ball screw)
-  pos_puu = (int32_t)(*(hal_data->cmd_value) * hal_data->pprev / hal_data->pos_scale);
+  pos_puu = (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->cmd_value) * hal_data->pprev / hal_data->pos_scale);
   EC_WRITE_S32(&pd[hal_data->cmdvalue_pdo_os], pos_puu);
 }
 

--- a/src/devices/lcec_deasda.c
+++ b/src/devices/lcec_deasda.c
@@ -107,11 +107,11 @@ typedef struct {
   hal_u32_t *operation_mode;
   hal_float_t *cmd_value;
 
-  hal_float_t pos_scale;
-  hal_float_t extenc_scale;
-  hal_u32_t pprev;
-  hal_u32_t fault_autoreset_cycles;
-  hal_u32_t fault_autoreset_retries;
+  lcec_param_float_t pos_scale;
+  lcec_param_float_t extenc_scale;
+  lcec_param_u32_t pprev;
+  lcec_param_u32_t fault_autoreset_cycles;
+  lcec_param_u32_t fault_autoreset_retries;
 
   hal_float_t *torque;
   hal_bit_t *neg_lim_switch;
@@ -393,20 +393,20 @@ static int lcec_deasda_init(int comp_id, lcec_slave_t *slave) {
   if ((err = class_enc_init(slave, &hal_data->extenc, 32, "extenc")) != 0) return err;
 
   // initialize variables
-  hal_data->pos_scale = 1.0;
-  hal_data->extenc_scale = 1.0;
-  hal_data->fault_autoreset_cycles = DEASDA_FAULT_AUTORESET_CYCLES;
-  hal_data->fault_autoreset_retries = DEASDA_FAULT_AUTORESET_RETRIES;
-  hal_data->pos_scale_old = hal_data->pos_scale + 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
+  LCEC_PARAM_FLOAT_SET(hal_data->extenc_scale, 1.0);
+  LCEC_PARAM_U32_SET(hal_data->fault_autoreset_cycles, DEASDA_FAULT_AUTORESET_CYCLES);
+  LCEC_PARAM_U32_SET(hal_data->fault_autoreset_retries, DEASDA_FAULT_AUTORESET_RETRIES);
+  hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) + 1.0;
   hal_data->pos_scale_rcpt = 1.0;
 
   // change based on FLAG_LOWRES_ENC/FLAG_HIGHRES_ENC
   if (flags & FLAG_LOWRES_ENC) {
-    hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_LOWRES;
+    LCEC_PARAM_U32_SET(hal_data->pprev, DEASDA_PULSES_PER_REV_DEFLT_LOWRES);
     rtapi_print_msg(
         RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting pprev to Low Res Encoder (1,280,000) for device %s.%s.\n", master->name, slave->name);
   } else if (flags & FLAG_HIGHRES_ENC) {
-    hal_data->pprev = DEASDA_PULSES_PER_REV_DEFLT_HIGHRES;
+    LCEC_PARAM_U32_SET(hal_data->pprev, DEASDA_PULSES_PER_REV_DEFLT_HIGHRES);
     rtapi_print_msg(
         RTAPI_MSG_DBG, LCEC_MSG_PFX "Setting pprev to High Res Encoder (16,777,216) for device %s.%s.\n", master->name, slave->name);
   }
@@ -425,14 +425,14 @@ static int lcec_deasda_init(int comp_id, lcec_slave_t *slave) {
 
 void lcec_deasda_check_scales(lcec_deasda_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->pos_scale != hal_data->pos_scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) != hal_data->pos_scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->pos_scale < 1e-20) && (hal_data->pos_scale > -1e-20)) hal_data->pos_scale = 1.0;
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) > -1e-20)) LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
 
     // save new scale to detect future changes
-    hal_data->pos_scale_old = hal_data->pos_scale;
+    hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
     // we actually want the reciprocal
-    hal_data->pos_scale_rcpt = 1.0 / hal_data->pos_scale;
+    hal_data->pos_scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
   }
 }
 
@@ -485,7 +485,7 @@ static void lcec_deasda_read(lcec_slave_t *slave, long period) {
 
   // generate gated fault
   if (hal_data->fault_reset_retry > 0) {
-    if (hal_data->fault_reset_cycle < hal_data->fault_autoreset_cycles) {
+    if (hal_data->fault_reset_cycle < LCEC_PARAM_U32_GET(hal_data->fault_autoreset_cycles)) {
       hal_data->fault_reset_cycle++;
     } else {
       hal_data->fault_reset_cycle = 0;
@@ -504,15 +504,15 @@ static void lcec_deasda_read(lcec_slave_t *slave, long period) {
   rpm = (double)speed_raw * DEASDA_RPM_FACTOR;
   LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm, rpm);
   LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(rpm));
-  LCEC_PIN_FLOAT_SET(hal_data->vel_fb, rpm * DEASDA_RPM_DIV * hal_data->pos_scale);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb, rpm * DEASDA_RPM_DIV * LCEC_PARAM_FLOAT_GET(hal_data->pos_scale));
 
   // update raw position counter
   pos_cnt = EC_READ_U32(&pd[hal_data->currpos_pdo_os]);
-  class_enc_update(&hal_data->enc, hal_data->pprev, hal_data->pos_scale, pos_cnt, 0, 0);
+  class_enc_update(&hal_data->enc, LCEC_PARAM_U32_GET(hal_data->pprev), LCEC_PARAM_FLOAT_GET(hal_data->pos_scale), pos_cnt, 0, 0);
 
   // update external encoder counter
   pos_cnt = EC_READ_U32(&pd[hal_data->extenc_pdo_os]);
-  class_enc_update(&hal_data->extenc, 1, hal_data->extenc_scale, pos_cnt, 0, 0);
+  class_enc_update(&hal_data->extenc, 1, LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale), pos_cnt, 0, 0);
 
   // read current
   LCEC_PIN_FLOAT_SET(hal_data->torque, (double)EC_READ_S16(&pd[hal_data->torque_pdo_os]) * 0.1);
@@ -548,8 +548,8 @@ static void lcec_deasda_write_csv(lcec_slave_t *slave, long period) {
   hal_data->last_switch_on = LCEC_PIN_BIT_GET(hal_data->switch_on);
 
   // check for autoreset
-  if (hal_data->fault_autoreset_retries > 0 && hal_data->fault_autoreset_cycles > 0 && switch_on_edge && hal_data->internal_fault) {
-    hal_data->fault_reset_retry = hal_data->fault_autoreset_retries;
+  if (LCEC_PARAM_U32_GET(hal_data->fault_autoreset_retries) > 0 && LCEC_PARAM_U32_GET(hal_data->fault_autoreset_cycles) > 0 && switch_on_edge && hal_data->internal_fault) {
+    hal_data->fault_reset_retry = LCEC_PARAM_U32_GET(hal_data->fault_autoreset_retries);
     hal_data->fault_reset_state = 1;
     hal_data->fault_reset_cycle = 0;
   }
@@ -601,8 +601,8 @@ static void lcec_deasda_write_csp(lcec_slave_t *slave, long period) {
   hal_data->last_switch_on = LCEC_PIN_BIT_GET(hal_data->switch_on);
 
   // check for autoreset
-  if (hal_data->fault_autoreset_retries > 0 && hal_data->fault_autoreset_cycles > 0 && switch_on_edge && hal_data->internal_fault) {
-    hal_data->fault_reset_retry = hal_data->fault_autoreset_retries;
+  if (LCEC_PARAM_U32_GET(hal_data->fault_autoreset_retries) > 0 && LCEC_PARAM_U32_GET(hal_data->fault_autoreset_cycles) > 0 && switch_on_edge && hal_data->internal_fault) {
+    hal_data->fault_reset_retry = LCEC_PARAM_U32_GET(hal_data->fault_autoreset_retries);
     hal_data->fault_reset_state = 1;
     hal_data->fault_reset_cycle = 0;
   }
@@ -628,7 +628,7 @@ static void lcec_deasda_write_csp(lcec_slave_t *slave, long period) {
   // ASDA Drives expect target Position in PUU (Pulse per User Unit)
   // See https://www.deltaww.com/en-US/FAQ/228
   // Calculation accordingly based on pprev and pos_scale (i.e. pitch of ball screw)
-  pos_puu = (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->cmd_value) * hal_data->pprev / hal_data->pos_scale);
+  pos_puu = (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->cmd_value) * LCEC_PARAM_U32_GET(hal_data->pprev) / LCEC_PARAM_FLOAT_GET(hal_data->pos_scale));
   EC_WRITE_S32(&pd[hal_data->cmdvalue_pdo_os], pos_puu);
 }
 

--- a/src/devices/lcec_dems300.c
+++ b/src/devices/lcec_dems300.c
@@ -66,8 +66,8 @@ typedef struct {
   hal_u32_t *vel_ramp_up;
   hal_u32_t *vel_ramp_down;
 
-  hal_bit_t auto_fault_reset;
-  hal_float_t vel_scale;
+  lcec_param_bit_t auto_fault_reset;
+  lcec_param_float_t vel_scale;
 
   double vel_scale_old;
   double vel_scale_rcpt;
@@ -217,9 +217,9 @@ static int lcec_dems300_init(int comp_id, lcec_slave_t *slave) {
   hal_data->enable_old = 0;
   hal_data->internal_fault = 0;
 
-  hal_data->auto_fault_reset = 1;
-  hal_data->vel_scale = 1.0;
-  hal_data->vel_scale_old = hal_data->vel_scale + 1.0;
+  LCEC_PARAM_BIT_SET(hal_data->auto_fault_reset, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->vel_scale, 1.0);
+  hal_data->vel_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->vel_scale) + 1.0;
   hal_data->vel_scale_rcpt = 1.0;
 
   return 0;
@@ -227,16 +227,16 @@ static int lcec_dems300_init(int comp_id, lcec_slave_t *slave) {
 
 static void lcec_dems300_check_scales(lcec_dems300_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->vel_scale != hal_data->vel_scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->vel_scale) != hal_data->vel_scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->vel_scale < 1e-20) && (hal_data->vel_scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->vel_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->vel_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->vel_scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->vel_scale, 1.0);
     }
     // save new scale to detect future changes
-    hal_data->vel_scale_old = hal_data->vel_scale;
+    hal_data->vel_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->vel_scale);
     // we actually want the reciprocal
-    hal_data->vel_scale_rcpt = 1.0 / hal_data->vel_scale;
+    hal_data->vel_scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->vel_scale);
   }
 }
 
@@ -341,7 +341,7 @@ static void lcec_dems300_write(lcec_slave_t *slave, long period) {
     if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) {
       control |= (1 << 7);  // fault reset
     }
-    if (hal_data->auto_fault_reset && enable_edge) {
+    if (LCEC_PARAM_BIT_GET(hal_data->auto_fault_reset) && enable_edge) {
       hal_data->auto_fault_reset_delay = MS300_FAULT_AUTORESET_DELAY_NS;
       control |= (1 << 7);  // fault reset
     }
@@ -373,7 +373,7 @@ static void lcec_dems300_write(lcec_slave_t *slave, long period) {
   EC_WRITE_U32(&pd[hal_data->ramp_down_pdo_os], LCEC_PIN_U32_GET(hal_data->vel_ramp_down));
 
   // set RPM
-  speed_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_rpm_cmd) * hal_data->vel_scale;
+  speed_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_rpm_cmd) * LCEC_PARAM_FLOAT_GET(hal_data->vel_scale);
   if (speed_raw > (double)0x7fff) {
     speed_raw = (double)0x7fff;
   }

--- a/src/devices/lcec_dems300.c
+++ b/src/devices/lcec_dems300.c
@@ -253,26 +253,26 @@ static void lcec_dems300_read(lcec_slave_t *slave, long period) {
   lcec_dems300_check_scales(hal_data);
 
   // read current
-  *(hal_data->act_current) = (double)EC_READ_U16(&pd[hal_data->current_pdo_os]) / 100.0;
+  LCEC_PIN_FLOAT_SET(hal_data->act_current, (double)EC_READ_U16(&pd[hal_data->current_pdo_os]) / 100.0);
   // read temp
-  *(hal_data->drive_temp) = (double)EC_READ_U16(&pd[hal_data->temp_pdo_os]) / 10.0;
+  LCEC_PIN_FLOAT_SET(hal_data->drive_temp, (double)EC_READ_U16(&pd[hal_data->temp_pdo_os]) / 10.0);
   // read warn and error code
   error = EC_READ_U16(&pd[hal_data->warn_err_pdo_os]);
-  *(hal_data->error_code) = error & 0xff;  // low byte
-  *(hal_data->warn_code) = error >> 8;     // high byte
+  LCEC_PIN_U32_SET(hal_data->error_code, error & 0xff);  // low byte
+  LCEC_PIN_U32_SET(hal_data->warn_code, error >> 8);     // high byte
 
   // wait for slave to be operational
   if (!slave->state.operational) {
-    *(hal_data->stat_switch_on_ready) = 0;
-    *(hal_data->stat_switched_on) = 0;
-    *(hal_data->stat_op_enabled) = 0;
-    *(hal_data->stat_fault) = 1;
-    *(hal_data->stat_volt_enabled) = 0;
-    *(hal_data->stat_quick_stoped) = 0;
-    *(hal_data->stat_switch_on_disabled) = 0;
-    *(hal_data->stat_warning) = 0;
-    *(hal_data->stat_remote) = 0;
-    *(hal_data->stat_at_speed) = 0;
+    LCEC_PIN_BIT_SET(hal_data->stat_switch_on_ready, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_switched_on, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_op_enabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_fault, 1);
+    LCEC_PIN_BIT_SET(hal_data->stat_volt_enabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_quick_stoped, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_switch_on_disabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_warning, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_remote, 0);
+    LCEC_PIN_BIT_SET(hal_data->stat_at_speed, 0);
     return;
   }
 
@@ -281,17 +281,17 @@ static void lcec_dems300_read(lcec_slave_t *slave, long period) {
 
   // read status word
   status = EC_READ_U16(&pd[hal_data->status_pdo_os]);
-  *(hal_data->stat_switch_on_ready) = (status >> 0) & 1;
-  *(hal_data->stat_switched_on) = (status >> 1) & 1;
-  *(hal_data->stat_op_enabled) = (status >> 2) & 1;
-  //  *(hal_data->stat_fault)             = (status >> 3) & 1;
+  LCEC_PIN_BIT_SET(hal_data->stat_switch_on_ready, (status >> 0) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_switched_on, (status >> 1) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_op_enabled, (status >> 2) & 1);
+  //  LCEC_PIN_BIT_SET(hal_data->stat_fault, (status >> 3) & 1);
   hal_data->internal_fault = (status >> 3) & 0x01;
-  *(hal_data->stat_volt_enabled) = (status >> 4) & 1;
-  *(hal_data->stat_quick_stoped) = (status >> 5) & 1;
-  *(hal_data->stat_switch_on_disabled) = (status >> 6) & 1;
-  *(hal_data->stat_warning) = (status >> 7) & 1;
-  *(hal_data->stat_remote) = (status >> 9) & 1;
-  *(hal_data->stat_at_speed) = (status >> 10) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->stat_volt_enabled, (status >> 4) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_quick_stoped, (status >> 5) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_switch_on_disabled, (status >> 6) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_warning, (status >> 7) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_remote, (status >> 9) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_at_speed, (status >> 10) & 0x01);
 
   // set fault if op mode is wrong
   if (opmode_in != 2) {
@@ -302,16 +302,16 @@ static void lcec_dems300_read(lcec_slave_t *slave, long period) {
   // update fault output
   if (hal_data->auto_fault_reset_delay > 0) {
     hal_data->auto_fault_reset_delay -= period;
-    *(hal_data->stat_fault) = 0;
+    LCEC_PIN_BIT_SET(hal_data->stat_fault, 0);
   } else {
-    *(hal_data->stat_fault) = hal_data->internal_fault;
+    LCEC_PIN_BIT_SET(hal_data->stat_fault, hal_data->internal_fault);
   }
 
   // read current speed
   speed_raw = EC_READ_S16(&pd[hal_data->currvel_pdo_os]);
   rpm = (double)speed_raw * hal_data->vel_scale_rcpt;
-  *(hal_data->vel_fb_rpm) = rpm;
-  *(hal_data->vel_fb_rpm_abs) = fabs(rpm);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm, rpm);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(rpm));
 }
 
 static void lcec_dems300_write(lcec_slave_t *slave, long period) {
@@ -331,14 +331,14 @@ static void lcec_dems300_write(lcec_slave_t *slave, long period) {
   EC_WRITE_S8(&pd[hal_data->mode_op_pdo_os], (int8_t)opmode);
 
   // check for enable edge
-  enable_edge = *(hal_data->enable) && !hal_data->enable_old;
-  hal_data->enable_old = *(hal_data->enable);
+  enable_edge = LCEC_PIN_BIT_GET(hal_data->enable) && !hal_data->enable_old;
+  hal_data->enable_old = LCEC_PIN_BIT_GET(hal_data->enable);
 
   // write control register
-  control = (!*(hal_data->fault_reset) << 2);  // quick stop
+  control = (!LCEC_PIN_BIT_GET(hal_data->fault_reset) << 2);  // quick stop
 
-  if (*(hal_data->stat_fault)) {
-    if (*(hal_data->fault_reset)) {
+  if (LCEC_PIN_BIT_GET(hal_data->stat_fault)) {
+    if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) {
       control |= (1 << 7);  // fault reset
     }
     if (hal_data->auto_fault_reset && enable_edge) {
@@ -346,17 +346,17 @@ static void lcec_dems300_write(lcec_slave_t *slave, long period) {
       control |= (1 << 7);  // fault reset
     }
   } else {
-    if (*(hal_data->enable)) {
+    if (LCEC_PIN_BIT_GET(hal_data->enable)) {
       control |= (1 << 1);  // enable voltage
-      if (*(hal_data->stat_switch_on_ready)) {
+      if (LCEC_PIN_BIT_GET(hal_data->stat_switch_on_ready)) {
         control |= (1 << 0);  // switch on
-        if (*(hal_data->stat_switched_on)) {
+        if (LCEC_PIN_BIT_GET(hal_data->stat_switched_on)) {
           control |= (1 << 3);  // enable op
         }
       }
     }
     // set velo control bits
-    if (*(hal_data->stat_op_enabled)) {
+    if (LCEC_PIN_BIT_GET(hal_data->stat_op_enabled)) {
       control |= (1 << 4);  // rfg enable
       control |= (1 << 5);  // rfg unlock
       control |= (1 << 6);  // rfg use ref
@@ -364,16 +364,16 @@ static void lcec_dems300_write(lcec_slave_t *slave, long period) {
   }
 
   // halt
-  control |= (*(hal_data->halt) << 8);  // halt
+  control |= (LCEC_PIN_BIT_GET(hal_data->halt) << 8);  // halt
 
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // write ramp times
-  EC_WRITE_U32(&pd[hal_data->ramp_up_pdo_os], *(hal_data->vel_ramp_up));
-  EC_WRITE_U32(&pd[hal_data->ramp_down_pdo_os], *(hal_data->vel_ramp_down));
+  EC_WRITE_U32(&pd[hal_data->ramp_up_pdo_os], LCEC_PIN_U32_GET(hal_data->vel_ramp_up));
+  EC_WRITE_U32(&pd[hal_data->ramp_down_pdo_os], LCEC_PIN_U32_GET(hal_data->vel_ramp_down));
 
   // set RPM
-  speed_raw = *(hal_data->vel_rpm_cmd) * hal_data->vel_scale;
+  speed_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_rpm_cmd) * hal_data->vel_scale;
   if (speed_raw > (double)0x7fff) {
     speed_raw = (double)0x7fff;
   }

--- a/src/devices/lcec_el1904.c
+++ b/src/devices/lcec_el1904.c
@@ -137,16 +137,16 @@ static void lcec_el1904_read(lcec_slave_t *slave, long period) {
 
   copy_fsoe_data(slave, hal_data->fsoe_slave_cmd_os, hal_data->fsoe_master_cmd_os);
 
-  *(hal_data->fsoe_slave_cmd) = EC_READ_U8(&pd[hal_data->fsoe_slave_cmd_os]);
-  *(hal_data->fsoe_slave_crc) = EC_READ_U16(&pd[hal_data->fsoe_slave_crc_os]);
-  *(hal_data->fsoe_slave_connid) = EC_READ_U16(&pd[hal_data->fsoe_slave_connid_os]);
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_cmd, EC_READ_U8(&pd[hal_data->fsoe_slave_cmd_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_crc, EC_READ_U16(&pd[hal_data->fsoe_slave_crc_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_connid, EC_READ_U16(&pd[hal_data->fsoe_slave_connid_os]));
 
-  *(hal_data->fsoe_master_cmd) = EC_READ_U8(&pd[hal_data->fsoe_master_cmd_os]);
-  *(hal_data->fsoe_master_crc) = EC_READ_U16(&pd[hal_data->fsoe_master_crc_os]);
-  *(hal_data->fsoe_master_connid) = EC_READ_U16(&pd[hal_data->fsoe_master_connid_os]);
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_cmd, EC_READ_U8(&pd[hal_data->fsoe_master_cmd_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_crc, EC_READ_U16(&pd[hal_data->fsoe_master_crc_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_connid, EC_READ_U16(&pd[hal_data->fsoe_master_connid_os]));
 
   for (i = 0, in = hal_data->inputs; i < LCEC_EL1904_INPUT_COUNT; i++, in++) {
-    *(in->fsoe_in) = EC_READ_BIT(&pd[in->fsoe_in_os], in->fsoe_in_bp);
-    *(in->fsoe_in_not) = !*(in->fsoe_in);
+    LCEC_PIN_BIT_SET(in->fsoe_in, EC_READ_BIT(&pd[in->fsoe_in_os], in->fsoe_in_bp));
+    LCEC_PIN_BIT_SET(in->fsoe_in_not, !LCEC_PIN_BIT_GET(in->fsoe_in));
   }
 }

--- a/src/devices/lcec_el1918_logic.c
+++ b/src/devices/lcec_el1918_logic.c
@@ -287,26 +287,26 @@ void lcec_el1918_logic_read(lcec_slave_t *slave, long period) {
   lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
-  *(hal_data->state) = EC_READ_U8(&pd[hal_data->state_os]);
-  *(hal_data->cycle_counter) = EC_READ_U8(&pd[hal_data->cycle_counter_os]);
+  LCEC_PIN_U32_SET(hal_data->state, EC_READ_U8(&pd[hal_data->state_os]));
+  LCEC_PIN_U32_SET(hal_data->cycle_counter, EC_READ_U8(&pd[hal_data->cycle_counter_os]));
 
   if (hal_data->std_out_count > 0) {
     std_out = EC_READ_U8(&pd[hal_data->std_out_os]);
     for (i = 0; i < hal_data->std_out_count; i++) {
-      *(hal_data->std_out_pins[i]) = !!(std_out & (1 << i));
+      LCEC_PIN_BIT_SET(hal_data->std_out_pins[i], !!(std_out & (1 << i)));
     }
   }
 
   for (i = 0, fsoe_data = hal_data->fsoe; i < hal_data->fsoe_count; i++, fsoe_data++) {
     fsoe_slave = fsoe_data->fsoe_slave;
     fsoeConf = fsoe_slave->fsoeConf;
-    *(fsoe_data->fsoe_master_cmd) = EC_READ_U8(&pd[fsoe_data->fsoe_master_cmd_os]);
-    *(fsoe_data->fsoe_master_connid) = EC_READ_U16(&pd[fsoe_data->fsoe_master_connid_os]);
-    *(fsoe_data->fsoe_slave_cmd) = EC_READ_U8(&pd[fsoe_data->fsoe_slave_cmd_os]);
-    *(fsoe_data->fsoe_slave_connid) = EC_READ_U16(&pd[fsoe_data->fsoe_slave_connid_os]);
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_master_cmd, EC_READ_U8(&pd[fsoe_data->fsoe_master_cmd_os]));
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_master_connid, EC_READ_U16(&pd[fsoe_data->fsoe_master_connid_os]));
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_slave_cmd, EC_READ_U8(&pd[fsoe_data->fsoe_slave_cmd_os]));
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_slave_connid, EC_READ_U16(&pd[fsoe_data->fsoe_slave_connid_os]));
     for (crc_idx = 0, crc = fsoe_data->fsoe_crc; crc_idx < fsoeConf->data_channels; crc_idx++, crc++) {
-      *(crc->fsoe_master_crc) = EC_READ_U16(&pd[crc->fsoe_master_crc_os]);
-      *(crc->fsoe_slave_crc) = EC_READ_U16(&pd[crc->fsoe_slave_crc_os]);
+      LCEC_PIN_U32_SET(crc->fsoe_master_crc, EC_READ_U16(&pd[crc->fsoe_master_crc_os]));
+      LCEC_PIN_U32_SET(crc->fsoe_slave_crc, EC_READ_U16(&pd[crc->fsoe_slave_crc_os]));
     }
   }
 }
@@ -321,7 +321,7 @@ void lcec_el1918_logic_write(lcec_slave_t *slave, long period) {
   if (hal_data->std_in_count > 0) {
     std_in = 0;
     for (i = 0; i < hal_data->std_in_count; i++) {
-      if (*(hal_data->std_in_pins[i])) std_in |= (1 << i);
+      if (LCEC_PIN_BIT_GET(hal_data->std_in_pins[i])) std_in |= (1 << i);
     }
     EC_WRITE_U8(&pd[hal_data->std_in_os], std_in);
   }

--- a/src/devices/lcec_el2202.c
+++ b/src/devices/lcec_el2202.c
@@ -138,8 +138,8 @@ static void lcec_el2202_write(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // set output
-    EC_WRITE_BIT(&pd[chan->out_offs], chan->out_bitp, *(chan->out));
+    EC_WRITE_BIT(&pd[chan->out_offs], chan->out_bitp, LCEC_PIN_BIT_GET(chan->out));
     // set tristate
-    EC_WRITE_BIT(&pd[chan->tristate_offs], chan->tristate_bitp, *(chan->tristate));
+    EC_WRITE_BIT(&pd[chan->tristate_offs], chan->tristate_bitp, LCEC_PIN_BIT_GET(chan->tristate));
   }
 }

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -20,7 +20,7 @@
 /// @brief Driver for Beckhoff EL2521 pulse train output modules
 
 #include "../lcec.h"
-#include "hal.h"
+#include <hal.h>
 
 // ****************************************************************************
 // CONFIG ISSUES:

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -264,13 +264,13 @@ static void lcec_el2521_read(lcec_slave_t *slave, long period) {
 
   // read state word
   state = EC_READ_U16(&pd[hal_data->state_pdo_os]);
-  *(hal_data->ramp_active) = (state >> 1) & 1;
+  LCEC_PIN_BIT_SET(hal_data->ramp_active, (state >> 1) & 1);
   in = (state >> 5) & 1;
-  *(hal_data->in_z) = in;
-  *(hal_data->in_z_not) = !in;
+  LCEC_PIN_BIT_SET(hal_data->in_z, in);
+  LCEC_PIN_BIT_SET(hal_data->in_z_not, !in);
   in = (state >> 4) & 1;
-  *(hal_data->in_t) = in;
-  *(hal_data->in_t_not) = !in;
+  LCEC_PIN_BIT_SET(hal_data->in_t, in);
+  LCEC_PIN_BIT_SET(hal_data->in_t_not, !in);
 
   // get counter diff
   hw_count = EC_READ_S16(&pd[hal_data->count_pdo_os]);
@@ -281,10 +281,10 @@ static void lcec_el2521_read(lcec_slave_t *slave, long period) {
   }
 
   // update raw count
-  *(hal_data->count) += hw_count_diff;
+  LCEC_PIN_S32_SET(hal_data->count, LCEC_PIN_S32_GET(hal_data->count) + hw_count_diff);
 
   // scale position
-  *(hal_data->pos_fb) = (double)(*(hal_data->count)) * hal_data->scale_recip;
+  LCEC_PIN_FLOAT_SET(hal_data->pos_fb, (double)(LCEC_PIN_S32_GET(hal_data->count)) * hal_data->scale_recip);
 
   hal_data->last_operational = 1;
 }
@@ -301,14 +301,14 @@ static void lcec_el2521_write(lcec_slave_t *slave, long period) {
 
   // write control word
   ctrl = 0;
-  if (*(hal_data->ramp_disable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->ramp_disable)) {
     ctrl |= (1 << 1);
   }
   EC_WRITE_S16(&pd[hal_data->ctrl_pdo_os], ctrl);
 
   // update frequency
-  if (*(hal_data->enable)) {
-    hal_data->freq = *(hal_data->vel_cmd) * hal_data->pos_scale;
+  if (LCEC_PIN_BIT_GET(hal_data->enable)) {
+    hal_data->freq = LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) * hal_data->pos_scale;
   } else {
     hal_data->freq = 0;
   }

--- a/src/devices/lcec_el2521.c
+++ b/src/devices/lcec_el2521.c
@@ -51,11 +51,11 @@ typedef struct {
   hal_bit_t *enable;     // pin for enable stepgen
   hal_float_t *vel_cmd;  // pin: velocity command (pos units/sec)
 
-  hal_float_t pos_scale;      // param: steps per position unit
-  hal_float_t freq;           // param: current frequency
-  hal_float_t maxvel;         // param: max velocity, (pos units/sec)
-  hal_float_t maxaccel_rise;  // param: max accel (pos units/sec^2)
-  hal_float_t maxaccel_fall;  // param: max accel (pos units/sec^2)
+  lcec_param_float_t pos_scale;      // param: steps per position unit
+  lcec_param_float_t freq;           // param: current frequency
+  lcec_param_float_t maxvel;         // param: max velocity, (pos units/sec)
+  lcec_param_float_t maxaccel_rise;  // param: max accel (pos units/sec^2)
+  lcec_param_float_t maxaccel_fall;  // param: max accel (pos units/sec^2)
 
   int last_operational;
   int16_t last_hw_count;  // last hw counter value
@@ -191,7 +191,7 @@ static int lcec_el2521_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // init parameters
-  hal_data->pos_scale = 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
 
   // init other fields
   hal_data->last_operational = 0;
@@ -227,16 +227,16 @@ static int lcec_el2521_init(int comp_id, lcec_slave_t *slave) {
 
 static void lcec_el2521_check_scale(lcec_el2521_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->pos_scale != hal_data->old_scale) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) != hal_data->old_scale) {
     // validate the new scale value
-    if ((hal_data->pos_scale < 1e-20) && (hal_data->pos_scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->pos_scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
     }
     // get ready to detect future scale changes
-    hal_data->old_scale = hal_data->pos_scale;
+    hal_data->old_scale = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
     // we will need the reciprocal
-    hal_data->scale_recip = 1.0 / hal_data->pos_scale;
+    hal_data->scale_recip = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
   }
 }
 
@@ -258,9 +258,9 @@ static void lcec_el2521_read(lcec_slave_t *slave, long period) {
   lcec_el2521_check_scale(hal_data);
 
   // calculate scaled limits
-  hal_data->maxvel = hal_data->max_freq * hal_data->scale_recip;
-  hal_data->maxaccel_rise = hal_data->max_ac_rise * hal_data->scale_recip;
-  hal_data->maxaccel_fall = hal_data->max_ac_fall * hal_data->scale_recip;
+  LCEC_PARAM_FLOAT_SET(hal_data->maxvel, hal_data->max_freq * hal_data->scale_recip);
+  LCEC_PARAM_FLOAT_SET(hal_data->maxaccel_rise, hal_data->max_ac_rise * hal_data->scale_recip);
+  LCEC_PARAM_FLOAT_SET(hal_data->maxaccel_fall, hal_data->max_ac_fall * hal_data->scale_recip);
 
   // read state word
   state = EC_READ_U16(&pd[hal_data->state_pdo_os]);
@@ -308,13 +308,13 @@ static void lcec_el2521_write(lcec_slave_t *slave, long period) {
 
   // update frequency
   if (LCEC_PIN_BIT_GET(hal_data->enable)) {
-    hal_data->freq = LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) * hal_data->pos_scale;
+    LCEC_PARAM_FLOAT_SET(hal_data->freq, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) * LCEC_PARAM_FLOAT_GET(hal_data->pos_scale));
   } else {
-    hal_data->freq = 0;
+    LCEC_PARAM_FLOAT_SET(hal_data->freq, 0);
   }
 
   // output frequency
-  freq_raw = hal_data->freq * hal_data->freqscale;
+  freq_raw = LCEC_PARAM_FLOAT_GET(hal_data->freq) * hal_data->freqscale;
   if (freq_raw > 0x7fff) {
     freq_raw = 0x7fff;
   }

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -265,8 +265,8 @@ static void lcec_el2522_read(lcec_slave_t *slave, long period) {
       diff = 0;
     }
 
-    *(channel->count) += diff;
-    *(channel->pos_fb) += ((double)diff) * channel->pos_scale_recip;
+    LCEC_PIN_S32_SET(channel->count, LCEC_PIN_S32_GET(channel->count) + diff);
+    LCEC_PIN_FLOAT_SET(channel->pos_fb, LCEC_PIN_FLOAT_GET(channel->pos_fb) + ((double)diff) * channel->pos_scale_recip);
   }
   hal_data->last_operational = true;
 }
@@ -287,14 +287,14 @@ static void lcec_el2522_write(lcec_slave_t *slave, long period) {
         channel->pos_scale = channel->last_pos_scale;
       } else {
         channel->last_pos_scale = channel->pos_scale;
-        channel->step_offset = *(channel->count) - *(channel->pos_fb) * channel->pos_scale;
+        channel->step_offset = LCEC_PIN_S32_GET(channel->count) - LCEC_PIN_FLOAT_GET(channel->pos_fb) * channel->pos_scale;
         channel->pos_scale_recip = 1.0 / channel->pos_scale;
       }
     }
 
     // explicit conversion casts used here to ensure correct handling for negative double values
-    const uint32_t target = (uint32_t)((int32_t)round(*(channel->pos_cmd) * channel->pos_scale + channel->step_offset));
+    const uint32_t target = (uint32_t)((int32_t)round(LCEC_PIN_FLOAT_GET(channel->pos_cmd) * channel->pos_scale + channel->step_offset));
     EC_WRITE_U32(&pd[channel->target_pdo_os], target);
-    EC_WRITE_BIT(&pd[channel->enable_pdo_os], channel->enable_pdo_bp, *(channel->enable));
+    EC_WRITE_BIT(&pd[channel->enable_pdo_os], channel->enable_pdo_bp, LCEC_PIN_BIT_GET(channel->enable));
   }
 }

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -75,7 +75,7 @@ typedef struct {
   hal_s32_t *count;      // pin: raw count output (steps), useful for commissioning
 
   // HAL parameters
-  hal_float_t pos_scale;  // param: pos scaling factor (steps/unit)
+  lcec_param_float_t pos_scale;  // param: pos scaling factor (steps/unit)
 
   // PDO offsets and bit positions
   unsigned int target_pdo_os;
@@ -232,7 +232,7 @@ static int lcec_el2522_init(int comp_id, lcec_slave_t *slave) {
       return err;
     }
 
-    channel->pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
+    LCEC_PARAM_FLOAT_SET(channel->pos_scale, LCEC_EL2522_POS_SCALE_DEFAULT);
     channel->pos_scale_recip = 1.0 / LCEC_EL2522_POS_SCALE_DEFAULT;
     channel->last_pos_scale = LCEC_EL2522_POS_SCALE_DEFAULT;
     channel->last_count = 0;
@@ -280,20 +280,20 @@ static void lcec_el2522_write(lcec_slave_t *slave, long period) {
     lcec_el2522_channel_t *channel = &hal_data->channels[i];
 
     // Check for scale change, and adjust offset to avoid position discontinuity
-    if (channel->pos_scale != channel->last_pos_scale) {
-      if ((channel->pos_scale < 1e-20) && (channel->pos_scale > -1e-20)) {
+    if (LCEC_PARAM_FLOAT_GET(channel->pos_scale) != channel->last_pos_scale) {
+      if ((LCEC_PARAM_FLOAT_GET(channel->pos_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(channel->pos_scale) > -1e-20)) {
         rtapi_print_msg(
             RTAPI_MSG_ERR, "Requested pos-scale for %s.%s.ch%i is too small, dropping\n", slave->master->name, slave->name, i+1);
-        channel->pos_scale = channel->last_pos_scale;
+        LCEC_PARAM_FLOAT_SET(channel->pos_scale, channel->last_pos_scale);
       } else {
-        channel->last_pos_scale = channel->pos_scale;
-        channel->step_offset = LCEC_PIN_S32_GET(channel->count) - LCEC_PIN_FLOAT_GET(channel->pos_fb) * channel->pos_scale;
-        channel->pos_scale_recip = 1.0 / channel->pos_scale;
+        channel->last_pos_scale = LCEC_PARAM_FLOAT_GET(channel->pos_scale);
+        channel->step_offset = LCEC_PIN_S32_GET(channel->count) - LCEC_PIN_FLOAT_GET(channel->pos_fb) * LCEC_PARAM_FLOAT_GET(channel->pos_scale);
+        channel->pos_scale_recip = 1.0 / LCEC_PARAM_FLOAT_GET(channel->pos_scale);
       }
     }
 
     // explicit conversion casts used here to ensure correct handling for negative double values
-    const uint32_t target = (uint32_t)((int32_t)round(LCEC_PIN_FLOAT_GET(channel->pos_cmd) * channel->pos_scale + channel->step_offset));
+    const uint32_t target = (uint32_t)((int32_t)round(LCEC_PIN_FLOAT_GET(channel->pos_cmd) * LCEC_PARAM_FLOAT_GET(channel->pos_scale) + channel->step_offset));
     EC_WRITE_U32(&pd[channel->target_pdo_os], target);
     EC_WRITE_BIT(&pd[channel->enable_pdo_os], channel->enable_pdo_bp, LCEC_PIN_BIT_GET(channel->enable));
   }

--- a/src/devices/lcec_el2522.c
+++ b/src/devices/lcec_el2522.c
@@ -25,7 +25,7 @@
 #include <stdbool.h>
 
 #include "../lcec.h"
-#include "hal.h"
+#include <hal.h>
 
 static int lcec_el2522_init(int comp_id, lcec_slave_t *slave);
 static void lcec_el2522_read(lcec_slave_t *slave, long period);

--- a/src/devices/lcec_el2564.c
+++ b/src/devices/lcec_el2564.c
@@ -35,7 +35,7 @@ typedef struct {
   hal_bit_t *warning;
   hal_bit_t *error;
 
-  hal_float_t scale;
+  lcec_param_float_t scale;
   hal_float_t offset;
   hal_float_t gamma;
   hal_float_t ramp_time;
@@ -119,7 +119,7 @@ static int lcec_el2564_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize parameters
-    chan->scale = 0.5;
+    LCEC_PARAM_FLOAT_SET(chan->scale, 0.5);
     chan->offset = 0.0;
     chan->gamma = 1.0;     
     chan->ramp_time = 0.0; 
@@ -224,7 +224,7 @@ if (hal_data->master_gain != hal_data->master_gain_prev) {
 
     // calculate PWM value
     if (LCEC_PIN_BIT_GET(chan->enable)) {
-      duty = LCEC_PIN_FLOAT_GET(chan->pwm) * chan->scale + chan->offset;
+      duty = LCEC_PIN_FLOAT_GET(chan->pwm) * LCEC_PARAM_FLOAT_GET(chan->scale) + chan->offset;
 
       // clamp to valid range
       if (duty < 0.0) duty = 0.0;

--- a/src/devices/lcec_el2564.c
+++ b/src/devices/lcec_el2564.c
@@ -190,8 +190,8 @@ static void lcec_el2564_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // read status bits
-    *(chan->warning) = EC_READ_BIT(&pd[chan->warning_pdo_os], chan->warning_pdo_bp);
-    *(chan->error) = EC_READ_BIT(&pd[chan->error_pdo_os], chan->error_pdo_bp);
+    LCEC_PIN_BIT_SET(chan->warning, EC_READ_BIT(&pd[chan->warning_pdo_os], chan->warning_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->error, EC_READ_BIT(&pd[chan->error_pdo_os], chan->error_pdo_bp));
   }
 }
 
@@ -223,8 +223,8 @@ if (hal_data->master_gain != hal_data->master_gain_prev) {
     chan = &hal_data->chans[i];
 
     // calculate PWM value
-    if (*(chan->enable)) {
-      duty = *(chan->pwm) * chan->scale + chan->offset;
+    if (LCEC_PIN_BIT_GET(chan->enable)) {
+      duty = LCEC_PIN_FLOAT_GET(chan->pwm) * chan->scale + chan->offset;
 
       // clamp to valid range
       if (duty < 0.0) duty = 0.0;

--- a/src/devices/lcec_el2564.c
+++ b/src/devices/lcec_el2564.c
@@ -36,9 +36,9 @@ typedef struct {
   hal_bit_t *error;
 
   lcec_param_float_t scale;
-  hal_float_t offset;
-  hal_float_t gamma;
-  hal_float_t ramp_time;
+  lcec_param_float_t offset;
+  lcec_param_float_t gamma;
+  lcec_param_float_t ramp_time;
 
   unsigned int pwm_pdo_os;
   unsigned int warning_pdo_os;
@@ -51,8 +51,8 @@ typedef struct {
 typedef struct {
   lcec_el2564_chan_t chans[LCEC_EL2564_CHANS];
 
-  hal_u32_t frequency;
-  hal_s32_t master_gain;
+  lcec_param_u32_t frequency;
+  lcec_param_s32_t master_gain;
   int32_t   master_gain_prev;
 } lcec_el2564_data_t;
 
@@ -120,9 +120,9 @@ static int lcec_el2564_init(int comp_id, lcec_slave_t *slave) {
 
     // initialize parameters
     LCEC_PARAM_FLOAT_SET(chan->scale, 0.5);
-    chan->offset = 0.0;
-    chan->gamma = 1.0;     
-    chan->ramp_time = 0.0; 
+    LCEC_PARAM_FLOAT_SET(chan->offset, 0.0);
+    LCEC_PARAM_FLOAT_SET(chan->gamma, 1.0);
+    LCEC_PARAM_FLOAT_SET(chan->ramp_time, 0.0);
   }
 
   // export global parameters
@@ -137,18 +137,18 @@ static int lcec_el2564_init(int comp_id, lcec_slave_t *slave) {
 
   // Read frequency (0xf819:11, uint32)
   if (lcec_read_sdo(slave, 0xf819, 0x11, sdo_buf, 4) == 0) {
-    hal_data->frequency = EC_READ_U32(sdo_buf);
+    LCEC_PARAM_U32_SET(hal_data->frequency, EC_READ_U32(sdo_buf));
   } else {
-    hal_data->frequency = 5000;    // Default: 5kHz
+    LCEC_PARAM_U32_SET(hal_data->frequency, 5000);    // Default: 5kHz
   }
 
   // Read master gain (0xf819:12, int16)
   if (lcec_read_sdo(slave, 0xf819, 0x12, sdo_buf, 2) == 0) {
-    hal_data->master_gain = EC_READ_S16(sdo_buf);
+    LCEC_PARAM_S32_SET(hal_data->master_gain, EC_READ_S16(sdo_buf));
   } else {
-    hal_data->master_gain = 32767; // Default: 100%
+    LCEC_PARAM_S32_SET(hal_data->master_gain, 32767); // Default: 100%
   }
-  hal_data->master_gain_prev = hal_data->master_gain;
+  hal_data->master_gain_prev = LCEC_PARAM_S32_GET(hal_data->master_gain);
   // Read per-channel parameters
   for (i = 0; i < LCEC_EL2564_CHANS; i++) {
     chan = &hal_data->chans[i];
@@ -160,13 +160,13 @@ static int lcec_el2564_init(int comp_id, lcec_slave_t *slave) {
     if (lcec_read_sdo(slave, sdo_index, 0x24, sdo_buf, 4) == 0) {
       float f;
       memcpy(&f, sdo_buf, 4);
-      chan->gamma = f;
+      LCEC_PARAM_FLOAT_SET(chan->gamma, f);
     }
     // Read ramp time (0x800x:25, float)
     if (lcec_read_sdo(slave, sdo_index, 0x25, sdo_buf, 4) == 0) {
       float f;
       memcpy(&f, sdo_buf, 4);
-      chan->ramp_time = f;
+      LCEC_PARAM_FLOAT_SET(chan->ramp_time, f);
     }
   }
 
@@ -206,8 +206,8 @@ static void lcec_el2564_write(lcec_slave_t *slave, long period) {
   uint8_t sdo_buf[4];
 
   // Check if master_gain changed and write via SDO
-if (hal_data->master_gain != hal_data->master_gain_prev) {
-    int16_t gain = hal_data->master_gain;
+if (LCEC_PARAM_S32_GET(hal_data->master_gain) != hal_data->master_gain_prev) {
+    int16_t gain = LCEC_PARAM_S32_GET(hal_data->master_gain);
     if (gain < 0) gain = 0;
     if (gain > 32767) gain = 32767;
 
@@ -215,7 +215,7 @@ if (hal_data->master_gain != hal_data->master_gain_prev) {
     if (lcec_write_sdo(slave, 0xf819, 0x12, sdo_buf, 2) == 0) {
         hal_data->master_gain_prev = gain;  // only remember on success
     }
-    hal_data->master_gain = gain;  // make the clamp visible on the HAL pin
+    LCEC_PARAM_S32_SET(hal_data->master_gain, gain);  // make the clamp visible on the HAL param
 }
 
   // write all channels
@@ -224,7 +224,7 @@ if (hal_data->master_gain != hal_data->master_gain_prev) {
 
     // calculate PWM value
     if (LCEC_PIN_BIT_GET(chan->enable)) {
-      duty = LCEC_PIN_FLOAT_GET(chan->pwm) * LCEC_PARAM_FLOAT_GET(chan->scale) + chan->offset;
+      duty = LCEC_PIN_FLOAT_GET(chan->pwm) * LCEC_PARAM_FLOAT_GET(chan->scale) + LCEC_PARAM_FLOAT_GET(chan->offset);
 
       // clamp to valid range
       if (duty < 0.0) duty = 0.0;

--- a/src/devices/lcec_el2904.c
+++ b/src/devices/lcec_el2904.c
@@ -147,18 +147,18 @@ static void lcec_el2904_read(lcec_slave_t *slave, long period) {
 
   copy_fsoe_data(slave, hal_data->fsoe_slave_cmd_os, hal_data->fsoe_master_cmd_os);
 
-  *(hal_data->fsoe_slave_cmd) = EC_READ_U8(&pd[hal_data->fsoe_slave_cmd_os]);
-  *(hal_data->fsoe_slave_crc) = EC_READ_U16(&pd[hal_data->fsoe_slave_crc_os]);
-  *(hal_data->fsoe_slave_connid) = EC_READ_U16(&pd[hal_data->fsoe_slave_connid_os]);
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_cmd, EC_READ_U8(&pd[hal_data->fsoe_slave_cmd_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_crc, EC_READ_U16(&pd[hal_data->fsoe_slave_crc_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_slave_connid, EC_READ_U16(&pd[hal_data->fsoe_slave_connid_os]));
 
-  *(hal_data->fsoe_master_cmd) = EC_READ_U8(&pd[hal_data->fsoe_master_cmd_os]);
-  *(hal_data->fsoe_master_crc) = EC_READ_U16(&pd[hal_data->fsoe_master_crc_os]);
-  *(hal_data->fsoe_master_connid) = EC_READ_U16(&pd[hal_data->fsoe_master_connid_os]);
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_cmd, EC_READ_U8(&pd[hal_data->fsoe_master_cmd_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_crc, EC_READ_U16(&pd[hal_data->fsoe_master_crc_os]));
+  LCEC_PIN_U32_SET(hal_data->fsoe_master_connid, EC_READ_U16(&pd[hal_data->fsoe_master_connid_os]));
 
-  *(hal_data->fsoe_out_0) = EC_READ_BIT(&pd[hal_data->fsoe_out_0_os], hal_data->fsoe_out_0_bp);
-  *(hal_data->fsoe_out_1) = EC_READ_BIT(&pd[hal_data->fsoe_out_1_os], hal_data->fsoe_out_1_bp);
-  *(hal_data->fsoe_out_2) = EC_READ_BIT(&pd[hal_data->fsoe_out_2_os], hal_data->fsoe_out_2_bp);
-  *(hal_data->fsoe_out_3) = EC_READ_BIT(&pd[hal_data->fsoe_out_3_os], hal_data->fsoe_out_3_bp);
+  LCEC_PIN_BIT_SET(hal_data->fsoe_out_0, EC_READ_BIT(&pd[hal_data->fsoe_out_0_os], hal_data->fsoe_out_0_bp));
+  LCEC_PIN_BIT_SET(hal_data->fsoe_out_1, EC_READ_BIT(&pd[hal_data->fsoe_out_1_os], hal_data->fsoe_out_1_bp));
+  LCEC_PIN_BIT_SET(hal_data->fsoe_out_2, EC_READ_BIT(&pd[hal_data->fsoe_out_2_os], hal_data->fsoe_out_2_bp));
+  LCEC_PIN_BIT_SET(hal_data->fsoe_out_3, EC_READ_BIT(&pd[hal_data->fsoe_out_3_os], hal_data->fsoe_out_3_bp));
 }
 
 static void lcec_el2904_write(lcec_slave_t *slave, long period) {
@@ -166,8 +166,8 @@ static void lcec_el2904_write(lcec_slave_t *slave, long period) {
   lcec_el2904_data_t *hal_data = (lcec_el2904_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
 
-  EC_WRITE_BIT(&pd[hal_data->out_0_os], hal_data->out_0_bp, *(hal_data->out_0));
-  EC_WRITE_BIT(&pd[hal_data->out_1_os], hal_data->out_1_bp, *(hal_data->out_1));
-  EC_WRITE_BIT(&pd[hal_data->out_2_os], hal_data->out_2_bp, *(hal_data->out_2));
-  EC_WRITE_BIT(&pd[hal_data->out_3_os], hal_data->out_3_bp, *(hal_data->out_3));
+  EC_WRITE_BIT(&pd[hal_data->out_0_os], hal_data->out_0_bp, LCEC_PIN_BIT_GET(hal_data->out_0));
+  EC_WRITE_BIT(&pd[hal_data->out_1_os], hal_data->out_1_bp, LCEC_PIN_BIT_GET(hal_data->out_1));
+  EC_WRITE_BIT(&pd[hal_data->out_2_os], hal_data->out_2_bp, LCEC_PIN_BIT_GET(hal_data->out_2));
+  EC_WRITE_BIT(&pd[hal_data->out_3_os], hal_data->out_3_bp, LCEC_PIN_BIT_GET(hal_data->out_3));
 }

--- a/src/devices/lcec_el31x2.c
+++ b/src/devices/lcec_el31x2.c
@@ -119,7 +119,7 @@ static int lcec_el31x2_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->scale, 1.0);
   }
 
   return 0;
@@ -145,13 +145,13 @@ static void lcec_el31x2_read(lcec_slave_t *slave, long period) {
 
     // update state
     state = pd[chan->state_pdo_os];
-    *(chan->error) = (state >> 6) & 0x01;
-    *(chan->overrange) = (state >> 1) & 0x01;
-    *(chan->underrange) = (state >> 0) & 0x01;
+    LCEC_PIN_BIT_SET(chan->error, (state >> 6) & 0x01);
+    LCEC_PIN_BIT_SET(chan->overrange, (state >> 1) & 0x01);
+    LCEC_PIN_BIT_SET(chan->underrange, (state >> 0) & 0x01);
 
     // update value
     value = EC_READ_S16(&pd[chan->val_pdo_os]);
-    *(chan->raw_val) = value;
-    *(chan->val) = *(chan->bias) + *(chan->scale) * (double)value * ((double)1 / (double)0x7fff);
+    LCEC_PIN_S32_SET(chan->raw_val, value);
+    LCEC_PIN_FLOAT_SET(chan->val, LCEC_PIN_FLOAT_GET(chan->bias) + LCEC_PIN_FLOAT_GET(chan->scale) * (double)value * ((double)1 / (double)0x7fff));
   }
 }

--- a/src/devices/lcec_el3255.c
+++ b/src/devices/lcec_el3255.c
@@ -179,7 +179,7 @@ static int lcec_el3255_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->scale, 1.0);
   }
 
   return 0;
@@ -203,14 +203,14 @@ static void lcec_el3255_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // update state
-    *(chan->overrange) = EC_READ_BIT(&pd[chan->ovr_pdo_os], chan->ovr_pdo_bp);
-    *(chan->underrange) = EC_READ_BIT(&pd[chan->udr_pdo_os], chan->udr_pdo_bp);
-    *(chan->error) = EC_READ_BIT(&pd[chan->error_pdo_os], chan->error_pdo_bp);
-    *(chan->sync_err) = EC_READ_BIT(&pd[chan->sync_err_pdo_os], chan->sync_err_pdo_bp);
+    LCEC_PIN_BIT_SET(chan->overrange, EC_READ_BIT(&pd[chan->ovr_pdo_os], chan->ovr_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->underrange, EC_READ_BIT(&pd[chan->udr_pdo_os], chan->udr_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->error, EC_READ_BIT(&pd[chan->error_pdo_os], chan->error_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->sync_err, EC_READ_BIT(&pd[chan->sync_err_pdo_os], chan->sync_err_pdo_bp));
 
     // update value
     value = EC_READ_S16(&pd[chan->val_pdo_os]);
-    *(chan->raw_val) = value;
-    *(chan->val) = *(chan->bias) + *(chan->scale) * (double)value * ((double)1 / (double)0x7fff);
+    LCEC_PIN_S32_SET(chan->raw_val, value);
+    LCEC_PIN_FLOAT_SET(chan->val, LCEC_PIN_FLOAT_GET(chan->bias) + LCEC_PIN_FLOAT_GET(chan->scale) * (double)value * ((double)1 / (double)0x7fff));
   }
 }

--- a/src/devices/lcec_el3403.c
+++ b/src/devices/lcec_el3403.c
@@ -224,8 +224,8 @@ static int lcec_el3403_init(int comp_id, lcec_slave_t *slave) {
   hal_data->last_operational = 0;
 
   // initialize pins
-  *(hal_data->sync_error_status) = 0;
-  *(hal_data->phase_sequence_error) = 0;
+  LCEC_PIN_BIT_SET(hal_data->sync_error_status, 0);
+  LCEC_PIN_BIT_SET(hal_data->phase_sequence_error, 0);
 
   // initialize channel L1/L2/L3
   for (i = 0; i < LCEC_EL3403_CHANS; i++) {
@@ -248,18 +248,18 @@ static int lcec_el3403_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->sync_error) = 0;
-    *(chan->txpdo_toggle) = 0;
-    *(chan->current) = 0.0;
-    *(chan->voltage) = 0.0;
-    *(chan->active_power) = 0.0;
-    *(chan->apparent_power) = 0.0;
-    *(chan->reactive_power) = 0.0;
-    *(chan->energy) = 0.0;
-    *(chan->cosphi) = 0.0;
-    *(chan->frequency) = 0.0;
-    *(chan->energy_negative) = 0.0;
-    *(chan->missing_zero_crossing) = 0;
+    LCEC_PIN_BIT_SET(chan->sync_error, 0);
+    LCEC_PIN_BIT_SET(chan->txpdo_toggle, 0);
+    LCEC_PIN_FLOAT_SET(chan->current, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->voltage, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->active_power, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->apparent_power, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->reactive_power, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->energy, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->cosphi, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->frequency, 0.0);
+    LCEC_PIN_FLOAT_SET(chan->energy_negative, 0.0);
+    LCEC_PIN_BIT_SET(chan->missing_zero_crossing, 0);
   }
   return 0;
 }
@@ -285,21 +285,21 @@ static void lcec_el3403_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // Update Status
-    *(chan->sync_error) = EC_READ_BIT(&pd[chan->sync_error_pdo_os], chan->sync_error_pdo_bp);
-    *(chan->txpdo_toggle) = EC_READ_BIT(&pd[chan->txpdo_toggle_pdo_os], chan->txpdo_toggle_pdo_bp);
-    *(chan->missing_zero_crossing) = EC_READ_BIT(&pd[chan->missing_zero_crossing_pdo_os], chan->missing_zero_crossing_pdo_bp);
+    LCEC_PIN_BIT_SET(chan->sync_error, EC_READ_BIT(&pd[chan->sync_error_pdo_os], chan->sync_error_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->txpdo_toggle, EC_READ_BIT(&pd[chan->txpdo_toggle_pdo_os], chan->txpdo_toggle_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->missing_zero_crossing, EC_READ_BIT(&pd[chan->missing_zero_crossing_pdo_os], chan->missing_zero_crossing_pdo_bp));
 
     // Update Current Channel
     current = EC_READ_S32(&pd[chan->current_pdo_os]);
-    *(chan->current) = (double)current * EL3403_FACTOR_CURRENT;
+    LCEC_PIN_FLOAT_SET(chan->current, (double)current * EL3403_FACTOR_CURRENT);
 
     // Update voltage Channel
     voltage = EC_READ_S32(&pd[chan->voltage_pdo_os]);
-    *(chan->voltage) = (double)voltage * EL3403_FACTOR_VOLTAGE;
+    LCEC_PIN_FLOAT_SET(chan->voltage, (double)voltage * EL3403_FACTOR_VOLTAGE);
 
     // Update Active Power Channel
     active_power = EC_READ_S32(&pd[chan->active_power_pdo_os]);
-    *(chan->active_power) = (double)active_power * EL3403_FACTOR_ACTIVE_POWER;
+    LCEC_PIN_FLOAT_SET(chan->active_power, (double)active_power * EL3403_FACTOR_ACTIVE_POWER);
 
     for (hal_data->index = 0; hal_data->index < 5; hal_data->index++) {
       EC_WRITE_U8(&pd[chan->index_pdo_os], hal_data->index);
@@ -308,35 +308,35 @@ static void lcec_el3403_read(lcec_slave_t *slave, long period) {
       switch (ovc) {
         case 0:
           apparent_power = EC_READ_S32(&pd[chan->variable_pdo_os]);
-          *(chan->apparent_power) = (double)apparent_power * EL3403_FACTOR_APPARENT_POWER;
+          LCEC_PIN_FLOAT_SET(chan->apparent_power, (double)apparent_power * EL3403_FACTOR_APPARENT_POWER);
           break;
         case 1:
           reactive_power = EC_READ_S32(&pd[chan->variable_pdo_os]);
-          *(chan->reactive_power) = (double)reactive_power * EL3403_FACTOR_REACTIVE_POWER;
+          LCEC_PIN_FLOAT_SET(chan->reactive_power, (double)reactive_power * EL3403_FACTOR_REACTIVE_POWER);
           break;
         case 2:
           energy = EC_READ_S32(&pd[chan->variable_pdo_os]);
-          *(chan->energy) = (double)energy * EL3403_FACTOR_ENERGY;
+          LCEC_PIN_FLOAT_SET(chan->energy, (double)energy * EL3403_FACTOR_ENERGY);
           break;
         case 3:
           cosphi = EC_READ_S32(&pd[chan->variable_pdo_os]);
-          *(chan->cosphi) = (double)cosphi * EL3403_FACTOR_COSPHI;
+          LCEC_PIN_FLOAT_SET(chan->cosphi, (double)cosphi * EL3403_FACTOR_COSPHI);
           break;
         case 4:
           frequency = EC_READ_S32(&pd[chan->variable_pdo_os]);
-          *(chan->frequency) = (double)frequency * EL3403_FACTOR_FREQUENCY;
+          LCEC_PIN_FLOAT_SET(chan->frequency, (double)frequency * EL3403_FACTOR_FREQUENCY);
           break;
         case 5:
           energy_negative = EC_READ_S32(&pd[chan->variable_pdo_os]);
-          *(chan->energy_negative) = (double)energy_negative * EL3403_FACTOR_ENERGY_NEGATIVE;
+          LCEC_PIN_FLOAT_SET(chan->energy_negative, (double)energy_negative * EL3403_FACTOR_ENERGY_NEGATIVE);
           break;
       }
     }
   }
 
   // Update Status
-  *(hal_data->sync_error_status) = EC_READ_BIT(&pd[hal_data->sync_error_status_pdo_os], hal_data->sync_error_status_pdo_bp);
-  *(hal_data->phase_sequence_error) = EC_READ_BIT(&pd[hal_data->phase_sequence_error_pdo_os], hal_data->phase_sequence_error_pdo_bp);
+  LCEC_PIN_BIT_SET(hal_data->sync_error_status, EC_READ_BIT(&pd[hal_data->sync_error_status_pdo_os], hal_data->sync_error_status_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->phase_sequence_error, EC_READ_BIT(&pd[hal_data->phase_sequence_error_pdo_os], hal_data->phase_sequence_error_pdo_bp));
 
   hal_data->last_operational = 1;
 }

--- a/src/devices/lcec_el3xxx.c
+++ b/src/devices/lcec_el3xxx.c
@@ -308,7 +308,7 @@ static int set_sensor_type(lcec_slave_t *slave, char *sensortype, lcec_class_ain
 
   if (setting != -1) {
     // See if this sensor type needs a non-default scale, otherwise default to 0.1.
-    *(chan->scale) = lcec_lookupdouble_i(temp_sensors_scale, sensortype, 0.1);
+    LCEC_PIN_FLOAT_SET(chan->scale, lcec_lookupdouble_i(temp_sensors_scale, sensortype, 0.1));
 
     // See if this sensor type is unsigned.  Otherwise signed.
     chan->is_unsigned = lcec_lookupint_i(temp_sensors_unsigned, sensortype, 0);
@@ -330,7 +330,7 @@ static int set_resolution(lcec_slave_t *slave, char *resolution_name, lcec_class
 
   if (setting != -1) {
     // See if this resolution type needs a non-default scale, otherwise leave it at 1.0.
-    *(chan->scale) = *(chan->scale) * lcec_lookupdouble_i(temp_resolutions_scale, resolution_name, 1.0);
+    LCEC_PIN_FLOAT_SET(chan->scale, LCEC_PIN_FLOAT_GET(chan->scale) * lcec_lookupdouble_i(temp_resolutions_scale, resolution_name, 1.0));
     if (lcec_write_sdo8(slave, idx, sidx, setting) != 0) {
       rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "failed to configure slave %s.%s sdo resolution!\n", slave->master->name, slave->name);
       return -1;

--- a/src/devices/lcec_el41x2.c
+++ b/src/devices/lcec_el41x2.c
@@ -114,12 +114,12 @@ static int lcec_el41x2_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // set default pin values
-    *(chan->scale) = 1.0;
-    *(chan->min_dc) = -1.0;
-    *(chan->max_dc) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->scale, 1.0);
+    LCEC_PIN_FLOAT_SET(chan->min_dc, -1.0);
+    LCEC_PIN_FLOAT_SET(chan->max_dc, 1.0);
 
     // init other fields
-    chan->old_scale = *(chan->scale) + 1.0;
+    chan->old_scale = LCEC_PIN_FLOAT_GET(chan->scale) + 1.0;
     chan->scale_recip = 1.0;
   }
 
@@ -140,53 +140,53 @@ static void lcec_el41x2_write(lcec_slave_t *slave, long period) {
 
     // validate duty cycle limits, both limits must be between
     // 0.0 and 1.0 (inclusive) and max must be greater then min
-    if (*(chan->max_dc) > 1.0) {
-      *(chan->max_dc) = 1.0;
+    if (LCEC_PIN_FLOAT_GET(chan->max_dc) > 1.0) {
+      LCEC_PIN_FLOAT_SET(chan->max_dc, 1.0);
     }
-    if (*(chan->min_dc) > *(chan->max_dc)) {
-      *(chan->min_dc) = *(chan->max_dc);
+    if (LCEC_PIN_FLOAT_GET(chan->min_dc) > LCEC_PIN_FLOAT_GET(chan->max_dc)) {
+      LCEC_PIN_FLOAT_SET(chan->min_dc, LCEC_PIN_FLOAT_GET(chan->max_dc));
     }
-    if (*(chan->min_dc) < -1.0) {
-      *(chan->min_dc) = -1.0;
+    if (LCEC_PIN_FLOAT_GET(chan->min_dc) < -1.0) {
+      LCEC_PIN_FLOAT_SET(chan->min_dc, -1.0);
     }
-    if (*(chan->max_dc) < *(chan->min_dc)) {
-      *(chan->max_dc) = *(chan->min_dc);
+    if (LCEC_PIN_FLOAT_GET(chan->max_dc) < LCEC_PIN_FLOAT_GET(chan->min_dc)) {
+      LCEC_PIN_FLOAT_SET(chan->max_dc, LCEC_PIN_FLOAT_GET(chan->min_dc));
     }
 
     // do scale calcs only when scale changes
-    if (*(chan->scale) != chan->old_scale) {
+    if (LCEC_PIN_FLOAT_GET(chan->scale) != chan->old_scale) {
       // validate the new scale value
-      if ((*(chan->scale) < 1e-20) && (*(chan->scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(chan->scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(chan->scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(chan->scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(chan->scale, 1.0);
       }
       // get ready to detect future scale changes
-      chan->old_scale = *(chan->scale);
+      chan->old_scale = LCEC_PIN_FLOAT_GET(chan->scale);
       // we will need the reciprocal
-      chan->scale_recip = 1.0 / *(chan->scale);
+      chan->scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(chan->scale);
     }
 
     // get command
-    tmpval = *(chan->value);
-    if (*(chan->absmode) && (tmpval < 0)) {
+    tmpval = LCEC_PIN_FLOAT_GET(chan->value);
+    if (LCEC_PIN_BIT_GET(chan->absmode) && (tmpval < 0)) {
       tmpval = -tmpval;
     }
 
     // convert value command to duty cycle
-    tmpdc = tmpval * chan->scale_recip + *(chan->offset);
-    if (tmpdc < *(chan->min_dc)) {
-      tmpdc = *(chan->min_dc);
+    tmpdc = tmpval * chan->scale_recip + LCEC_PIN_FLOAT_GET(chan->offset);
+    if (tmpdc < LCEC_PIN_FLOAT_GET(chan->min_dc)) {
+      tmpdc = LCEC_PIN_FLOAT_GET(chan->min_dc);
     }
-    if (tmpdc > *(chan->max_dc)) {
-      tmpdc = *(chan->max_dc);
+    if (tmpdc > LCEC_PIN_FLOAT_GET(chan->max_dc)) {
+      tmpdc = LCEC_PIN_FLOAT_GET(chan->max_dc);
     }
 
     // set output values
-    if (*(chan->enable) == 0) {
+    if (LCEC_PIN_BIT_GET(chan->enable) == 0) {
       raw_val = 0;
-      *(chan->pos) = 0;
-      *(chan->neg) = 0;
-      *(chan->curr_dc) = 0;
+      LCEC_PIN_BIT_SET(chan->pos, 0);
+      LCEC_PIN_BIT_SET(chan->neg, 0);
+      LCEC_PIN_FLOAT_SET(chan->curr_dc, 0);
     } else {
       raw_val = (double)0x7fff * tmpdc;
       if (raw_val > (double)0x7fff) {
@@ -195,13 +195,13 @@ static void lcec_el41x2_write(lcec_slave_t *slave, long period) {
       if (raw_val < (double)-0x7fff) {
         raw_val = (double)-0x7fff;
       }
-      *(chan->pos) = (*(chan->value) > 0);
-      *(chan->neg) = (*(chan->value) < 0);
-      *(chan->curr_dc) = tmpdc;
+      LCEC_PIN_BIT_SET(chan->pos, (LCEC_PIN_FLOAT_GET(chan->value) > 0));
+      LCEC_PIN_BIT_SET(chan->neg, (LCEC_PIN_FLOAT_GET(chan->value) < 0));
+      LCEC_PIN_FLOAT_SET(chan->curr_dc, tmpdc);
     }
 
     // update value
     EC_WRITE_S16(&pd[chan->val_pdo_os], (int16_t)raw_val);
-    *(chan->raw_val) = (int32_t)raw_val;
+    LCEC_PIN_S32_SET(chan->raw_val, (int32_t)raw_val);
   }
 }

--- a/src/devices/lcec_el5002.c
+++ b/src/devices/lcec_el5002.c
@@ -266,12 +266,12 @@ static int lcec_el5002_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->pos_scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
 
     // initialize variables
     chan->do_init = 1;
     chan->last_count = 0;
-    chan->old_scale = *(chan->pos_scale) + 1.0;
+    chan->old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale) + 1.0;
     chan->scale = 1.0;
   }
 
@@ -297,25 +297,25 @@ static void lcec_el5002_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // check for change in scale value
-    if (*(chan->pos_scale) != chan->old_scale) {
+    if (LCEC_PIN_FLOAT_GET(chan->pos_scale) != chan->old_scale) {
       // scale value has changed, test and update it
-      if ((*(chan->pos_scale) < 1e-20) && (*(chan->pos_scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(chan->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(chan->pos_scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(chan->pos_scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
       }
       // save new scale to detect future changes
-      chan->old_scale = *(chan->pos_scale);
+      chan->old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale);
       // we actually want the reciprocal
-      chan->scale = 1.0 / *(chan->pos_scale);
+      chan->scale = 1.0 / LCEC_PIN_FLOAT_GET(chan->pos_scale);
     }
 
     // get bit states
-    *(chan->err_data) = EC_READ_BIT(&pd[chan->err_data_os], chan->err_data_bp);
-    *(chan->err_frame) = EC_READ_BIT(&pd[chan->err_frame_os], chan->err_frame_bp);
-    *(chan->err_power) = EC_READ_BIT(&pd[chan->err_power_os], chan->err_power_bp);
-    *(chan->err_sync) = EC_READ_BIT(&pd[chan->err_sync_os], chan->err_sync_bp);
-    *(chan->tx_state) = EC_READ_BIT(&pd[chan->tx_state_os], chan->tx_state_bp);
-    *(chan->tx_toggle) = EC_READ_BIT(&pd[chan->tx_toggle_os], chan->tx_toggle_bp);
+    LCEC_PIN_BIT_SET(chan->err_data, EC_READ_BIT(&pd[chan->err_data_os], chan->err_data_bp));
+    LCEC_PIN_BIT_SET(chan->err_frame, EC_READ_BIT(&pd[chan->err_frame_os], chan->err_frame_bp));
+    LCEC_PIN_BIT_SET(chan->err_power, EC_READ_BIT(&pd[chan->err_power_os], chan->err_power_bp));
+    LCEC_PIN_BIT_SET(chan->err_sync, EC_READ_BIT(&pd[chan->err_sync_os], chan->err_sync_bp));
+    LCEC_PIN_BIT_SET(chan->tx_state, EC_READ_BIT(&pd[chan->tx_state_os], chan->tx_state_bp));
+    LCEC_PIN_BIT_SET(chan->tx_toggle, EC_READ_BIT(&pd[chan->tx_toggle_os], chan->tx_toggle_bp));
 
     // read raw values
     raw_count = EC_READ_S32(&pd[chan->count_pdo_os]);
@@ -326,25 +326,25 @@ static void lcec_el5002_read(lcec_slave_t *slave, long period) {
     }
 
     // update raw values
-    *(chan->raw_count) = raw_count;
+    LCEC_PIN_S32_SET(chan->raw_count, raw_count);
 
     // handle initialization
-    if (chan->do_init || *(chan->reset)) {
+    if (chan->do_init || LCEC_PIN_BIT_GET(chan->reset)) {
       chan->do_init = 0;
       chan->last_count = raw_count;
-      *(chan->count) = 0;
+      LCEC_PIN_S32_SET(chan->count, 0);
     }
 
     // compute net counts
     raw_delta = raw_count - chan->last_count;
     chan->last_count = raw_count;
-    *(chan->count) += raw_delta;
+    LCEC_PIN_S32_SET(chan->count, LCEC_PIN_S32_GET(chan->count) + raw_delta);
 
     // scale count to make floating point position
-    if (*(chan->abs_mode)) {
-      *(chan->pos) = *(chan->raw_count) * chan->scale;
+    if (LCEC_PIN_BIT_GET(chan->abs_mode)) {
+      LCEC_PIN_FLOAT_SET(chan->pos, LCEC_PIN_S32_GET(chan->raw_count) * chan->scale);
     } else {
-      *(chan->pos) = *(chan->count) * chan->scale;
+      LCEC_PIN_FLOAT_SET(chan->pos, LCEC_PIN_S32_GET(chan->count) * chan->scale);
     }
   }
 

--- a/src/devices/lcec_el5032.c
+++ b/src/devices/lcec_el5032.c
@@ -39,9 +39,9 @@ typedef struct {
   hal_bit_t *ready;
   hal_bit_t *diag;
   hal_bit_t *tx_state;
-  hal_u32_t *cyc_cnt;
-  hal_u32_t *raw_count_lo;
-  hal_u32_t *raw_count_hi;
+  hal_s32_t *cyc_cnt;
+  hal_s32_t *raw_count_lo;
+  hal_s32_t *raw_count_hi;
   hal_s32_t *count;
   hal_float_t *pos;
   hal_float_t *pos_scale;
@@ -217,7 +217,7 @@ static void lcec_el5032_read(lcec_slave_t *slave, long period) {
     LCEC_PIN_BIT_SET(chan->tx_state, EC_READ_BIT(&pd[chan->tx_state_os], chan->tx_state_bp));
 
     // get cycle counter
-    LCEC_PIN_U32_SET(chan->cyc_cnt, (EC_READ_U8(&pd[chan->cyc_cnt_os]) >> chan->cyc_cnt_bp) & 0x03);
+    LCEC_PIN_S32_SET(chan->cyc_cnt, (EC_READ_U8(&pd[chan->cyc_cnt_os]) >> chan->cyc_cnt_bp) & 0x03);
 
     // read raw values
     raw_count = EC_READ_S64(&pd[chan->count_pdo_os]);
@@ -228,8 +228,8 @@ static void lcec_el5032_read(lcec_slave_t *slave, long period) {
     }
 
     // update raw values
-    LCEC_PIN_U32_SET(chan->raw_count_lo, raw_count);
-    LCEC_PIN_U32_SET(chan->raw_count_hi, raw_count >> 32);
+    LCEC_PIN_S32_SET(chan->raw_count_lo, (int32_t)raw_count);
+    LCEC_PIN_S32_SET(chan->raw_count_hi, (int32_t)(raw_count >> 32));
 
     // handle initialization
     if (chan->do_init || LCEC_PIN_BIT_GET(chan->reset)) {

--- a/src/devices/lcec_el5032.c
+++ b/src/devices/lcec_el5032.c
@@ -166,12 +166,12 @@ static int lcec_el5032_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->pos_scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
 
     // initialize variables
     chan->do_init = 1;
     chan->last_count = 0;
-    chan->old_scale = *(chan->pos_scale) + 1.0;
+    chan->old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale) + 1.0;
     chan->scale = 1.0;
   }
 
@@ -197,27 +197,27 @@ static void lcec_el5032_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // check for change in scale value
-    if (*(chan->pos_scale) != chan->old_scale) {
+    if (LCEC_PIN_FLOAT_GET(chan->pos_scale) != chan->old_scale) {
       // scale value has changed, test and update it
-      if ((*(chan->pos_scale) < 1e-20) && (*(chan->pos_scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(chan->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(chan->pos_scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(chan->pos_scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
       }
       // save new scale to detect future changes
-      chan->old_scale = *(chan->pos_scale);
+      chan->old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale);
       // we actually want the reciprocal
-      chan->scale = 1.0 / *(chan->pos_scale);
+      chan->scale = 1.0 / LCEC_PIN_FLOAT_GET(chan->pos_scale);
     }
 
     // get bit states
-    *(chan->warn) = EC_READ_BIT(&pd[chan->warn_os], chan->warn_bp);
-    *(chan->error) = EC_READ_BIT(&pd[chan->error_os], chan->error_bp);
-    *(chan->ready) = EC_READ_BIT(&pd[chan->ready_os], chan->ready_bp);
-    *(chan->diag) = EC_READ_BIT(&pd[chan->diag_os], chan->diag_bp);
-    *(chan->tx_state) = EC_READ_BIT(&pd[chan->tx_state_os], chan->tx_state_bp);
+    LCEC_PIN_BIT_SET(chan->warn, EC_READ_BIT(&pd[chan->warn_os], chan->warn_bp));
+    LCEC_PIN_BIT_SET(chan->error, EC_READ_BIT(&pd[chan->error_os], chan->error_bp));
+    LCEC_PIN_BIT_SET(chan->ready, EC_READ_BIT(&pd[chan->ready_os], chan->ready_bp));
+    LCEC_PIN_BIT_SET(chan->diag, EC_READ_BIT(&pd[chan->diag_os], chan->diag_bp));
+    LCEC_PIN_BIT_SET(chan->tx_state, EC_READ_BIT(&pd[chan->tx_state_os], chan->tx_state_bp));
 
     // get cycle counter
-    *(chan->cyc_cnt) = (EC_READ_U8(&pd[chan->cyc_cnt_os]) >> chan->cyc_cnt_bp) & 0x03;
+    LCEC_PIN_U32_SET(chan->cyc_cnt, (EC_READ_U8(&pd[chan->cyc_cnt_os]) >> chan->cyc_cnt_bp) & 0x03);
 
     // read raw values
     raw_count = EC_READ_S64(&pd[chan->count_pdo_os]);
@@ -228,26 +228,26 @@ static void lcec_el5032_read(lcec_slave_t *slave, long period) {
     }
 
     // update raw values
-    *(chan->raw_count_lo) = raw_count;
-    *(chan->raw_count_hi) = raw_count >> 32;
+    LCEC_PIN_U32_SET(chan->raw_count_lo, raw_count);
+    LCEC_PIN_U32_SET(chan->raw_count_hi, raw_count >> 32);
 
     // handle initialization
-    if (chan->do_init || *(chan->reset)) {
+    if (chan->do_init || LCEC_PIN_BIT_GET(chan->reset)) {
       chan->do_init = 0;
       chan->last_count = raw_count;
-      *(chan->count) = 0;
+      LCEC_PIN_S32_SET(chan->count, 0);
     }
 
     // compute net counts
     raw_delta = raw_count - chan->last_count;
     chan->last_count = raw_count;
-    *(chan->count) += raw_delta;
+    LCEC_PIN_S32_SET(chan->count, LCEC_PIN_S32_GET(chan->count) + raw_delta);
 
     // scale count to make floating point position
-    if (*(chan->abs_mode)) {
-      *(chan->pos) = raw_count * chan->scale;
+    if (LCEC_PIN_BIT_GET(chan->abs_mode)) {
+      LCEC_PIN_FLOAT_SET(chan->pos, raw_count * chan->scale);
     } else {
-      *(chan->pos) = *(chan->count) * chan->scale;
+      LCEC_PIN_FLOAT_SET(chan->pos, LCEC_PIN_S32_GET(chan->count) * chan->scale);
     }
   }
 

--- a/src/devices/lcec_el5101.c
+++ b/src/devices/lcec_el5101.c
@@ -290,7 +290,7 @@ static void lcec_el5101_read(lcec_slave_t *slave, long period) {
   LCEC_PIN_FLOAT_SET(hal_data->pos, LCEC_PIN_S32_GET(hal_data->count) * hal_data->scale);
 
   // scale period
-  LCEC_PIN_FLOAT_SET(hal_data->frequency, ((double)(LCEC_PIN_U32_GET(hal_data->raw_frequency))) * (*hal_data->frequency_scale));
+  LCEC_PIN_FLOAT_SET(hal_data->frequency, ((double)(LCEC_PIN_U32_GET(hal_data->raw_frequency))) * LCEC_PIN_FLOAT_GET(hal_data->frequency_scale));
   LCEC_PIN_FLOAT_SET(hal_data->period, ((double)(LCEC_PIN_U32_GET(hal_data->raw_period))) * LCEC_EL5101_PERIOD_SCALE);
 
   hal_data->last_operational = 1;

--- a/src/devices/lcec_el5101.c
+++ b/src/devices/lcec_el5101.c
@@ -182,17 +182,17 @@ static int lcec_el5101_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // initialize pins
-  *(hal_data->pos_scale) = 1.0;
+  LCEC_PIN_FLOAT_SET(hal_data->pos_scale, 1.0);
 
   // initialize variables
   hal_data->do_init = 1;
   hal_data->last_count = 0;
-  hal_data->old_scale = *(hal_data->pos_scale) + 1.0;
+  hal_data->old_scale = LCEC_PIN_FLOAT_GET(hal_data->pos_scale) + 1.0;
   hal_data->scale = 1.0;
 
   // This should really be 1e-2 (0.001), but this driver has had the wrong value here for years.  It produces incorrect results, but
   // presumably people are expecting that at this point?
-  *(hal_data->frequency_scale) = 5e-2;
+  LCEC_PIN_FLOAT_SET(hal_data->frequency_scale, 5e-2);
 
   return 0;
 }
@@ -213,25 +213,25 @@ static void lcec_el5101_read(lcec_slave_t *slave, long period) {
   }
 
   // check for change in scale value
-  if (*(hal_data->pos_scale) != hal_data->old_scale) {
+  if (LCEC_PIN_FLOAT_GET(hal_data->pos_scale) != hal_data->old_scale) {
     // scale value has changed, test and update it
-    if ((*(hal_data->pos_scale) < 1e-20) && (*(hal_data->pos_scale) > -1e-20)) {
+    if ((LCEC_PIN_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(hal_data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      *(hal_data->pos_scale) = 1.0;
+      LCEC_PIN_FLOAT_SET(hal_data->pos_scale, 1.0);
     }
     // save new scale to detect future changes
-    hal_data->old_scale = *(hal_data->pos_scale);
+    hal_data->old_scale = LCEC_PIN_FLOAT_GET(hal_data->pos_scale);
     // we actually want the reciprocal
-    hal_data->scale = 1.0 / *(hal_data->pos_scale);
+    hal_data->scale = 1.0 / LCEC_PIN_FLOAT_GET(hal_data->pos_scale);
   }
 
   // get bit states
   raw_status = EC_READ_U8(&pd[hal_data->status_pdo_os]);
-  *(hal_data->inext) = raw_status & LCEC_EL5101_STATUS_INPUT;
-  *(hal_data->overflow) = raw_status & LCEC_EL5101_STATUS_OVERFLOW;
-  *(hal_data->underflow) = raw_status & LCEC_EL5101_STATUS_UNDERFLOW;
-  *(hal_data->latch_ext_valid) = raw_status & LCEC_EL5101_STATUS_LAT_EXT_VAL;
-  *(hal_data->latch_c_valid) = raw_status & LCEC_EL5101_STATUS_LATC_VAL;
+  LCEC_PIN_BIT_SET(hal_data->inext, raw_status & LCEC_EL5101_STATUS_INPUT);
+  LCEC_PIN_BIT_SET(hal_data->overflow, raw_status & LCEC_EL5101_STATUS_OVERFLOW);
+  LCEC_PIN_BIT_SET(hal_data->underflow, raw_status & LCEC_EL5101_STATUS_UNDERFLOW);
+  LCEC_PIN_BIT_SET(hal_data->latch_ext_valid, raw_status & LCEC_EL5101_STATUS_LAT_EXT_VAL);
+  LCEC_PIN_BIT_SET(hal_data->latch_c_valid, raw_status & LCEC_EL5101_STATUS_LATC_VAL);
 
   // read raw values
   raw_count = EC_READ_S16(&pd[hal_data->value_pdo_os]);
@@ -248,50 +248,50 @@ static void lcec_el5101_read(lcec_slave_t *slave, long period) {
   // check for counter set done
   if (raw_status & LCEC_EL5101_STATUS_CNTSET_ACC) {
     hal_data->last_count = raw_count;
-    *(hal_data->set_raw_count) = 0;
+    LCEC_PIN_BIT_SET(hal_data->set_raw_count, 0);
   }
 
   // update raw values
-  if (!*(hal_data->set_raw_count)) {
-    *(hal_data->raw_count) = raw_count;
-    *(hal_data->raw_frequency) = raw_frequency;
-    *(hal_data->raw_period) = raw_period;
-    *(hal_data->raw_window) = raw_window;
+  if (!LCEC_PIN_BIT_GET(hal_data->set_raw_count)) {
+    LCEC_PIN_S32_SET(hal_data->raw_count, raw_count);
+    LCEC_PIN_U32_SET(hal_data->raw_frequency, raw_frequency);
+    LCEC_PIN_U32_SET(hal_data->raw_period, raw_period);
+    LCEC_PIN_U32_SET(hal_data->raw_window, raw_window);
   }
 
   // handle initialization
-  if (hal_data->do_init || *(hal_data->reset)) {
+  if (hal_data->do_init || LCEC_PIN_BIT_GET(hal_data->reset)) {
     hal_data->do_init = 0;
     hal_data->last_count = raw_count;
-    *(hal_data->count) = 0;
+    LCEC_PIN_S32_SET(hal_data->count, 0);
   }
 
   // handle index
-  if (*(hal_data->latch_ext_valid)) {
-    *(hal_data->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(hal_data->latch_ext_valid)) {
+    LCEC_PIN_S32_SET(hal_data->raw_latch, raw_latch);
     hal_data->last_count = raw_latch;
-    *(hal_data->count) = 0;
-    *(hal_data->ena_latch_ext_pos) = 0;
-    *(hal_data->ena_latch_ext_neg) = 0;
+    LCEC_PIN_S32_SET(hal_data->count, 0);
+    LCEC_PIN_BIT_SET(hal_data->ena_latch_ext_pos, 0);
+    LCEC_PIN_BIT_SET(hal_data->ena_latch_ext_neg, 0);
   }
-  if (*(hal_data->latch_c_valid)) {
-    *(hal_data->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(hal_data->latch_c_valid)) {
+    LCEC_PIN_S32_SET(hal_data->raw_latch, raw_latch);
     hal_data->last_count = raw_latch;
-    *(hal_data->count) = 0;
-    *(hal_data->ena_latch_c) = 0;
+    LCEC_PIN_S32_SET(hal_data->count, 0);
+    LCEC_PIN_BIT_SET(hal_data->ena_latch_c, 0);
   }
 
   // compute net counts
   raw_delta = raw_count - hal_data->last_count;
   hal_data->last_count = raw_count;
-  *(hal_data->count) += raw_delta;
+  LCEC_PIN_S32_SET(hal_data->count, LCEC_PIN_S32_GET(hal_data->count) + raw_delta);
 
   // scale count to make floating point position
-  *(hal_data->pos) = *(hal_data->count) * hal_data->scale;
+  LCEC_PIN_FLOAT_SET(hal_data->pos, LCEC_PIN_S32_GET(hal_data->count) * hal_data->scale);
 
   // scale period
-  *(hal_data->frequency) = ((double)(*(hal_data->raw_frequency))) * (*hal_data->frequency_scale);
-  *(hal_data->period) = ((double)(*(hal_data->raw_period))) * LCEC_EL5101_PERIOD_SCALE;
+  LCEC_PIN_FLOAT_SET(hal_data->frequency, ((double)(LCEC_PIN_U32_GET(hal_data->raw_frequency))) * (*hal_data->frequency_scale));
+  LCEC_PIN_FLOAT_SET(hal_data->period, ((double)(LCEC_PIN_U32_GET(hal_data->raw_period))) * LCEC_EL5101_PERIOD_SCALE);
 
   hal_data->last_operational = 1;
 }
@@ -304,20 +304,20 @@ static void lcec_el5101_write(lcec_slave_t *slave, long period) {
 
   // build control byte
   raw_ctrl = 0;
-  if (*(hal_data->ena_latch_ext_neg)) {
+  if (LCEC_PIN_BIT_GET(hal_data->ena_latch_ext_neg)) {
     raw_ctrl |= LCEC_EL5101_CTRL_EN_LATCH_EXTN;
   }
-  if (*(hal_data->set_raw_count)) {
+  if (LCEC_PIN_BIT_GET(hal_data->set_raw_count)) {
     raw_ctrl |= LCEC_EL5101_CTRL_CNT_SET;
   }
-  if (*(hal_data->ena_latch_ext_pos)) {
+  if (LCEC_PIN_BIT_GET(hal_data->ena_latch_ext_pos)) {
     raw_ctrl |= LCEC_EL5101_CTRL_EN_LATCH_EXTP;
   }
-  if (*(hal_data->ena_latch_c)) {
+  if (LCEC_PIN_BIT_GET(hal_data->ena_latch_c)) {
     raw_ctrl |= LCEC_EL5101_CTRL_EN_LATC;
   }
 
   // set output data
   EC_WRITE_U8(&pd[hal_data->control_pdo_os], raw_ctrl);
-  EC_WRITE_S16(&pd[hal_data->setval_pdo_os], *(hal_data->set_raw_count_val));
+  EC_WRITE_S16(&pd[hal_data->setval_pdo_os], LCEC_PIN_S32_GET(hal_data->set_raw_count_val));
 }

--- a/src/devices/lcec_el5102.c
+++ b/src/devices/lcec_el5102.c
@@ -194,12 +194,12 @@ static int lcec_el5102_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(data->pos_scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(data->pos_scale, 1.0);
 
     // initialize variables
     data->do_init = 1;
     data->last_count = 0;
-    data->old_scale = *(data->pos_scale) + 1.0;
+    data->old_scale = LCEC_PIN_FLOAT_GET(data->pos_scale) + 1.0;
     data->scale = 1.0;
   }
 
@@ -226,16 +226,16 @@ static void lcec_el5102_read_channel(lcec_slave_t *slave, long period, int chann
   }
 
   // check for change in scale value
-  if (*(data->pos_scale) != data->old_scale) {
+  if (LCEC_PIN_FLOAT_GET(data->pos_scale) != data->old_scale) {
     // scale value has changed, test and update it
-    if ((*(data->pos_scale) < 1e-20) && (*(data->pos_scale) > -1e-20)) {
+    if ((LCEC_PIN_FLOAT_GET(data->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      *(data->pos_scale) = 1.0;
+      LCEC_PIN_FLOAT_SET(data->pos_scale, 1.0);
     }
     // save new scale to detect future changes
-    data->old_scale = *(data->pos_scale);
+    data->old_scale = LCEC_PIN_FLOAT_GET(data->pos_scale);
     // we actually want the reciprocal
-    data->scale = 1.0 / *(data->pos_scale);
+    data->scale = 1.0 / LCEC_PIN_FLOAT_GET(data->pos_scale);
   }
 
   // read raw values
@@ -248,16 +248,16 @@ static void lcec_el5102_read_channel(lcec_slave_t *slave, long period, int chann
   // using 6 of them here (including "counter set done", below).
   // Someone should review which of the remaining status bits are
   // useful and add pins for them, and then delete the rest.
-  *(data->inext) = EC_READ_BIT(&pd[data->status_input_status_os], data->status_input_status_bp);
-  *(data->overflow) = EC_READ_BIT(&pd[data->status_counter_overflow_os], data->status_counter_overflow_bp);
-  *(data->underflow) = EC_READ_BIT(&pd[data->status_counter_underflow_os], data->status_counter_underflow_bp);
-  *(data->latch_ext_valid) = EC_READ_BIT(&pd[data->status_latch_extern_os], data->status_latch_extern_bp);
-  *(data->latch_c_valid) = EC_READ_BIT(&pd[data->status_latch_c_os], data->status_latch_c_bp);
+  LCEC_PIN_BIT_SET(data->inext, EC_READ_BIT(&pd[data->status_input_status_os], data->status_input_status_bp));
+  LCEC_PIN_BIT_SET(data->overflow, EC_READ_BIT(&pd[data->status_counter_overflow_os], data->status_counter_overflow_bp));
+  LCEC_PIN_BIT_SET(data->underflow, EC_READ_BIT(&pd[data->status_counter_underflow_os], data->status_counter_underflow_bp));
+  LCEC_PIN_BIT_SET(data->latch_ext_valid, EC_READ_BIT(&pd[data->status_latch_extern_os], data->status_latch_extern_bp));
+  LCEC_PIN_BIT_SET(data->latch_c_valid, EC_READ_BIT(&pd[data->status_latch_c_os], data->status_latch_c_bp));
 
   // check for counter set done
   if (EC_READ_BIT(&pd[data->status_set_counter_done_os], data->status_set_counter_done_bp)) {
     data->last_count = raw_count;
-    *(data->set_raw_count) = 0;
+    LCEC_PIN_BIT_SET(data->set_raw_count, 0);
   }
   // check for operational change of slave
   if (!data->last_operational) {
@@ -265,45 +265,45 @@ static void lcec_el5102_read_channel(lcec_slave_t *slave, long period, int chann
   }
 
   // update raw values
-  if (!*(data->set_raw_count)) {
-    *(data->raw_count) = raw_count;
-    //*(data->raw_frequency) = raw_frequency;
-    //*(data->raw_period) = raw_period;
+  if (!LCEC_PIN_BIT_GET(data->set_raw_count)) {
+    LCEC_PIN_S32_SET(data->raw_count, raw_count);
+    //LCEC_PIN_U32_SET(data->raw_frequency, raw_frequency);
+    //LCEC_PIN_U32_SET(data->raw_period, raw_period);
   }
 
   // handle initialization
-  if (data->do_init || *(data->reset)) {
+  if (data->do_init || LCEC_PIN_BIT_GET(data->reset)) {
     data->do_init = 0;
     data->last_count = raw_count;
-    *(data->count) = 0;
+    LCEC_PIN_S32_SET(data->count, 0);
   }
 
   // handle index
-  if (*(data->latch_ext_valid)) {
-    *(data->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(data->latch_ext_valid)) {
+    LCEC_PIN_S32_SET(data->raw_latch, raw_latch);
     data->last_count = raw_latch;
-    *(data->count) = 0;
-    *(data->ena_latch_ext_pos) = 0;
-    *(data->ena_latch_ext_neg) = 0;
+    LCEC_PIN_S32_SET(data->count, 0);
+    LCEC_PIN_BIT_SET(data->ena_latch_ext_pos, 0);
+    LCEC_PIN_BIT_SET(data->ena_latch_ext_neg, 0);
   }
-  if (*(data->latch_c_valid)) {
-    *(data->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(data->latch_c_valid)) {
+    LCEC_PIN_S32_SET(data->raw_latch, raw_latch);
     data->last_count = raw_latch;
-    *(data->count) = 0;
-    *(data->ena_latch_c) = 0;
+    LCEC_PIN_S32_SET(data->count, 0);
+    LCEC_PIN_BIT_SET(data->ena_latch_c, 0);
   }
 
   // compute net counts
   raw_delta = raw_count - data->last_count;
   data->last_count = raw_count;
-  *(data->count) += raw_delta;
+  LCEC_PIN_S32_SET(data->count, LCEC_PIN_S32_GET(data->count) + raw_delta);
 
   // scale count to make floating point position
-  *(data->pos) = *(data->count) * data->scale;
+  LCEC_PIN_FLOAT_SET(data->pos, LCEC_PIN_S32_GET(data->count) * data->scale);
 
   // scale period
-  //*(data->frequency) = ((double)(*(data->raw_frequency))) * LCEC_EL5102_FREQUENCY_SCALE;
-  //*(data->period) = ((double)(*(data->raw_period))) * LCEC_EL5102_PERIOD_SCALE;
+  //LCEC_PIN_FLOAT_SET(data->frequency, ((double)(LCEC_PIN_U32_GET(data->raw_frequency))) * LCEC_EL5102_FREQUENCY_SCALE);
+  //LCEC_PIN_FLOAT_SET(data->period, ((double)(LCEC_PIN_U32_GET(data->raw_period))) * LCEC_EL5102_PERIOD_SCALE);
 
   data->last_operational = 1;
 }
@@ -322,11 +322,11 @@ static void lcec_el5102_write_channel(lcec_slave_t *slave, long period, int chan
   // but we're only actually using 4 of them.  We should add the
   // remaining ones that are useful here (presumably also adding pins
   // for them), and then delete whatever is left.
-  EC_WRITE_BIT(&pd[data->control_set_counter_os], data->control_set_counter_bp, *(data->set_raw_count));
-  EC_WRITE_BIT(&pd[data->control_enable_latch_c_os], data->control_enable_latch_c_bp, *(data->ena_latch_c));
-  EC_WRITE_BIT(&pd[data->control_enable_latch_extern_pos_os], data->control_enable_latch_extern_pos_bp, *(data->ena_latch_ext_pos));
-  EC_WRITE_BIT(&pd[data->control_enable_latch_extern_neg_os], data->control_enable_latch_extern_neg_bp, *(data->ena_latch_ext_neg));
+  EC_WRITE_BIT(&pd[data->control_set_counter_os], data->control_set_counter_bp, LCEC_PIN_BIT_GET(data->set_raw_count));
+  EC_WRITE_BIT(&pd[data->control_enable_latch_c_os], data->control_enable_latch_c_bp, LCEC_PIN_BIT_GET(data->ena_latch_c));
+  EC_WRITE_BIT(&pd[data->control_enable_latch_extern_pos_os], data->control_enable_latch_extern_pos_bp, LCEC_PIN_BIT_GET(data->ena_latch_ext_pos));
+  EC_WRITE_BIT(&pd[data->control_enable_latch_extern_neg_os], data->control_enable_latch_extern_neg_bp, LCEC_PIN_BIT_GET(data->ena_latch_ext_neg));
 
   // set output data
-  EC_WRITE_S16(&pd[data->setval_pdo_os], *(data->set_raw_count_val));
+  EC_WRITE_S16(&pd[data->setval_pdo_os], LCEC_PIN_S32_GET(data->set_raw_count_val));
 }

--- a/src/devices/lcec_el5151.c
+++ b/src/devices/lcec_el5151.c
@@ -219,12 +219,12 @@ static int lcec_el5151_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // initialize pins
-  *(hal_data->pos_scale) = 1.0;
+  LCEC_PIN_FLOAT_SET(hal_data->pos_scale, 1.0);
 
   // initialize variables
   hal_data->do_init = 1;
   hal_data->last_count = 0;
-  hal_data->old_scale = *(hal_data->pos_scale) + 1.0;
+  hal_data->old_scale = LCEC_PIN_FLOAT_GET(hal_data->pos_scale) + 1.0;
   hal_data->scale = 1.0;
 
   return 0;
@@ -244,28 +244,28 @@ static void lcec_el5151_read(lcec_slave_t *slave, long period) {
   }
 
   // check for change in scale value
-  if (*(hal_data->pos_scale) != hal_data->old_scale) {
+  if (LCEC_PIN_FLOAT_GET(hal_data->pos_scale) != hal_data->old_scale) {
     // scale value has changed, test and update it
-    if ((*(hal_data->pos_scale) < 1e-20) && (*(hal_data->pos_scale) > -1e-20)) {
+    if ((LCEC_PIN_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(hal_data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      *(hal_data->pos_scale) = 1.0;
+      LCEC_PIN_FLOAT_SET(hal_data->pos_scale, 1.0);
     }
     // save new scale to detect future changes
-    hal_data->old_scale = *(hal_data->pos_scale);
+    hal_data->old_scale = LCEC_PIN_FLOAT_GET(hal_data->pos_scale);
     // we actually want the reciprocal
-    hal_data->scale = 1.0 / *(hal_data->pos_scale);
+    hal_data->scale = 1.0 / LCEC_PIN_FLOAT_GET(hal_data->pos_scale);
   }
 
   // get bit states
-  *(hal_data->ina) = EC_READ_BIT(&pd[hal_data->ina_pdo_os], hal_data->ina_pdo_bp);
-  *(hal_data->inb) = EC_READ_BIT(&pd[hal_data->inb_pdo_os], hal_data->inb_pdo_bp);
-  *(hal_data->inc) = EC_READ_BIT(&pd[hal_data->inc_pdo_os], hal_data->inc_pdo_bp);
-  *(hal_data->inext) = EC_READ_BIT(&pd[hal_data->inext_pdo_os], hal_data->inext_pdo_bp);
-  *(hal_data->expol_stall) = EC_READ_BIT(&pd[hal_data->expol_stall_pdo_os], hal_data->expol_stall_pdo_bp);
-  *(hal_data->sync_err) = EC_READ_BIT(&pd[hal_data->sync_err_pdo_os], hal_data->sync_err_pdo_bp);
-  *(hal_data->latch_c_valid) = EC_READ_BIT(&pd[hal_data->latch_c_valid_pdo_os], hal_data->latch_c_valid_pdo_bp);
-  *(hal_data->latch_ext_valid) = EC_READ_BIT(&pd[hal_data->latch_ext_valid_pdo_os], hal_data->latch_ext_valid_pdo_bp);
-  *(hal_data->tx_toggle) = EC_READ_BIT(&pd[hal_data->tx_toggle_pdo_os], hal_data->tx_toggle_pdo_bp);
+  LCEC_PIN_BIT_SET(hal_data->ina, EC_READ_BIT(&pd[hal_data->ina_pdo_os], hal_data->ina_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->inb, EC_READ_BIT(&pd[hal_data->inb_pdo_os], hal_data->inb_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->inc, EC_READ_BIT(&pd[hal_data->inc_pdo_os], hal_data->inc_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->inext, EC_READ_BIT(&pd[hal_data->inext_pdo_os], hal_data->inext_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->expol_stall, EC_READ_BIT(&pd[hal_data->expol_stall_pdo_os], hal_data->expol_stall_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->sync_err, EC_READ_BIT(&pd[hal_data->sync_err_pdo_os], hal_data->sync_err_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->latch_c_valid, EC_READ_BIT(&pd[hal_data->latch_c_valid_pdo_os], hal_data->latch_c_valid_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->latch_ext_valid, EC_READ_BIT(&pd[hal_data->latch_ext_valid_pdo_os], hal_data->latch_ext_valid_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->tx_toggle, EC_READ_BIT(&pd[hal_data->tx_toggle_pdo_os], hal_data->tx_toggle_pdo_bp));
 
   // read raw values
   raw_count = EC_READ_S32(&pd[hal_data->count_pdo_os]);
@@ -280,47 +280,47 @@ static void lcec_el5151_read(lcec_slave_t *slave, long period) {
   // check for counter set done
   if (EC_READ_BIT(&pd[hal_data->set_count_done_pdo_os], hal_data->set_count_done_pdo_bp)) {
     hal_data->last_count = raw_count;
-    *(hal_data->set_raw_count) = 0;
+    LCEC_PIN_BIT_SET(hal_data->set_raw_count, 0);
   }
 
   // update raw values
-  if (!*(hal_data->set_raw_count)) {
-    *(hal_data->raw_count) = raw_count;
-    *(hal_data->raw_period) = raw_period;
+  if (!LCEC_PIN_BIT_GET(hal_data->set_raw_count)) {
+    LCEC_PIN_S32_SET(hal_data->raw_count, raw_count);
+    LCEC_PIN_U32_SET(hal_data->raw_period, raw_period);
   }
 
   // handle initialization
-  if (hal_data->do_init || *(hal_data->reset)) {
+  if (hal_data->do_init || LCEC_PIN_BIT_GET(hal_data->reset)) {
     hal_data->do_init = 0;
     hal_data->last_count = raw_count;
-    *(hal_data->count) = 0;
+    LCEC_PIN_S32_SET(hal_data->count, 0);
   }
 
   // handle index
-  if (*(hal_data->latch_ext_valid)) {
-    *(hal_data->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(hal_data->latch_ext_valid)) {
+    LCEC_PIN_S32_SET(hal_data->raw_latch, raw_latch);
     hal_data->last_count = raw_latch;
-    *(hal_data->count) = 0;
-    *(hal_data->ena_latch_ext_pos) = 0;
-    *(hal_data->ena_latch_ext_neg) = 0;
+    LCEC_PIN_S32_SET(hal_data->count, 0);
+    LCEC_PIN_BIT_SET(hal_data->ena_latch_ext_pos, 0);
+    LCEC_PIN_BIT_SET(hal_data->ena_latch_ext_neg, 0);
   }
-  if (*(hal_data->latch_c_valid)) {
-    *(hal_data->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(hal_data->latch_c_valid)) {
+    LCEC_PIN_S32_SET(hal_data->raw_latch, raw_latch);
     hal_data->last_count = raw_latch;
-    *(hal_data->count) = 0;
-    *(hal_data->ena_latch_c) = 0;
+    LCEC_PIN_S32_SET(hal_data->count, 0);
+    LCEC_PIN_BIT_SET(hal_data->ena_latch_c, 0);
   }
 
   // compute net counts
   raw_delta = raw_count - hal_data->last_count;
   hal_data->last_count = raw_count;
-  *(hal_data->count) += raw_delta;
+  LCEC_PIN_S32_SET(hal_data->count, LCEC_PIN_S32_GET(hal_data->count) + raw_delta);
 
   // scale count to make floating point position
-  *(hal_data->pos) = *(hal_data->count) * hal_data->scale;
+  LCEC_PIN_FLOAT_SET(hal_data->pos, LCEC_PIN_S32_GET(hal_data->count) * hal_data->scale);
 
   // scale period
-  *(hal_data->period) = ((double)(*(hal_data->raw_period))) * LCEC_EL5151_PERIOD_SCALE;
+  LCEC_PIN_FLOAT_SET(hal_data->period, ((double)(LCEC_PIN_U32_GET(hal_data->raw_period))) * LCEC_EL5151_PERIOD_SCALE);
 
   hal_data->last_operational = 1;
 }
@@ -331,9 +331,9 @@ static void lcec_el5151_write(lcec_slave_t *slave, long period) {
   uint8_t *pd = master->process_data;
 
   // set output data
-  EC_WRITE_BIT(&pd[hal_data->set_count_pdo_os], hal_data->set_count_pdo_bp, *(hal_data->set_raw_count));
-  EC_WRITE_BIT(&pd[hal_data->ena_latch_c_pdo_os], hal_data->ena_latch_c_pdo_bp, *(hal_data->ena_latch_c));
-  EC_WRITE_BIT(&pd[hal_data->ena_latch_ext_pos_pdo_os], hal_data->ena_latch_ext_pos_pdo_bp, *(hal_data->ena_latch_ext_pos));
-  EC_WRITE_BIT(&pd[hal_data->ena_latch_ext_neg_pdo_os], hal_data->ena_latch_ext_neg_pdo_bp, *(hal_data->ena_latch_ext_neg));
-  EC_WRITE_S32(&pd[hal_data->set_count_val_pdo_os], *(hal_data->set_raw_count_val));
+  EC_WRITE_BIT(&pd[hal_data->set_count_pdo_os], hal_data->set_count_pdo_bp, LCEC_PIN_BIT_GET(hal_data->set_raw_count));
+  EC_WRITE_BIT(&pd[hal_data->ena_latch_c_pdo_os], hal_data->ena_latch_c_pdo_bp, LCEC_PIN_BIT_GET(hal_data->ena_latch_c));
+  EC_WRITE_BIT(&pd[hal_data->ena_latch_ext_pos_pdo_os], hal_data->ena_latch_ext_pos_pdo_bp, LCEC_PIN_BIT_GET(hal_data->ena_latch_ext_pos));
+  EC_WRITE_BIT(&pd[hal_data->ena_latch_ext_neg_pdo_os], hal_data->ena_latch_ext_neg_pdo_bp, LCEC_PIN_BIT_GET(hal_data->ena_latch_ext_neg));
+  EC_WRITE_S32(&pd[hal_data->set_count_val_pdo_os], LCEC_PIN_S32_GET(hal_data->set_raw_count_val));
 }

--- a/src/devices/lcec_el5152.c
+++ b/src/devices/lcec_el5152.c
@@ -204,13 +204,13 @@ static int lcec_el5152_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->pos_scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
 
     // initialize variables
     chan->do_init = 1;
     chan->last_count = 0;
     chan->last_index = 0;
-    chan->old_scale = *(chan->pos_scale) + 1.0;
+    chan->old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale) + 1.0;
     chan->scale = 1.0;
   }
 
@@ -237,23 +237,23 @@ static void lcec_el5152_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // check for change in scale value
-    if (*(chan->pos_scale) != chan->old_scale) {
+    if (LCEC_PIN_FLOAT_GET(chan->pos_scale) != chan->old_scale) {
       // scale value has changed, test and update it
-      if ((*(chan->pos_scale) < 1e-20) && (*(chan->pos_scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(chan->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(chan->pos_scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(chan->pos_scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
       }
       // save new scale to detect future changes
-      chan->old_scale = *(chan->pos_scale);
+      chan->old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale);
       // we actually want the reciprocal
-      chan->scale = 1.0 / *(chan->pos_scale);
+      chan->scale = 1.0 / LCEC_PIN_FLOAT_GET(chan->pos_scale);
     }
 
     // get bit states
-    *(chan->ina) = EC_READ_BIT(&pd[chan->ina_pdo_os], chan->ina_pdo_bp);
-    *(chan->inb) = EC_READ_BIT(&pd[chan->inb_pdo_os], chan->inb_pdo_bp);
-    *(chan->expol_stall) = EC_READ_BIT(&pd[chan->expol_stall_pdo_os], chan->expol_stall_pdo_bp);
-    *(chan->tx_toggle) = EC_READ_BIT(&pd[chan->tx_toggle_pdo_os], chan->tx_toggle_pdo_bp);
+    LCEC_PIN_BIT_SET(chan->ina, EC_READ_BIT(&pd[chan->ina_pdo_os], chan->ina_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->inb, EC_READ_BIT(&pd[chan->inb_pdo_os], chan->inb_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->expol_stall, EC_READ_BIT(&pd[chan->expol_stall_pdo_os], chan->expol_stall_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->tx_toggle, EC_READ_BIT(&pd[chan->tx_toggle_pdo_os], chan->tx_toggle_pdo_bp));
 
     // read raw values
     raw_count = EC_READ_S32(&pd[chan->count_pdo_os]);
@@ -267,49 +267,49 @@ static void lcec_el5152_read(lcec_slave_t *slave, long period) {
     // check for counter set done
     if (EC_READ_BIT(&pd[chan->set_count_done_pdo_os], chan->set_count_done_pdo_bp)) {
       chan->last_count = raw_count;
-      *(chan->set_raw_count) = 0;
+      LCEC_PIN_BIT_SET(chan->set_raw_count, 0);
     }
 
     // update raw values
-    if (!*(chan->set_raw_count)) {
-      *(chan->raw_count) = raw_count;
-      *(chan->raw_period) = raw_period;
+    if (!LCEC_PIN_BIT_GET(chan->set_raw_count)) {
+      LCEC_PIN_S32_SET(chan->raw_count, raw_count);
+      LCEC_PIN_U32_SET(chan->raw_period, raw_period);
     }
 
     // check for index edge
     idx_flag = 0;
     idx_count = 0;
-    if (*(chan->index) && !chan->last_index) {
+    if (LCEC_PIN_BIT_GET(chan->index) && !chan->last_index) {
       idx_count = raw_count;
       idx_flag = 1;
     }
-    chan->last_index = *(chan->index);
+    chan->last_index = LCEC_PIN_BIT_GET(chan->index);
 
     // handle initialization
-    if (chan->do_init || *(chan->reset)) {
+    if (chan->do_init || LCEC_PIN_BIT_GET(chan->reset)) {
       chan->do_init = 0;
       chan->last_count = raw_count;
-      *(chan->count) = 0;
+      LCEC_PIN_S32_SET(chan->count, 0);
       idx_flag = 0;
     }
 
     // handle index
-    if (idx_flag && *(chan->index_ena)) {
+    if (idx_flag && LCEC_PIN_BIT_GET(chan->index_ena)) {
       chan->last_count = idx_count;
-      *(chan->count) = 0;
-      *(chan->index_ena) = 0;
+      LCEC_PIN_S32_SET(chan->count, 0);
+      LCEC_PIN_BIT_SET(chan->index_ena, 0);
     }
 
     // compute net counts
     raw_delta = raw_count - chan->last_count;
     chan->last_count = raw_count;
-    *(chan->count) += raw_delta;
+    LCEC_PIN_S32_SET(chan->count, LCEC_PIN_S32_GET(chan->count) + raw_delta);
 
     // scale count to make floating point position
-    *(chan->pos) = *(chan->count) * chan->scale;
+    LCEC_PIN_FLOAT_SET(chan->pos, LCEC_PIN_S32_GET(chan->count) * chan->scale);
 
     // scale period
-    *(chan->period) = ((double)(*(chan->raw_period))) * LCEC_EL5152_PERIOD_SCALE;
+    LCEC_PIN_FLOAT_SET(chan->period, ((double)(LCEC_PIN_U32_GET(chan->raw_period))) * LCEC_EL5152_PERIOD_SCALE);
   }
 
   hal_data->last_operational = 1;
@@ -327,7 +327,7 @@ static void lcec_el5152_write(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // set output data
-    EC_WRITE_BIT(&pd[chan->set_count_pdo_os], chan->set_count_pdo_bp, *(chan->set_raw_count));
-    EC_WRITE_S32(&pd[chan->set_count_val_pdo_os], *(chan->set_raw_count_val));
+    EC_WRITE_BIT(&pd[chan->set_count_pdo_os], chan->set_count_pdo_bp, LCEC_PIN_BIT_GET(chan->set_raw_count));
+    EC_WRITE_S32(&pd[chan->set_count_val_pdo_os], LCEC_PIN_S32_GET(chan->set_raw_count_val));
   }
 }

--- a/src/devices/lcec_el6090.c
+++ b/src/devices/lcec_el6090.c
@@ -297,15 +297,15 @@ static int lcec_el6090_init(int comp_id, lcec_slave_t *slave) {
   hal_data->last_operational = 0;
 
   // initialize Pins
-  *(hal_data->button_up) = 0;
-  *(hal_data->button_down) = 0;
-  *(hal_data->button_left) = 0;
-  *(hal_data->button_right) = 0;
-  *(hal_data->button_enter) = 0;
-  *(hal_data->button_toggle) = 0;
+  LCEC_PIN_BIT_SET(hal_data->button_up, 0);
+  LCEC_PIN_BIT_SET(hal_data->button_down, 0);
+  LCEC_PIN_BIT_SET(hal_data->button_left, 0);
+  LCEC_PIN_BIT_SET(hal_data->button_right, 0);
+  LCEC_PIN_BIT_SET(hal_data->button_enter, 0);
+  LCEC_PIN_BIT_SET(hal_data->button_toggle, 0);
 
-  *(hal_data->value_1) = 0;
-  *(hal_data->value_2) = 0;
+  LCEC_PIN_U32_SET(hal_data->value_1, 0);
+  LCEC_PIN_U32_SET(hal_data->value_2, 0);
 
   // initialize Channel 1/2/3/4
   for (i = 0; i < LCEC_EL6090_CHANS; i++) {
@@ -330,10 +330,10 @@ static int lcec_el6090_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize Pins
-    *(chan->timer_start) = 0;
-    *(chan->timer_reset) = 0;
-    *(chan->counter_clock) = 0;
-    *(chan->counter_reset) = 0;
+    LCEC_PIN_BIT_SET(chan->timer_start, 0);
+    LCEC_PIN_BIT_SET(chan->timer_reset, 0);
+    LCEC_PIN_BIT_SET(chan->counter_clock, 0);
+    LCEC_PIN_BIT_SET(chan->counter_reset, 0);
   }
 
   return 0;
@@ -355,25 +355,25 @@ static void lcec_el6090_read(lcec_slave_t *slave, long period) {
   }
 
   // Read Keyboard
-  *(hal_data->button_up) = EC_READ_BIT(&pd[hal_data->button_up_pdo_os], hal_data->button_up_pdo_bp);
-  *(hal_data->button_down) = EC_READ_BIT(&pd[hal_data->button_down_pdo_os], hal_data->button_down_pdo_bp);
-  *(hal_data->button_left) = EC_READ_BIT(&pd[hal_data->button_left_pdo_os], hal_data->button_left_pdo_bp);
-  *(hal_data->button_right) = EC_READ_BIT(&pd[hal_data->button_right_pdo_os], hal_data->button_right_pdo_bp);
-  *(hal_data->button_enter) = EC_READ_BIT(&pd[hal_data->button_enter_pdo_os], hal_data->button_enter_pdo_bp);
-  *(hal_data->button_toggle) = EC_READ_BIT(&pd[hal_data->button_toggle_pdo_os], hal_data->button_toggle_pdo_bp);
+  LCEC_PIN_BIT_SET(hal_data->button_up, EC_READ_BIT(&pd[hal_data->button_up_pdo_os], hal_data->button_up_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->button_down, EC_READ_BIT(&pd[hal_data->button_down_pdo_os], hal_data->button_down_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->button_left, EC_READ_BIT(&pd[hal_data->button_left_pdo_os], hal_data->button_left_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->button_right, EC_READ_BIT(&pd[hal_data->button_right_pdo_os], hal_data->button_right_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->button_enter, EC_READ_BIT(&pd[hal_data->button_enter_pdo_os], hal_data->button_enter_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->button_toggle, EC_READ_BIT(&pd[hal_data->button_toggle_pdo_os], hal_data->button_toggle_pdo_bp));
 
   // Read Operating Hours Counter (second)
   operating_time = EC_READ_U32(&pd[hal_data->operating_time_pdo_os]);
-  *(hal_data->operating_time) = operating_time;
-  *(hal_data->operating_time_hour) = operating_time / EL6090_HOUR_SCALE;
+  LCEC_PIN_U32_SET(hal_data->operating_time, operating_time);
+  LCEC_PIN_U32_SET(hal_data->operating_time_hour, operating_time / EL6090_HOUR_SCALE);
 
   // Read Channel 1/2/3/4
   for (i = 0; i < LCEC_EL6090_CHANS; i++) {
     chan = &hal_data->chans[i];
 
     // Read Channel
-    *(chan->timer) = EC_READ_U32(&pd[chan->timer_channel_pdo_os]);
-    *(chan->counter) = EC_READ_U32(&pd[chan->counter_channel_pdo_os]);
+    LCEC_PIN_U32_SET(chan->timer, EC_READ_U32(&pd[chan->timer_channel_pdo_os]));
+    LCEC_PIN_U32_SET(chan->counter, EC_READ_U32(&pd[chan->counter_channel_pdo_os]));
   }
 
   hal_data->last_operational = 1;
@@ -388,16 +388,16 @@ static void lcec_el6090_write(lcec_slave_t *slave, long period) {
   int i;
 
   // Write Value LCD
-  EC_WRITE_U16(&pd[hal_data->value_row1_pdo_os], *(hal_data->value_1));
-  EC_WRITE_U16(&pd[hal_data->value_row2_pdo_os], *(hal_data->value_2));
+  EC_WRITE_U16(&pd[hal_data->value_row1_pdo_os], LCEC_PIN_U32_GET(hal_data->value_1));
+  EC_WRITE_U16(&pd[hal_data->value_row2_pdo_os], LCEC_PIN_U32_GET(hal_data->value_2));
 
   // Write Channel 1/2/3/4
   for (i = 0; i < LCEC_EL6090_CHANS; i++) {
     chan = &hal_data->chans[i];
 
-    EC_WRITE_BIT(&pd[chan->timer_start_channel_pdo_os], chan->timer_start_channel_pdo_bp, *(chan->timer_start));
-    EC_WRITE_BIT(&pd[chan->timer_reset_channel_pdo_os], chan->timer_reset_channel_pdo_bp, *(chan->timer_reset));
-    EC_WRITE_BIT(&pd[chan->counter_clock_channel_pdo_os], chan->counter_clock_channel_pdo_bp, *(chan->counter_clock));
-    EC_WRITE_BIT(&pd[chan->counter_reset_channel_pdo_os], chan->counter_reset_channel_pdo_bp, *(chan->counter_reset));
+    EC_WRITE_BIT(&pd[chan->timer_start_channel_pdo_os], chan->timer_start_channel_pdo_bp, LCEC_PIN_BIT_GET(chan->timer_start));
+    EC_WRITE_BIT(&pd[chan->timer_reset_channel_pdo_os], chan->timer_reset_channel_pdo_bp, LCEC_PIN_BIT_GET(chan->timer_reset));
+    EC_WRITE_BIT(&pd[chan->counter_clock_channel_pdo_os], chan->counter_clock_channel_pdo_bp, LCEC_PIN_BIT_GET(chan->counter_clock));
+    EC_WRITE_BIT(&pd[chan->counter_reset_channel_pdo_os], chan->counter_reset_channel_pdo_bp, LCEC_PIN_BIT_GET(chan->counter_reset));
   }
 }

--- a/src/devices/lcec_el6900.c
+++ b/src/devices/lcec_el6900.c
@@ -305,25 +305,25 @@ void lcec_el6900_read(lcec_slave_t *slave, long period) {
   lcec_slave_t *fsoe_slave;
   const LCEC_CONF_FSOE_T *fsoeConf;
 
-  *(hal_data->state) = EC_READ_U8(&pd[hal_data->state_os]) & 0x03;
-  *(hal_data->login_active) = EC_READ_BIT(&pd[hal_data->login_active_os], hal_data->login_active_bp);
-  *(hal_data->input_size_missmatch) = EC_READ_BIT(&pd[hal_data->input_size_missmatch_os], hal_data->input_size_missmatch_bp);
-  *(hal_data->output_size_missmatch) = EC_READ_BIT(&pd[hal_data->output_size_missmatch_os], hal_data->output_size_missmatch_bp);
+  LCEC_PIN_U32_SET(hal_data->state, EC_READ_U8(&pd[hal_data->state_os]) & 0x03);
+  LCEC_PIN_BIT_SET(hal_data->login_active, EC_READ_BIT(&pd[hal_data->login_active_os], hal_data->login_active_bp));
+  LCEC_PIN_BIT_SET(hal_data->input_size_missmatch, EC_READ_BIT(&pd[hal_data->input_size_missmatch_os], hal_data->input_size_missmatch_bp));
+  LCEC_PIN_BIT_SET(hal_data->output_size_missmatch, EC_READ_BIT(&pd[hal_data->output_size_missmatch_os], hal_data->output_size_missmatch_bp));
 
   for (i = 0, io = hal_data->std_outs; i < hal_data->std_outs_count; i++, io++) {
-    *(io->pin) = EC_READ_BIT(&pd[io->os], io->bp);
+    LCEC_PIN_BIT_SET(io->pin, EC_READ_BIT(&pd[io->os], io->bp));
   }
 
   for (i = 0, fsoe_data = hal_data->fsoe; i < hal_data->fsoe_count; i++, fsoe_data++) {
     fsoe_slave = fsoe_data->fsoe_slave;
     fsoeConf = fsoe_slave->fsoeConf;
-    *(fsoe_data->fsoe_master_cmd) = EC_READ_U8(&pd[fsoe_data->fsoe_master_cmd_os]);
-    *(fsoe_data->fsoe_master_connid) = EC_READ_U16(&pd[fsoe_data->fsoe_master_connid_os]);
-    *(fsoe_data->fsoe_slave_cmd) = EC_READ_U8(&pd[fsoe_data->fsoe_slave_cmd_os]);
-    *(fsoe_data->fsoe_slave_connid) = EC_READ_U16(&pd[fsoe_data->fsoe_slave_connid_os]);
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_master_cmd, EC_READ_U8(&pd[fsoe_data->fsoe_master_cmd_os]));
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_master_connid, EC_READ_U16(&pd[fsoe_data->fsoe_master_connid_os]));
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_slave_cmd, EC_READ_U8(&pd[fsoe_data->fsoe_slave_cmd_os]));
+    LCEC_PIN_U32_SET(fsoe_data->fsoe_slave_connid, EC_READ_U16(&pd[fsoe_data->fsoe_slave_connid_os]));
     for (crc_idx = 0, crc = fsoe_data->fsoe_crc; crc_idx < fsoeConf->data_channels; crc_idx++, crc++) {
-      *(crc->fsoe_master_crc) = EC_READ_U16(&pd[crc->fsoe_master_crc_os]);
-      *(crc->fsoe_slave_crc) = EC_READ_U16(&pd[crc->fsoe_slave_crc_os]);
+      LCEC_PIN_U32_SET(crc->fsoe_master_crc, EC_READ_U16(&pd[crc->fsoe_master_crc_os]));
+      LCEC_PIN_U32_SET(crc->fsoe_slave_crc, EC_READ_U16(&pd[crc->fsoe_slave_crc_os]));
     }
   }
 }
@@ -335,9 +335,9 @@ void lcec_el6900_write(lcec_slave_t *slave, long period) {
   lcec_el6900_fsoe_io_t *io;
   int i;
 
-  EC_WRITE_U16(&pd[hal_data->control_os], *(hal_data->control));
+  EC_WRITE_U16(&pd[hal_data->control_os], LCEC_PIN_U32_GET(hal_data->control));
 
   for (i = 0, io = hal_data->std_ins; i < hal_data->std_ins_count; i++, io++) {
-    EC_WRITE_BIT(&pd[io->os], io->bp, *(io->pin));
+    EC_WRITE_BIT(&pd[io->os], io->bp, LCEC_PIN_BIT_GET(io->pin));
   }
 }

--- a/src/devices/lcec_el7041.c
+++ b/src/devices/lcec_el7041.c
@@ -574,19 +574,19 @@ static int lcec_el7041_init(int comp_id, lcec_slave_t *s) {
   }
 
   // initialize pins
-  *(hd->pos_scale) = 1.0;
+  LCEC_PIN_FLOAT_SET(hd->pos_scale, 1.0);
 
-  *(hd->dcm_scale) = 1.0;
-  *(hd->dcm_min_dc) = -1.0;
-  *(hd->dcm_max_dc) = 1.0;
+  LCEC_PIN_FLOAT_SET(hd->dcm_scale, 1.0);
+  LCEC_PIN_FLOAT_SET(hd->dcm_min_dc, -1.0);
+  LCEC_PIN_FLOAT_SET(hd->dcm_max_dc, 1.0);
 
   // initialize variables
   hd->enc_do_init = 1;
   hd->enc_last_count = 0;
-  hd->enc_old_scale = *(hd->pos_scale) + 1.0;
+  hd->enc_old_scale = LCEC_PIN_FLOAT_GET(hd->pos_scale) + 1.0;
   hd->enc_scale_recip = 1.0;
 
-  hd->dcm_old_scale = *(hd->dcm_scale) + 1.0;
+  hd->dcm_old_scale = LCEC_PIN_FLOAT_GET(hd->dcm_scale) + 1.0;
   hd->dcm_scale_recip = 1.0;
 
   hd->internal_fault = 0;
@@ -615,44 +615,44 @@ static void lcec_el7041_read(lcec_slave_t *s, long period) {
   // check inputs
 
   // check for change in scale value
-  if (*(hd->pos_scale) != hd->enc_old_scale) {
+  if (LCEC_PIN_FLOAT_GET(hd->pos_scale) != hd->enc_old_scale) {
     // scale value has changed, test and update it
-    if ((*(hd->pos_scale) < 1e-20) && (*(hd->pos_scale) > -1e-20)) {
+    if ((LCEC_PIN_FLOAT_GET(hd->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(hd->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      *(hd->pos_scale) = 1.0;
+      LCEC_PIN_FLOAT_SET(hd->pos_scale, 1.0);
     }
     // save new scale to detect future changes
-    hd->enc_old_scale = *(hd->pos_scale);
+    hd->enc_old_scale = LCEC_PIN_FLOAT_GET(hd->pos_scale);
     // we actually want the reciprocal
-    hd->enc_scale_recip = 1.0 / *(hd->pos_scale);
+    hd->enc_scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(hd->pos_scale);
   }
 
   // get bit states
-  *(hd->ina) = EC_READ_BIT(&pd[hd->ina_pdo_os], hd->ina_pdo_bp);
-  *(hd->inb) = EC_READ_BIT(&pd[hd->inb_pdo_os], hd->inb_pdo_bp);
-  *(hd->inc) = EC_READ_BIT(&pd[hd->inc_pdo_os], hd->inc_pdo_bp);
-  *(hd->inext) = EC_READ_BIT(&pd[hd->inext_pdo_os], hd->inext_pdo_bp);
-  *(hd->sync_err) = EC_READ_BIT(&pd[hd->sync_err_pdo_os], hd->sync_err_pdo_bp);
-  *(hd->expol_stall) = EC_READ_BIT(&pd[hd->expol_stall_pdo_os], hd->expol_stall_pdo_bp);
-  *(hd->tx_toggle) = EC_READ_BIT(&pd[hd->tx_toggle_pdo_os], hd->tx_toggle_pdo_bp);
-  *(hd->count_overflow) = EC_READ_BIT(&pd[hd->count_overflow_pdo_os], hd->count_overflow_pdo_bp);
-  *(hd->count_underflow) = EC_READ_BIT(&pd[hd->count_underflow_pdo_os], hd->count_underflow_pdo_bp);
-  *(hd->latch_c_valid) = EC_READ_BIT(&pd[hd->latch_c_valid_pdo_os], hd->latch_c_valid_pdo_bp);
-  *(hd->latch_ext_valid) = EC_READ_BIT(&pd[hd->latch_ext_valid_pdo_os], hd->latch_ext_valid_pdo_bp);
+  LCEC_PIN_BIT_SET(hd->ina, EC_READ_BIT(&pd[hd->ina_pdo_os], hd->ina_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->inb, EC_READ_BIT(&pd[hd->inb_pdo_os], hd->inb_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->inc, EC_READ_BIT(&pd[hd->inc_pdo_os], hd->inc_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->inext, EC_READ_BIT(&pd[hd->inext_pdo_os], hd->inext_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->sync_err, EC_READ_BIT(&pd[hd->sync_err_pdo_os], hd->sync_err_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->expol_stall, EC_READ_BIT(&pd[hd->expol_stall_pdo_os], hd->expol_stall_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->tx_toggle, EC_READ_BIT(&pd[hd->tx_toggle_pdo_os], hd->tx_toggle_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->count_overflow, EC_READ_BIT(&pd[hd->count_overflow_pdo_os], hd->count_overflow_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->count_underflow, EC_READ_BIT(&pd[hd->count_underflow_pdo_os], hd->count_underflow_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->latch_c_valid, EC_READ_BIT(&pd[hd->latch_c_valid_pdo_os], hd->latch_c_valid_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->latch_ext_valid, EC_READ_BIT(&pd[hd->latch_ext_valid_pdo_os], hd->latch_ext_valid_pdo_bp));
 
-  *(hd->dcm_ready_to_enable) = EC_READ_BIT(&pd[hd->dcm_ready_to_enable_pdo_os], hd->dcm_ready_to_enable_pdo_bp);
-  *(hd->dcm_ready) = EC_READ_BIT(&pd[hd->dcm_ready_pdo_os], hd->dcm_ready_pdo_bp);
-  *(hd->dcm_warning) = EC_READ_BIT(&pd[hd->dcm_warning_pdo_os], hd->dcm_warning_pdo_bp);
-  *(hd->dcm_error) = EC_READ_BIT(&pd[hd->dcm_error_pdo_os], hd->dcm_error_pdo_bp);
-  *(hd->dcm_move_pos) = EC_READ_BIT(&pd[hd->dcm_move_pos_pdo_os], hd->dcm_move_pos_pdo_bp);
-  *(hd->dcm_move_neg) = EC_READ_BIT(&pd[hd->dcm_move_neg_pdo_os], hd->dcm_move_neg_pdo_bp);
-  *(hd->dcm_torque_reduced) = EC_READ_BIT(&pd[hd->dcm_torque_reduced_pdo_os], hd->dcm_torque_reduced_pdo_bp);
-  *(hd->dcm_din1) = EC_READ_BIT(&pd[hd->dcm_din1_pdo_os], hd->dcm_din1_pdo_bp);
-  *(hd->dcm_din2) = EC_READ_BIT(&pd[hd->dcm_din2_pdo_os], hd->dcm_din2_pdo_bp);
-  *(hd->dcm_sync_err) = EC_READ_BIT(&pd[hd->dcm_sync_err_pdo_os], hd->dcm_sync_err_pdo_bp);
-  *(hd->dcm_tx_toggle) = EC_READ_BIT(&pd[hd->dcm_tx_toggle_pdo_os], hd->dcm_tx_toggle_pdo_bp);
+  LCEC_PIN_BIT_SET(hd->dcm_ready_to_enable, EC_READ_BIT(&pd[hd->dcm_ready_to_enable_pdo_os], hd->dcm_ready_to_enable_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_ready, EC_READ_BIT(&pd[hd->dcm_ready_pdo_os], hd->dcm_ready_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_warning, EC_READ_BIT(&pd[hd->dcm_warning_pdo_os], hd->dcm_warning_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_error, EC_READ_BIT(&pd[hd->dcm_error_pdo_os], hd->dcm_error_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_move_pos, EC_READ_BIT(&pd[hd->dcm_move_pos_pdo_os], hd->dcm_move_pos_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_move_neg, EC_READ_BIT(&pd[hd->dcm_move_neg_pdo_os], hd->dcm_move_neg_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_torque_reduced, EC_READ_BIT(&pd[hd->dcm_torque_reduced_pdo_os], hd->dcm_torque_reduced_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_din1, EC_READ_BIT(&pd[hd->dcm_din1_pdo_os], hd->dcm_din1_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_din2, EC_READ_BIT(&pd[hd->dcm_din2_pdo_os], hd->dcm_din2_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_sync_err, EC_READ_BIT(&pd[hd->dcm_sync_err_pdo_os], hd->dcm_sync_err_pdo_bp));
+  LCEC_PIN_BIT_SET(hd->dcm_tx_toggle, EC_READ_BIT(&pd[hd->dcm_tx_toggle_pdo_os], hd->dcm_tx_toggle_pdo_bp));
 
-  hd->internal_fault = *(hd->dcm_error);
+  hd->internal_fault = LCEC_PIN_BIT_GET(hd->dcm_error);
 
   // read raw values
   raw_count = EC_READ_S16(&pd[hd->count_pdo_os]);
@@ -666,19 +666,19 @@ static void lcec_el7041_read(lcec_slave_t *s, long period) {
   // check for counter set done
   if (EC_READ_BIT(&pd[hd->set_count_done_pdo_os], hd->set_count_done_pdo_bp)) {
     hd->enc_last_count = raw_count;
-    *(hd->set_raw_count) = 0;
+    LCEC_PIN_BIT_SET(hd->set_raw_count, 0);
   }
 
   // update raw values
-  if (!*(hd->set_raw_count)) {
-    *(hd->raw_count) = raw_count;
+  if (!LCEC_PIN_BIT_GET(hd->set_raw_count)) {
+    LCEC_PIN_S32_SET(hd->raw_count, raw_count);
   }
 
   // handle initialization
-  if (hd->enc_do_init || *(hd->reset)) {
+  if (hd->enc_do_init || LCEC_PIN_BIT_GET(hd->reset)) {
     hd->enc_do_init = 0;
     hd->enc_last_count = raw_count;
-    *(hd->count) = 0;
+    LCEC_PIN_S32_SET(hd->count, 0);
   }
 
   // clear pending fault reset if no fault
@@ -697,27 +697,27 @@ static void lcec_el7041_read(lcec_slave_t *s, long period) {
         hd->fault_reset_retry--;
       }
     }
-    *(hd->fault) = 0;
+    LCEC_PIN_BIT_SET(hd->fault, 0);
   } else {
-    *(hd->fault) = hd->internal_fault;
+    LCEC_PIN_BIT_SET(hd->fault, hd->internal_fault);
   }
 
   // handle index
-  if (*(hd->latch_ext_valid)) {
-    *(hd->raw_latch) = raw_latch;
+  if (LCEC_PIN_BIT_GET(hd->latch_ext_valid)) {
+    LCEC_PIN_S32_SET(hd->raw_latch, raw_latch);
     hd->enc_last_count = raw_latch;
-    *(hd->count) = 0;
-    *(hd->ena_latch_ext_pos) = 0;
-    *(hd->ena_latch_ext_neg) = 0;
+    LCEC_PIN_S32_SET(hd->count, 0);
+    LCEC_PIN_BIT_SET(hd->ena_latch_ext_pos, 0);
+    LCEC_PIN_BIT_SET(hd->ena_latch_ext_neg, 0);
   }
 
   // compute net counts
   raw_delta = raw_count - hd->enc_last_count;
   hd->enc_last_count = raw_count;
-  *(hd->count) += raw_delta;
+  LCEC_PIN_S32_SET(hd->count, LCEC_PIN_S32_GET(hd->count) + raw_delta);
 
   // scale count to make floating point position
-  *(hd->pos) = *(hd->count) * hd->enc_scale_recip;
+  LCEC_PIN_FLOAT_SET(hd->pos, LCEC_PIN_S32_GET(hd->count) * hd->enc_scale_recip);
 
   hd->last_operational = 1;
 }
@@ -732,8 +732,8 @@ static void lcec_el7041_write(lcec_slave_t *s, long period) {
   // set outputs
 
   // check for enable edge
-  enable_on_edge = *(hd->dcm_enable) && !hd->last_dcm_enable;
-  hd->last_dcm_enable = *(hd->dcm_enable);
+  enable_on_edge = LCEC_PIN_BIT_GET(hd->dcm_enable) && !hd->last_dcm_enable;
+  hd->last_dcm_enable = LCEC_PIN_BIT_GET(hd->dcm_enable);
 
   // check for autoreset
   if (enable_on_edge && hd->internal_fault) {
@@ -744,51 +744,51 @@ static void lcec_el7041_write(lcec_slave_t *s, long period) {
 
   // validate duty cycle limits, both limits must be between
   // 0.0 and 1.0 (inclusive) and max must be greater then min
-  if (*(hd->dcm_max_dc) > 1.0) {
-    *(hd->dcm_max_dc) = 1.0;
+  if (LCEC_PIN_FLOAT_GET(hd->dcm_max_dc) > 1.0) {
+    LCEC_PIN_FLOAT_SET(hd->dcm_max_dc, 1.0);
   }
-  if (*(hd->dcm_min_dc) > *(hd->dcm_max_dc)) {
-    *(hd->dcm_min_dc) = *(hd->dcm_max_dc);
+  if (LCEC_PIN_FLOAT_GET(hd->dcm_min_dc) > LCEC_PIN_FLOAT_GET(hd->dcm_max_dc)) {
+    LCEC_PIN_FLOAT_SET(hd->dcm_min_dc, LCEC_PIN_FLOAT_GET(hd->dcm_max_dc));
   }
-  if (*(hd->dcm_min_dc) < -1.0) {
-    *(hd->dcm_min_dc) = -1.0;
+  if (LCEC_PIN_FLOAT_GET(hd->dcm_min_dc) < -1.0) {
+    LCEC_PIN_FLOAT_SET(hd->dcm_min_dc, -1.0);
   }
-  if (*(hd->dcm_max_dc) < *(hd->dcm_min_dc)) {
-    *(hd->dcm_max_dc) = *(hd->dcm_min_dc);
+  if (LCEC_PIN_FLOAT_GET(hd->dcm_max_dc) < LCEC_PIN_FLOAT_GET(hd->dcm_min_dc)) {
+    LCEC_PIN_FLOAT_SET(hd->dcm_max_dc, LCEC_PIN_FLOAT_GET(hd->dcm_min_dc));
   }
 
   // do scale calcs only when scale changes
-  if (*(hd->dcm_scale) != hd->dcm_old_scale) {
+  if (LCEC_PIN_FLOAT_GET(hd->dcm_scale) != hd->dcm_old_scale) {
     // validate the new scale value
-    if ((*(hd->dcm_scale) < 1e-20) && (*(hd->dcm_scale) > -1e-20)) {
+    if ((LCEC_PIN_FLOAT_GET(hd->dcm_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(hd->dcm_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      *(hd->dcm_scale) = 1.0;
+      LCEC_PIN_FLOAT_SET(hd->dcm_scale, 1.0);
     }
     // get ready to detect future scale changes
-    hd->dcm_old_scale = *(hd->dcm_scale);
+    hd->dcm_old_scale = LCEC_PIN_FLOAT_GET(hd->dcm_scale);
     // we will need the reciprocal
-    hd->dcm_scale_recip = 1.0 / *(hd->dcm_scale);
+    hd->dcm_scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(hd->dcm_scale);
   }
 
   // get command
-  tmpval = *(hd->dcm_value);
-  if (*(hd->dcm_absmode) && (tmpval < 0)) {
+  tmpval = LCEC_PIN_FLOAT_GET(hd->dcm_value);
+  if (LCEC_PIN_BIT_GET(hd->dcm_absmode) && (tmpval < 0)) {
     tmpval = -tmpval;
   }
 
   // convert value command to duty cycle
-  tmpdc = tmpval * hd->dcm_scale_recip + *(hd->dcm_offset);
-  if (tmpdc < *(hd->dcm_min_dc)) {
-    tmpdc = *(hd->dcm_min_dc);
+  tmpdc = tmpval * hd->dcm_scale_recip + LCEC_PIN_FLOAT_GET(hd->dcm_offset);
+  if (tmpdc < LCEC_PIN_FLOAT_GET(hd->dcm_min_dc)) {
+    tmpdc = LCEC_PIN_FLOAT_GET(hd->dcm_min_dc);
   }
-  if (tmpdc > *(hd->dcm_max_dc)) {
-    tmpdc = *(hd->dcm_max_dc);
+  if (tmpdc > LCEC_PIN_FLOAT_GET(hd->dcm_max_dc)) {
+    tmpdc = LCEC_PIN_FLOAT_GET(hd->dcm_max_dc);
   }
 
   // set output values
-  if (*(hd->dcm_enable) == 0) {
+  if (LCEC_PIN_BIT_GET(hd->dcm_enable) == 0) {
     raw_val = 0;
-    *(hd->dcm_curr_dc) = 0;
+    LCEC_PIN_FLOAT_SET(hd->dcm_curr_dc, 0);
   } else {
     raw_val = (double)0x7fff * tmpdc;
     if (raw_val > (double)0x7fff) {
@@ -797,37 +797,37 @@ static void lcec_el7041_write(lcec_slave_t *s, long period) {
     if (raw_val < (double)-0x7fff) {
       raw_val = (double)-0x7fff;
     }
-    *(hd->dcm_curr_dc) = tmpdc;
+    LCEC_PIN_FLOAT_SET(hd->dcm_curr_dc, tmpdc);
   }
 
   // update value
-  *(hd->dcm_raw_val) = (int32_t)raw_val;
+  LCEC_PIN_S32_SET(hd->dcm_raw_val, (int32_t)raw_val);
 
   // fault reset
-  if (*(hd->fault_reset)) {
-    *(hd->dcm_reset) = 1;
+  if (LCEC_PIN_BIT_GET(hd->fault_reset)) {
+    LCEC_PIN_BIT_SET(hd->dcm_reset, 1);
   }
 
   if (hd->fault_reset_retry > 0) {
     if (hd->fault_reset_state) {
-      *(hd->dcm_reset) = 1;
+      LCEC_PIN_BIT_SET(hd->dcm_reset, 1);
     }
   } else {
-    if (*(hd->dcm_enable)) {
-      *(hd->dcm_reset) = 0;
+    if (LCEC_PIN_BIT_GET(hd->dcm_enable)) {
+      LCEC_PIN_BIT_SET(hd->dcm_reset, 0);
     }
-    *(hd->fault_reset) = 0;
+    LCEC_PIN_BIT_SET(hd->fault_reset, 0);
   }
 
   // set output data
-  EC_WRITE_BIT(&pd[hd->set_count_pdo_os], hd->set_count_pdo_bp, *(hd->set_raw_count));
-  EC_WRITE_BIT(&pd[hd->ena_latch_c_pdo_os], hd->ena_latch_c_pdo_bp, *(hd->ena_latch_c));
-  EC_WRITE_BIT(&pd[hd->ena_latch_ext_pos_pdo_os], hd->ena_latch_ext_pos_pdo_bp, *(hd->ena_latch_ext_pos));
-  EC_WRITE_BIT(&pd[hd->ena_latch_ext_neg_pdo_os], hd->ena_latch_ext_neg_pdo_bp, *(hd->ena_latch_ext_neg));
-  EC_WRITE_S16(&pd[hd->set_count_val_pdo_os], *(hd->set_raw_count_val));
+  EC_WRITE_BIT(&pd[hd->set_count_pdo_os], hd->set_count_pdo_bp, LCEC_PIN_BIT_GET(hd->set_raw_count));
+  EC_WRITE_BIT(&pd[hd->ena_latch_c_pdo_os], hd->ena_latch_c_pdo_bp, LCEC_PIN_BIT_GET(hd->ena_latch_c));
+  EC_WRITE_BIT(&pd[hd->ena_latch_ext_pos_pdo_os], hd->ena_latch_ext_pos_pdo_bp, LCEC_PIN_BIT_GET(hd->ena_latch_ext_pos));
+  EC_WRITE_BIT(&pd[hd->ena_latch_ext_neg_pdo_os], hd->ena_latch_ext_neg_pdo_bp, LCEC_PIN_BIT_GET(hd->ena_latch_ext_neg));
+  EC_WRITE_S16(&pd[hd->set_count_val_pdo_os], LCEC_PIN_S32_GET(hd->set_raw_count_val));
 
-  EC_WRITE_BIT(&pd[hd->dcm_ena_pdo_os], hd->dcm_ena_pdo_bp, *(hd->dcm_enable));
-  EC_WRITE_BIT(&pd[hd->dcm_reset_pdo_os], hd->dcm_reset_pdo_bp, *(hd->dcm_reset));
-  EC_WRITE_BIT(&pd[hd->dcm_reduce_torque_pdo_os], hd->dcm_reduce_torque_pdo_bp, *(hd->dcm_reduce_torque));
+  EC_WRITE_BIT(&pd[hd->dcm_ena_pdo_os], hd->dcm_ena_pdo_bp, LCEC_PIN_BIT_GET(hd->dcm_enable));
+  EC_WRITE_BIT(&pd[hd->dcm_reset_pdo_os], hd->dcm_reset_pdo_bp, LCEC_PIN_BIT_GET(hd->dcm_reset));
+  EC_WRITE_BIT(&pd[hd->dcm_reduce_torque_pdo_os], hd->dcm_reduce_torque_pdo_bp, LCEC_PIN_BIT_GET(hd->dcm_reduce_torque));
   EC_WRITE_S16(&pd[hd->dcm_velo_pdo_os], (int16_t)raw_val);
 }

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -367,17 +367,17 @@ static void lcec_el70x1_read(lcec_slave_t *slave, long period) {
   lcec_el70x1_data_t *hal_data = (lcec_el70x1_data_t *)slave->hal_data;
   uint8_t *pd = master->process_data;
 
-  *(hal_data->stm_ready_to_enable) = EC_READ_BIT(&pd[hal_data->stm_ready_to_enable_pdo_os], hal_data->stm_ready_to_enable_pdo_bp);
-  *(hal_data->stm_ready) = EC_READ_BIT(&pd[hal_data->stm_ready_pdo_os], hal_data->stm_ready_pdo_bp);
-  *(hal_data->stm_warning) = EC_READ_BIT(&pd[hal_data->stm_warning_pdo_os], hal_data->stm_warning_pdo_bp);
-  *(hal_data->stm_error) = EC_READ_BIT(&pd[hal_data->stm_error_pdo_os], hal_data->stm_error_pdo_bp);
-  *(hal_data->stm_move_pos) = EC_READ_BIT(&pd[hal_data->stm_move_pos_pdo_os], hal_data->stm_move_pos_pdo_bp);
-  *(hal_data->stm_move_neg) = EC_READ_BIT(&pd[hal_data->stm_move_neg_pdo_os], hal_data->stm_move_neg_pdo_bp);
-  *(hal_data->stm_torque_reduced) = EC_READ_BIT(&pd[hal_data->stm_torque_reduced_pdo_os], hal_data->stm_torque_reduced_pdo_bp);
-  *(hal_data->stm_din1) = EC_READ_BIT(&pd[hal_data->stm_din1_pdo_os], hal_data->stm_din1_pdo_bp);
-  *(hal_data->stm_din2) = EC_READ_BIT(&pd[hal_data->stm_din2_pdo_os], hal_data->stm_din2_pdo_bp);
-  *(hal_data->stm_sync_err) = EC_READ_BIT(&pd[hal_data->stm_sync_err_pdo_os], hal_data->stm_sync_err_pdo_bp);
-  *(hal_data->stm_tx_toggle) = EC_READ_BIT(&pd[hal_data->stm_tx_toggle_pdo_os], hal_data->stm_tx_toggle_pdo_bp);
+  LCEC_PIN_BIT_SET(hal_data->stm_ready_to_enable, EC_READ_BIT(&pd[hal_data->stm_ready_to_enable_pdo_os], hal_data->stm_ready_to_enable_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_ready, EC_READ_BIT(&pd[hal_data->stm_ready_pdo_os], hal_data->stm_ready_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_warning, EC_READ_BIT(&pd[hal_data->stm_warning_pdo_os], hal_data->stm_warning_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_error, EC_READ_BIT(&pd[hal_data->stm_error_pdo_os], hal_data->stm_error_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_move_pos, EC_READ_BIT(&pd[hal_data->stm_move_pos_pdo_os], hal_data->stm_move_pos_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_move_neg, EC_READ_BIT(&pd[hal_data->stm_move_neg_pdo_os], hal_data->stm_move_neg_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_torque_reduced, EC_READ_BIT(&pd[hal_data->stm_torque_reduced_pdo_os], hal_data->stm_torque_reduced_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_din1, EC_READ_BIT(&pd[hal_data->stm_din1_pdo_os], hal_data->stm_din1_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_din2, EC_READ_BIT(&pd[hal_data->stm_din2_pdo_os], hal_data->stm_din2_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_sync_err, EC_READ_BIT(&pd[hal_data->stm_sync_err_pdo_os], hal_data->stm_sync_err_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->stm_tx_toggle, EC_READ_BIT(&pd[hal_data->stm_tx_toggle_pdo_os], hal_data->stm_tx_toggle_pdo_bp));
 }
 
 static void lcec_el70x1_write(lcec_slave_t *slave, long period) {
@@ -386,17 +386,17 @@ static void lcec_el70x1_write(lcec_slave_t *slave, long period) {
   uint8_t *pd = master->process_data;
   bool enabled, reduce_tourque;
 
-  *(hal_data->stm_pos_cmd_raw) = (int32_t)(*(hal_data->stm_pos_cmd) * hal_data->stm_pos_scale);
+  LCEC_PIN_S32_SET(hal_data->stm_pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->stm_pos_cmd) * hal_data->stm_pos_scale));
 
-  enabled = *(hal_data->stm_enable);
+  enabled = LCEC_PIN_BIT_GET(hal_data->stm_enable);
   if (!enabled) {
     hal_data->auto_reduce_tourque_timer = 0;
   }
   EC_WRITE_BIT(&pd[hal_data->stm_ena_pdo_os], hal_data->stm_ena_pdo_bp, enabled);
 
-  reduce_tourque = *(hal_data->stm_reduce_torque);
-  if (*(hal_data->stm_pos_cmd_raw) != hal_data->stm_pos_cmd_raw_last) {
-    hal_data->stm_pos_cmd_raw_last = *(hal_data->stm_pos_cmd_raw);
+  reduce_tourque = LCEC_PIN_BIT_GET(hal_data->stm_reduce_torque);
+  if (LCEC_PIN_S32_GET(hal_data->stm_pos_cmd_raw) != hal_data->stm_pos_cmd_raw_last) {
+    hal_data->stm_pos_cmd_raw_last = LCEC_PIN_S32_GET(hal_data->stm_pos_cmd_raw);
     hal_data->auto_reduce_tourque_timer = 0;
   }
   if (hal_data->auto_reduce_tourque_delay > 0.0) {
@@ -408,7 +408,7 @@ static void lcec_el70x1_write(lcec_slave_t *slave, long period) {
   }
   EC_WRITE_BIT(&pd[hal_data->stm_reduce_torque_pdo_os], hal_data->stm_reduce_torque_pdo_bp, reduce_tourque);
 
-  EC_WRITE_BIT(&pd[hal_data->stm_reset_pdo_os], hal_data->stm_reset_pdo_bp, *(hal_data->stm_reset));
+  EC_WRITE_BIT(&pd[hal_data->stm_reset_pdo_os], hal_data->stm_reset_pdo_bp, LCEC_PIN_BIT_GET(hal_data->stm_reset));
 
-  EC_WRITE_S32(&pd[hal_data->stm_pos_raw_pdo_os], *(hal_data->stm_pos_cmd_raw));
+  EC_WRITE_S32(&pd[hal_data->stm_pos_raw_pdo_os], LCEC_PIN_S32_GET(hal_data->stm_pos_cmd_raw));
 }

--- a/src/devices/lcec_el70x1.c
+++ b/src/devices/lcec_el70x1.c
@@ -46,12 +46,12 @@ static lcec_typelist_t types[] = {
 ADD_TYPES(types);
 
 typedef struct {
-  hal_bit_t auto_fault_reset;
+  lcec_param_bit_t auto_fault_reset;
 
-  hal_float_t stm_pos_scale;
+  lcec_param_float_t stm_pos_scale;
   hal_float_t *stm_pos_cmd;
 
-  hal_float_t auto_reduce_tourque_delay;
+  lcec_param_float_t auto_reduce_tourque_delay;
   long long auto_reduce_tourque_timer;
 
   hal_bit_t *stm_ready_to_enable;
@@ -353,9 +353,9 @@ static int lcec_el70x1_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // initialize variables
-  hal_data->stm_pos_scale = 1.0;
-  hal_data->auto_fault_reset = 1;
-  hal_data->auto_reduce_tourque_delay = 0.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->stm_pos_scale, 1.0);
+  LCEC_PARAM_BIT_SET(hal_data->auto_fault_reset, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->auto_reduce_tourque_delay, 0.0);
   hal_data->auto_reduce_tourque_timer = 0;
   hal_data->stm_pos_cmd_raw_last = 0;
 
@@ -386,7 +386,7 @@ static void lcec_el70x1_write(lcec_slave_t *slave, long period) {
   uint8_t *pd = master->process_data;
   bool enabled, reduce_tourque;
 
-  LCEC_PIN_S32_SET(hal_data->stm_pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->stm_pos_cmd) * hal_data->stm_pos_scale));
+  LCEC_PIN_S32_SET(hal_data->stm_pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->stm_pos_cmd) * LCEC_PARAM_FLOAT_GET(hal_data->stm_pos_scale)));
 
   enabled = LCEC_PIN_BIT_GET(hal_data->stm_enable);
   if (!enabled) {
@@ -399,8 +399,8 @@ static void lcec_el70x1_write(lcec_slave_t *slave, long period) {
     hal_data->stm_pos_cmd_raw_last = LCEC_PIN_S32_GET(hal_data->stm_pos_cmd_raw);
     hal_data->auto_reduce_tourque_timer = 0;
   }
-  if (hal_data->auto_reduce_tourque_delay > 0.0) {
-    if (hal_data->auto_reduce_tourque_timer < (long long)(hal_data->auto_reduce_tourque_delay * 1e9)) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->auto_reduce_tourque_delay) > 0.0) {
+    if (hal_data->auto_reduce_tourque_timer < (long long)(LCEC_PARAM_FLOAT_GET(hal_data->auto_reduce_tourque_delay) * 1e9)) {
       hal_data->auto_reduce_tourque_timer += period;
     } else {
       reduce_tourque = true;

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -340,9 +340,9 @@ static int lcec_el7201_9014_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // initialize extra variables
-  *(hal_data->input_0) = 0;
-  *(hal_data->input_1) = 0;
-  *(hal_data->input_sto) = 0;
+  LCEC_PIN_BIT_SET(hal_data->input_0, 0);
+  LCEC_PIN_BIT_SET(hal_data->input_1, 0);
+  LCEC_PIN_BIT_SET(hal_data->input_sto, 0);
 
   return 0;
 }
@@ -375,14 +375,14 @@ static void lcec_el7211_read(lcec_slave_t *slave, long period) {
 
   // wait for slave to be operational
   if (!slave->state.operational) {
-    *(hal_data->status_ready) = 0;
-    *(hal_data->status_switched_on) = 0;
-    *(hal_data->status_operation) = 0;
-    *(hal_data->status_fault) = 1;
-    *(hal_data->status_disabled) = 0;
-    *(hal_data->status_warning) = 0;
-    *(hal_data->status_limit_active) = 0;
-    *(hal_data->enabled) = 0;
+    LCEC_PIN_BIT_SET(hal_data->status_ready, 0);
+    LCEC_PIN_BIT_SET(hal_data->status_switched_on, 0);
+    LCEC_PIN_BIT_SET(hal_data->status_operation, 0);
+    LCEC_PIN_BIT_SET(hal_data->status_fault, 1);
+    LCEC_PIN_BIT_SET(hal_data->status_disabled, 0);
+    LCEC_PIN_BIT_SET(hal_data->status_warning, 0);
+    LCEC_PIN_BIT_SET(hal_data->status_limit_active, 0);
+    LCEC_PIN_BIT_SET(hal_data->enabled, 0);
     return;
   }
 
@@ -391,21 +391,21 @@ static void lcec_el7211_read(lcec_slave_t *slave, long period) {
 
   // read status word
   status = EC_READ_U16(&pd[hal_data->status_pdo_os]);
-  *(hal_data->status_ready) = (status >> 0) & 0x01;
-  *(hal_data->status_switched_on) = (status >> 1) & 0x01;
-  *(hal_data->status_operation) = (status >> 2) & 0x01;
-  *(hal_data->status_fault) = (status >> 3) & 0x01;
-  *(hal_data->status_disabled) = (status >> 6) & 0x01;
-  *(hal_data->status_warning) = (status >> 7) & 0x01;
-  *(hal_data->status_limit_active) = (status >> 11) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->status_ready, (status >> 0) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->status_switched_on, (status >> 1) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->status_operation, (status >> 2) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->status_fault, (status >> 3) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->status_disabled, (status >> 6) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->status_warning, (status >> 7) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->status_limit_active, (status >> 11) & 0x01);
 
-  *(hal_data->enabled) = *(hal_data->status_ready) && *(hal_data->status_switched_on) && *(hal_data->status_operation);
-  *(hal_data->fault) = 0;
-  if (*(hal_data->enable) && *(hal_data->status_fault)) {
+  LCEC_PIN_BIT_SET(hal_data->enabled, LCEC_PIN_BIT_GET(hal_data->status_ready) && LCEC_PIN_BIT_GET(hal_data->status_switched_on) && LCEC_PIN_BIT_GET(hal_data->status_operation));
+  LCEC_PIN_BIT_SET(hal_data->fault, 0);
+  if (LCEC_PIN_BIT_GET(hal_data->enable) && LCEC_PIN_BIT_GET(hal_data->status_fault)) {
     if (hal_data->fault_reset_timer > 0) {
       hal_data->fault_reset_timer -= period;
     } else {
-      *(hal_data->fault) = 1;
+      LCEC_PIN_BIT_SET(hal_data->fault, 1);
     }
   } else {
     hal_data->fault_reset_timer = FAULT_RESET_PERIOD_NS;
@@ -413,16 +413,16 @@ static void lcec_el7211_read(lcec_slave_t *slave, long period) {
 
   // read velocity
   vel_raw = EC_READ_S32(&pd[hal_data->vel_fb_pdo_os]);
-  *(hal_data->vel_fb_raw) = vel_raw;
+  LCEC_PIN_S32_SET(hal_data->vel_fb_raw, vel_raw);
   vel = ((double)vel_raw) * hal_data->vel_rcpt;
-  *(hal_data->vel_fb) = vel * hal_data->scale_rcpt;
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb, vel * hal_data->scale_rcpt);
   vel = vel * 60.0;
-  *(hal_data->vel_fb_rpm) = vel;
-  *(hal_data->vel_fb_rpm_abs) = fabs(vel);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm, vel);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(vel));
 
   // update at-speed
-  *(hal_data->at_speed) = *(hal_data->vel_fb) >= (*(hal_data->vel_cmd) - hal_data->at_speed_window) &&
-                          *(hal_data->vel_fb) <= (*(hal_data->vel_cmd) + hal_data->at_speed_window);
+  LCEC_PIN_BIT_SET(hal_data->at_speed, LCEC_PIN_FLOAT_GET(hal_data->vel_fb) >= (LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) - hal_data->at_speed_window) &&
+                          LCEC_PIN_FLOAT_GET(hal_data->vel_fb) <= (LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) + hal_data->at_speed_window));
 
   // update position feedback
   pos_cnt = EC_READ_U32(&pd[hal_data->pos_fb_pdo_os]);
@@ -439,11 +439,11 @@ static void lcec_el7201_9014_read(lcec_slave_t *slave, long period) {
 
   // read info1
   info1 = EC_READ_U16(&pd[hal_data->info1_pdo_os]);
-  *(hal_data->input_0) = (info1 >> 0) & 0x01;
-  *(hal_data->input_0_not) = !*(hal_data->input_0);
-  *(hal_data->input_1) = (info1 >> 1) & 0x01;
-  *(hal_data->input_1_not) = !*(hal_data->input_1);
-  *(hal_data->input_sto) = (info1 >> 8) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->input_0, (info1 >> 0) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->input_0_not, !LCEC_PIN_BIT_GET(hal_data->input_0));
+  LCEC_PIN_BIT_SET(hal_data->input_1, (info1 >> 1) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->input_1_not, !LCEC_PIN_BIT_GET(hal_data->input_1));
+  LCEC_PIN_BIT_SET(hal_data->input_sto, (info1 >> 8) & 0x01);
 }
 
 static inline double clamp(double v, double sub, double sup) {
@@ -463,21 +463,21 @@ static void lcec_el7211_write(lcec_slave_t *slave, long period) {
   lcec_el7211_check_scales(hal_data);
 
   velo_cmd = 0.0;
-  if (*(hal_data->enable)) {
-    velo_cmd = clamp(*(hal_data->vel_cmd), hal_data->min_vel, hal_data->max_vel);
+  if (LCEC_PIN_BIT_GET(hal_data->enable)) {
+    velo_cmd = clamp(LCEC_PIN_FLOAT_GET(hal_data->vel_cmd), hal_data->min_vel, hal_data->max_vel);
   }
   velo_maxdelta = hal_data->max_accel * (double)period * 1e-9;
-  *(hal_data->vel_cmd_out) = clamp(velo_cmd, *(hal_data->vel_cmd_out) - velo_maxdelta, *(hal_data->vel_cmd_out) + velo_maxdelta);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_cmd_out, clamp(velo_cmd, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd_out) - velo_maxdelta, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd_out) + velo_maxdelta));
 
   control = 0;
-  if (*(hal_data->enable) || *(hal_data->vel_cmd_out) != 0) {
-    if (*(hal_data->status_fault)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enable) || LCEC_PIN_FLOAT_GET(hal_data->vel_cmd_out) != 0) {
+    if (LCEC_PIN_BIT_GET(hal_data->status_fault)) {
       control = 0x80;
-    } else if (*(hal_data->status_disabled)) {
+    } else if (LCEC_PIN_BIT_GET(hal_data->status_disabled)) {
       control = 0x06;
-    } else if (*(hal_data->status_ready)) {
+    } else if (LCEC_PIN_BIT_GET(hal_data->status_ready)) {
       control = 0x07;
-      if (*(hal_data->status_switched_on)) {
+      if (LCEC_PIN_BIT_GET(hal_data->status_switched_on)) {
         control = 0x0f;
       }
     }
@@ -485,13 +485,13 @@ static void lcec_el7211_write(lcec_slave_t *slave, long period) {
   EC_WRITE_U16(&pd[hal_data->ctrl_pdo_os], control);
 
   // set velocity
-  velo_raw = *(hal_data->vel_cmd_out) * hal_data->vel_out_scale;
+  velo_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_cmd_out) * hal_data->vel_out_scale;
   if (velo_raw > (double)0x7fffffff) {
     velo_raw = (double)0x7fffffff;
   }
   if (velo_raw < (double)-0x7fffffff) {
     velo_raw = (double)-0x7fffffff;
   }
-  *(hal_data->vel_cmd_out_raw) = (int32_t)velo_raw;
-  EC_WRITE_S32(&pd[hal_data->vel_cmd_pdo_os], *(hal_data->vel_cmd_out_raw));
+  LCEC_PIN_S32_SET(hal_data->vel_cmd_out_raw, (int32_t)velo_raw);
+  EC_WRITE_S32(&pd[hal_data->vel_cmd_pdo_os], LCEC_PIN_S32_GET(hal_data->vel_cmd_out_raw));
 }

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -22,7 +22,7 @@
 #include "lcec_el7211.h"
 
 #include "../lcec.h"
-#include "hal.h"
+#include <hal.h>
 #include "lcec_class_enc.h"
 
 #define FAULT_RESET_PERIOD_NS 100000000

--- a/src/devices/lcec_el7211.c
+++ b/src/devices/lcec_el7211.c
@@ -69,15 +69,15 @@ typedef struct {
   hal_float_t *vel_cmd_out;
   hal_s32_t *vel_cmd_out_raw;
 
-  hal_float_t scale;
+  lcec_param_float_t scale;
 
-  hal_u32_t vel_resolution;
-  hal_u32_t pos_resolution;
+  lcec_param_u32_t vel_resolution;
+  lcec_param_u32_t pos_resolution;
 
-  hal_float_t min_vel;
-  hal_float_t max_vel;
-  hal_float_t max_accel;
-  hal_float_t at_speed_window;
+  lcec_param_float_t min_vel;
+  lcec_param_float_t max_vel;
+  lcec_param_float_t max_accel;
+  lcec_param_float_t at_speed_window;
 
   lcec_class_enc_data_t enc;
 
@@ -242,9 +242,9 @@ static int lcec_el7211_export_pins(lcec_master_t *master, lcec_slave_t *slave, l
   }
 
   // init parameters
-  hal_data->scale = 1.0;
-  hal_data->vel_resolution = sdo_vel_resolution;
-  hal_data->pos_resolution = sdo_pos_resolution;
+  LCEC_PARAM_FLOAT_SET(hal_data->scale, 1.0);
+  LCEC_PARAM_U32_SET(hal_data->vel_resolution, sdo_vel_resolution);
+  LCEC_PARAM_U32_SET(hal_data->pos_resolution, sdo_pos_resolution);
 
   // initialize variables
   if (sdo_vel_resolution > 0) {
@@ -254,13 +254,13 @@ static int lcec_el7211_export_pins(lcec_master_t *master, lcec_slave_t *slave, l
     hal_data->vel_scale = 0.0;
     hal_data->vel_rcpt = 0.0;
   }
-  hal_data->scale_old = hal_data->scale + 1.0;
+  hal_data->scale_old = LCEC_PARAM_FLOAT_GET(hal_data->scale) + 1.0;
   hal_data->scale_rcpt = 0.0;
   hal_data->vel_out_scale = 0.0;
   hal_data->fault_reset_timer = 0;
-  hal_data->min_vel = -1e20;
-  hal_data->max_vel = 1e20;
-  hal_data->max_accel = 1e20;
+  LCEC_PARAM_FLOAT_SET(hal_data->min_vel, -1e20);
+  LCEC_PARAM_FLOAT_SET(hal_data->max_vel, 1e20);
+  LCEC_PARAM_FLOAT_SET(hal_data->max_accel, 1e20);
 
   return 0;
 }
@@ -349,18 +349,18 @@ static int lcec_el7201_9014_init(int comp_id, lcec_slave_t *slave) {
 
 static void lcec_el7211_check_scales(lcec_el7211_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->scale != hal_data->scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->scale) != hal_data->scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->scale < 1e-20) && (hal_data->scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->scale, 1.0);
     }
     // save new scale to detect future changes
-    hal_data->scale_old = hal_data->scale;
+    hal_data->scale_old = LCEC_PARAM_FLOAT_GET(hal_data->scale);
     // we actually want the reciprocal
-    hal_data->scale_rcpt = 1.0 / hal_data->scale;
+    hal_data->scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->scale);
     // calculate velo output scale
-    hal_data->vel_out_scale = hal_data->vel_scale * hal_data->scale;
+    hal_data->vel_out_scale = hal_data->vel_scale * LCEC_PARAM_FLOAT_GET(hal_data->scale);
   }
 }
 
@@ -421,12 +421,12 @@ static void lcec_el7211_read(lcec_slave_t *slave, long period) {
   LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(vel));
 
   // update at-speed
-  LCEC_PIN_BIT_SET(hal_data->at_speed, LCEC_PIN_FLOAT_GET(hal_data->vel_fb) >= (LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) - hal_data->at_speed_window) &&
-                          LCEC_PIN_FLOAT_GET(hal_data->vel_fb) <= (LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) + hal_data->at_speed_window));
+  LCEC_PIN_BIT_SET(hal_data->at_speed, LCEC_PIN_FLOAT_GET(hal_data->vel_fb) >= (LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) - LCEC_PARAM_FLOAT_GET(hal_data->at_speed_window)) &&
+                          LCEC_PIN_FLOAT_GET(hal_data->vel_fb) <= (LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) + LCEC_PARAM_FLOAT_GET(hal_data->at_speed_window)));
 
   // update position feedback
   pos_cnt = EC_READ_U32(&pd[hal_data->pos_fb_pdo_os]);
-  class_enc_update(&hal_data->enc, hal_data->pos_resolution, hal_data->scale_rcpt, pos_cnt, 0, 0);
+  class_enc_update(&hal_data->enc, LCEC_PARAM_U32_GET(hal_data->pos_resolution), hal_data->scale_rcpt, pos_cnt, 0, 0);
 }
 
 static void lcec_el7201_9014_read(lcec_slave_t *slave, long period) {
@@ -464,9 +464,9 @@ static void lcec_el7211_write(lcec_slave_t *slave, long period) {
 
   velo_cmd = 0.0;
   if (LCEC_PIN_BIT_GET(hal_data->enable)) {
-    velo_cmd = clamp(LCEC_PIN_FLOAT_GET(hal_data->vel_cmd), hal_data->min_vel, hal_data->max_vel);
+    velo_cmd = clamp(LCEC_PIN_FLOAT_GET(hal_data->vel_cmd), LCEC_PARAM_FLOAT_GET(hal_data->min_vel), LCEC_PARAM_FLOAT_GET(hal_data->max_vel));
   }
-  velo_maxdelta = hal_data->max_accel * (double)period * 1e-9;
+  velo_maxdelta = LCEC_PARAM_FLOAT_GET(hal_data->max_accel) * (double)period * 1e-9;
   LCEC_PIN_FLOAT_SET(hal_data->vel_cmd_out, clamp(velo_cmd, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd_out) - velo_maxdelta, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd_out) + velo_maxdelta));
 
   control = 0;

--- a/src/devices/lcec_el7342.c
+++ b/src/devices/lcec_el7342.c
@@ -472,21 +472,21 @@ static int lcec_el7342_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(chan->pos_scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
 
-    *(chan->dcm_scale) = 1.0;
-    *(chan->dcm_min_dc) = -1.0;
-    *(chan->dcm_max_dc) = 1.0;
-    *(chan->dcm_sel_info1) = info1_select;
-    *(chan->dcm_sel_info2) = info2_select;
+    LCEC_PIN_FLOAT_SET(chan->dcm_scale, 1.0);
+    LCEC_PIN_FLOAT_SET(chan->dcm_min_dc, -1.0);
+    LCEC_PIN_FLOAT_SET(chan->dcm_max_dc, 1.0);
+    LCEC_PIN_U32_SET(chan->dcm_sel_info1, info1_select);
+    LCEC_PIN_U32_SET(chan->dcm_sel_info2, info2_select);
 
     // initialize variables
     chan->enc_do_init = 1;
     chan->enc_last_count = 0;
-    chan->enc_old_scale = *(chan->pos_scale) + 1.0;
+    chan->enc_old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale) + 1.0;
     chan->enc_scale_recip = 1.0;
 
-    chan->dcm_old_scale = *(chan->dcm_scale) + 1.0;
+    chan->dcm_old_scale = LCEC_PIN_FLOAT_GET(chan->dcm_scale) + 1.0;
     chan->dcm_scale_recip = 1.0;
   }
 
@@ -512,48 +512,48 @@ static void lcec_el7342_read(lcec_slave_t *slave, long period) {
     chan = &hal_data->chans[i];
 
     // check for change in scale value
-    if (*(chan->pos_scale) != chan->enc_old_scale) {
+    if (LCEC_PIN_FLOAT_GET(chan->pos_scale) != chan->enc_old_scale) {
       // scale value has changed, test and update it
-      if ((*(chan->pos_scale) < 1e-20) && (*(chan->pos_scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(chan->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(chan->pos_scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(chan->pos_scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(chan->pos_scale, 1.0);
       }
       // save new scale to detect future changes
-      chan->enc_old_scale = *(chan->pos_scale);
+      chan->enc_old_scale = LCEC_PIN_FLOAT_GET(chan->pos_scale);
       // we actually want the reciprocal
-      chan->enc_scale_recip = 1.0 / *(chan->pos_scale);
+      chan->enc_scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(chan->pos_scale);
     }
 
     // get bit states
-    *(chan->ina) = EC_READ_BIT(&pd[chan->ina_pdo_os], chan->ina_pdo_bp);
-    *(chan->inb) = EC_READ_BIT(&pd[chan->inb_pdo_os], chan->inb_pdo_bp);
-    *(chan->inext) = EC_READ_BIT(&pd[chan->inext_pdo_os], chan->inext_pdo_bp);
-    *(chan->sync_err) = EC_READ_BIT(&pd[chan->sync_err_pdo_os], chan->sync_err_pdo_bp);
-    *(chan->expol_stall) = EC_READ_BIT(&pd[chan->expol_stall_pdo_os], chan->expol_stall_pdo_bp);
-    *(chan->tx_toggle) = EC_READ_BIT(&pd[chan->tx_toggle_pdo_os], chan->tx_toggle_pdo_bp);
-    *(chan->count_overflow) = EC_READ_BIT(&pd[chan->count_overflow_pdo_os], chan->count_overflow_pdo_bp);
-    *(chan->count_underflow) = EC_READ_BIT(&pd[chan->count_underflow_pdo_os], chan->count_underflow_pdo_bp);
-    *(chan->latch_ext_valid) = EC_READ_BIT(&pd[chan->latch_ext_valid_pdo_os], chan->latch_ext_valid_pdo_bp);
+    LCEC_PIN_BIT_SET(chan->ina, EC_READ_BIT(&pd[chan->ina_pdo_os], chan->ina_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->inb, EC_READ_BIT(&pd[chan->inb_pdo_os], chan->inb_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->inext, EC_READ_BIT(&pd[chan->inext_pdo_os], chan->inext_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->sync_err, EC_READ_BIT(&pd[chan->sync_err_pdo_os], chan->sync_err_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->expol_stall, EC_READ_BIT(&pd[chan->expol_stall_pdo_os], chan->expol_stall_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->tx_toggle, EC_READ_BIT(&pd[chan->tx_toggle_pdo_os], chan->tx_toggle_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->count_overflow, EC_READ_BIT(&pd[chan->count_overflow_pdo_os], chan->count_overflow_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->count_underflow, EC_READ_BIT(&pd[chan->count_underflow_pdo_os], chan->count_underflow_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->latch_ext_valid, EC_READ_BIT(&pd[chan->latch_ext_valid_pdo_os], chan->latch_ext_valid_pdo_bp));
 
-    *(chan->dcm_ready_to_enable) = EC_READ_BIT(&pd[chan->dcm_ready_to_enable_pdo_os], chan->dcm_ready_to_enable_pdo_bp);
-    *(chan->dcm_ready) = EC_READ_BIT(&pd[chan->dcm_ready_pdo_os], chan->dcm_ready_pdo_bp);
-    *(chan->dcm_warning) = EC_READ_BIT(&pd[chan->dcm_warning_pdo_os], chan->dcm_warning_pdo_bp);
-    *(chan->dcm_error) = EC_READ_BIT(&pd[chan->dcm_error_pdo_os], chan->dcm_error_pdo_bp);
-    *(chan->dcm_move_pos) = EC_READ_BIT(&pd[chan->dcm_move_pos_pdo_os], chan->dcm_move_pos_pdo_bp);
-    *(chan->dcm_move_neg) = EC_READ_BIT(&pd[chan->dcm_move_neg_pdo_os], chan->dcm_move_neg_pdo_bp);
-    *(chan->dcm_torque_reduced) = EC_READ_BIT(&pd[chan->dcm_torque_reduced_pdo_os], chan->dcm_torque_reduced_pdo_bp);
-    *(chan->dcm_din1) = EC_READ_BIT(&pd[chan->dcm_din1_pdo_os], chan->dcm_din1_pdo_bp);
-    *(chan->dcm_din2) = EC_READ_BIT(&pd[chan->dcm_din2_pdo_os], chan->dcm_din2_pdo_bp);
-    *(chan->dcm_sync_err) = EC_READ_BIT(&pd[chan->dcm_sync_err_pdo_os], chan->dcm_sync_err_pdo_bp);
-    *(chan->dcm_tx_toggle) = EC_READ_BIT(&pd[chan->dcm_tx_toggle_pdo_os], chan->dcm_tx_toggle_pdo_bp);
+    LCEC_PIN_BIT_SET(chan->dcm_ready_to_enable, EC_READ_BIT(&pd[chan->dcm_ready_to_enable_pdo_os], chan->dcm_ready_to_enable_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_ready, EC_READ_BIT(&pd[chan->dcm_ready_pdo_os], chan->dcm_ready_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_warning, EC_READ_BIT(&pd[chan->dcm_warning_pdo_os], chan->dcm_warning_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_error, EC_READ_BIT(&pd[chan->dcm_error_pdo_os], chan->dcm_error_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_move_pos, EC_READ_BIT(&pd[chan->dcm_move_pos_pdo_os], chan->dcm_move_pos_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_move_neg, EC_READ_BIT(&pd[chan->dcm_move_neg_pdo_os], chan->dcm_move_neg_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_torque_reduced, EC_READ_BIT(&pd[chan->dcm_torque_reduced_pdo_os], chan->dcm_torque_reduced_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_din1, EC_READ_BIT(&pd[chan->dcm_din1_pdo_os], chan->dcm_din1_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_din2, EC_READ_BIT(&pd[chan->dcm_din2_pdo_os], chan->dcm_din2_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_sync_err, EC_READ_BIT(&pd[chan->dcm_sync_err_pdo_os], chan->dcm_sync_err_pdo_bp));
+    LCEC_PIN_BIT_SET(chan->dcm_tx_toggle, EC_READ_BIT(&pd[chan->dcm_tx_toggle_pdo_os], chan->dcm_tx_toggle_pdo_bp));
 
     // read raw values
     raw_count = EC_READ_S16(&pd[chan->count_pdo_os]);
     raw_latch = EC_READ_S16(&pd[chan->latch_pdo_os]);
 
     // read raw info values
-    *(chan->dcm_raw_info1) = EC_READ_S16(&pd[chan->dcm_info1_pdo_os]);
-    *(chan->dcm_raw_info2) = EC_READ_S16(&pd[chan->dcm_info2_pdo_os]);
+    LCEC_PIN_S32_SET(chan->dcm_raw_info1, EC_READ_S16(&pd[chan->dcm_info1_pdo_os]));
+    LCEC_PIN_S32_SET(chan->dcm_raw_info2, EC_READ_S16(&pd[chan->dcm_info2_pdo_os]));
 
     // dispatch info values
     lcec_el7342_set_info(chan, chan->dcm_raw_info1, chan->dcm_sel_info1);
@@ -567,37 +567,37 @@ static void lcec_el7342_read(lcec_slave_t *slave, long period) {
     // check for counter set done
     if (EC_READ_BIT(&pd[chan->set_count_done_pdo_os], chan->set_count_done_pdo_bp)) {
       chan->enc_last_count = raw_count;
-      *(chan->set_raw_count) = 0;
+      LCEC_PIN_BIT_SET(chan->set_raw_count, 0);
     }
 
     // update raw values
-    if (!*(chan->set_raw_count)) {
-      *(chan->raw_count) = raw_count;
+    if (!LCEC_PIN_BIT_GET(chan->set_raw_count)) {
+      LCEC_PIN_S32_SET(chan->raw_count, raw_count);
     }
 
     // handle initialization
-    if (chan->enc_do_init || *(chan->reset)) {
+    if (chan->enc_do_init || LCEC_PIN_BIT_GET(chan->reset)) {
       chan->enc_do_init = 0;
       chan->enc_last_count = raw_count;
-      *(chan->count) = 0;
+      LCEC_PIN_S32_SET(chan->count, 0);
     }
 
     // handle index
-    if (*(chan->latch_ext_valid)) {
-      *(chan->raw_latch) = raw_latch;
+    if (LCEC_PIN_BIT_GET(chan->latch_ext_valid)) {
+      LCEC_PIN_S32_SET(chan->raw_latch, raw_latch);
       chan->enc_last_count = raw_latch;
-      *(chan->count) = 0;
-      *(chan->ena_latch_ext_pos) = 0;
-      *(chan->ena_latch_ext_neg) = 0;
+      LCEC_PIN_S32_SET(chan->count, 0);
+      LCEC_PIN_BIT_SET(chan->ena_latch_ext_pos, 0);
+      LCEC_PIN_BIT_SET(chan->ena_latch_ext_neg, 0);
     }
 
     // compute net counts
     raw_delta = raw_count - chan->enc_last_count;
     chan->enc_last_count = raw_count;
-    *(chan->count) += raw_delta;
+    LCEC_PIN_S32_SET(chan->count, LCEC_PIN_S32_GET(chan->count) + raw_delta);
 
     // scale count to make floating point position
-    *(chan->pos) = *(chan->count) * chan->enc_scale_recip;
+    LCEC_PIN_FLOAT_SET(chan->pos, LCEC_PIN_S32_GET(chan->count) * chan->enc_scale_recip);
   }
 
   hal_data->last_operational = 1;
@@ -617,51 +617,51 @@ static void lcec_el7342_write(lcec_slave_t *slave, long period) {
 
     // validate duty cycle limits, both limits must be between
     // 0.0 and 1.0 (inclusive) and max must be greater then min
-    if (*(chan->dcm_max_dc) > 1.0) {
-      *(chan->dcm_max_dc) = 1.0;
+    if (LCEC_PIN_FLOAT_GET(chan->dcm_max_dc) > 1.0) {
+      LCEC_PIN_FLOAT_SET(chan->dcm_max_dc, 1.0);
     }
-    if (*(chan->dcm_min_dc) > *(chan->dcm_max_dc)) {
-      *(chan->dcm_min_dc) = *(chan->dcm_max_dc);
+    if (LCEC_PIN_FLOAT_GET(chan->dcm_min_dc) > LCEC_PIN_FLOAT_GET(chan->dcm_max_dc)) {
+      LCEC_PIN_FLOAT_SET(chan->dcm_min_dc, LCEC_PIN_FLOAT_GET(chan->dcm_max_dc));
     }
-    if (*(chan->dcm_min_dc) < -1.0) {
-      *(chan->dcm_min_dc) = -1.0;
+    if (LCEC_PIN_FLOAT_GET(chan->dcm_min_dc) < -1.0) {
+      LCEC_PIN_FLOAT_SET(chan->dcm_min_dc, -1.0);
     }
-    if (*(chan->dcm_max_dc) < *(chan->dcm_min_dc)) {
-      *(chan->dcm_max_dc) = *(chan->dcm_min_dc);
+    if (LCEC_PIN_FLOAT_GET(chan->dcm_max_dc) < LCEC_PIN_FLOAT_GET(chan->dcm_min_dc)) {
+      LCEC_PIN_FLOAT_SET(chan->dcm_max_dc, LCEC_PIN_FLOAT_GET(chan->dcm_min_dc));
     }
 
     // do scale calcs only when scale changes
-    if (*(chan->dcm_scale) != chan->dcm_old_scale) {
+    if (LCEC_PIN_FLOAT_GET(chan->dcm_scale) != chan->dcm_old_scale) {
       // validate the new scale value
-      if ((*(chan->dcm_scale) < 1e-20) && (*(chan->dcm_scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(chan->dcm_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(chan->dcm_scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(chan->dcm_scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(chan->dcm_scale, 1.0);
       }
       // get ready to detect future scale changes
-      chan->dcm_old_scale = *(chan->dcm_scale);
+      chan->dcm_old_scale = LCEC_PIN_FLOAT_GET(chan->dcm_scale);
       // we will need the reciprocal
-      chan->dcm_scale_recip = 1.0 / *(chan->dcm_scale);
+      chan->dcm_scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(chan->dcm_scale);
     }
 
     // get command
-    tmpval = *(chan->dcm_value);
-    if (*(chan->dcm_absmode) && (tmpval < 0)) {
+    tmpval = LCEC_PIN_FLOAT_GET(chan->dcm_value);
+    if (LCEC_PIN_BIT_GET(chan->dcm_absmode) && (tmpval < 0)) {
       tmpval = -tmpval;
     }
 
     // convert value command to duty cycle
-    tmpdc = tmpval * chan->dcm_scale_recip + *(chan->dcm_offset);
-    if (tmpdc < *(chan->dcm_min_dc)) {
-      tmpdc = *(chan->dcm_min_dc);
+    tmpdc = tmpval * chan->dcm_scale_recip + LCEC_PIN_FLOAT_GET(chan->dcm_offset);
+    if (tmpdc < LCEC_PIN_FLOAT_GET(chan->dcm_min_dc)) {
+      tmpdc = LCEC_PIN_FLOAT_GET(chan->dcm_min_dc);
     }
-    if (tmpdc > *(chan->dcm_max_dc)) {
-      tmpdc = *(chan->dcm_max_dc);
+    if (tmpdc > LCEC_PIN_FLOAT_GET(chan->dcm_max_dc)) {
+      tmpdc = LCEC_PIN_FLOAT_GET(chan->dcm_max_dc);
     }
 
     // set output values
-    if (*(chan->dcm_enable) == 0) {
+    if (LCEC_PIN_BIT_GET(chan->dcm_enable) == 0) {
       raw_val = 0;
-      *(chan->dcm_curr_dc) = 0;
+      LCEC_PIN_FLOAT_SET(chan->dcm_curr_dc, 0);
     } else {
       raw_val = (double)0x7fff * tmpdc;
       if (raw_val > (double)0x7fff) {
@@ -670,21 +670,21 @@ static void lcec_el7342_write(lcec_slave_t *slave, long period) {
       if (raw_val < (double)-0x7fff) {
         raw_val = (double)-0x7fff;
       }
-      *(chan->dcm_curr_dc) = tmpdc;
+      LCEC_PIN_FLOAT_SET(chan->dcm_curr_dc, tmpdc);
     }
 
     // update value
-    *(chan->dcm_raw_val) = (int32_t)raw_val;
+    LCEC_PIN_S32_SET(chan->dcm_raw_val, (int32_t)raw_val);
 
     // set output data
-    EC_WRITE_BIT(&pd[chan->set_count_pdo_os], chan->set_count_pdo_bp, *(chan->set_raw_count));
-    EC_WRITE_BIT(&pd[chan->ena_latch_ext_pos_pdo_os], chan->ena_latch_ext_pos_pdo_bp, *(chan->ena_latch_ext_pos));
-    EC_WRITE_BIT(&pd[chan->ena_latch_ext_neg_pdo_os], chan->ena_latch_ext_neg_pdo_bp, *(chan->ena_latch_ext_neg));
-    EC_WRITE_S16(&pd[chan->set_count_val_pdo_os], *(chan->set_raw_count_val));
+    EC_WRITE_BIT(&pd[chan->set_count_pdo_os], chan->set_count_pdo_bp, LCEC_PIN_BIT_GET(chan->set_raw_count));
+    EC_WRITE_BIT(&pd[chan->ena_latch_ext_pos_pdo_os], chan->ena_latch_ext_pos_pdo_bp, LCEC_PIN_BIT_GET(chan->ena_latch_ext_pos));
+    EC_WRITE_BIT(&pd[chan->ena_latch_ext_neg_pdo_os], chan->ena_latch_ext_neg_pdo_bp, LCEC_PIN_BIT_GET(chan->ena_latch_ext_neg));
+    EC_WRITE_S16(&pd[chan->set_count_val_pdo_os], LCEC_PIN_S32_GET(chan->set_raw_count_val));
 
-    EC_WRITE_BIT(&pd[chan->dcm_ena_pdo_os], chan->dcm_ena_pdo_bp, *(chan->dcm_enable));
-    EC_WRITE_BIT(&pd[chan->dcm_reset_pdo_os], chan->dcm_reset_pdo_bp, *(chan->dcm_reset));
-    EC_WRITE_BIT(&pd[chan->dcm_reduce_torque_pdo_os], chan->dcm_reduce_torque_pdo_bp, *(chan->dcm_reduce_torque));
+    EC_WRITE_BIT(&pd[chan->dcm_ena_pdo_os], chan->dcm_ena_pdo_bp, LCEC_PIN_BIT_GET(chan->dcm_enable));
+    EC_WRITE_BIT(&pd[chan->dcm_reset_pdo_os], chan->dcm_reset_pdo_bp, LCEC_PIN_BIT_GET(chan->dcm_reset));
+    EC_WRITE_BIT(&pd[chan->dcm_reduce_torque_pdo_os], chan->dcm_reduce_torque_pdo_bp, LCEC_PIN_BIT_GET(chan->dcm_reduce_torque));
     EC_WRITE_S16(&pd[chan->dcm_velo_pdo_os], (int16_t)raw_val);
   }
 }
@@ -692,11 +692,11 @@ static void lcec_el7342_write(lcec_slave_t *slave, long period) {
 static void lcec_el7342_set_info(lcec_el7342_chan_t *chan, hal_s32_t *raw_info, hal_u32_t *sel_info) {
   switch (*sel_info) {
     case INFO_SEL_MOTOR_VELO:
-      *(chan->dcm_velo_fb) = (double)*raw_info * 0.0001 * chan->dcm_old_scale;
+      LCEC_PIN_FLOAT_SET(chan->dcm_velo_fb, (double)*raw_info * 0.0001 * chan->dcm_old_scale);
       break;
 
     case INFO_SEL_MOTOR_CURR:
-      *(chan->dcm_current_fb) = (double)*raw_info * 0.001;
+      LCEC_PIN_FLOAT_SET(chan->dcm_current_fb, (double)*raw_info * 0.001);
       break;
   }
 }

--- a/src/devices/lcec_el7342.c
+++ b/src/devices/lcec_el7342.c
@@ -690,13 +690,13 @@ static void lcec_el7342_write(lcec_slave_t *slave, long period) {
 }
 
 static void lcec_el7342_set_info(lcec_el7342_chan_t *chan, hal_s32_t *raw_info, hal_u32_t *sel_info) {
-  switch (*sel_info) {
+  switch (LCEC_PIN_U32_GET(sel_info)) {
     case INFO_SEL_MOTOR_VELO:
-      LCEC_PIN_FLOAT_SET(chan->dcm_velo_fb, (double)*raw_info * 0.0001 * chan->dcm_old_scale);
+      LCEC_PIN_FLOAT_SET(chan->dcm_velo_fb, (double)LCEC_PIN_S32_GET(raw_info) * 0.0001 * chan->dcm_old_scale);
       break;
 
     case INFO_SEL_MOTOR_CURR:
-      LCEC_PIN_FLOAT_SET(chan->dcm_current_fb, (double)*raw_info * 0.001);
+      LCEC_PIN_FLOAT_SET(chan->dcm_current_fb, (double)LCEC_PIN_S32_GET(raw_info) * 0.001);
       break;
   }
 }

--- a/src/devices/lcec_el7411.c
+++ b/src/devices/lcec_el7411.c
@@ -22,7 +22,7 @@
 #include "lcec_el7411.h"
 
 #include "../lcec.h"
-#include "hal.h"
+#include <hal.h>
 
 static int lcec_el7411_init(int comp_id, lcec_slave_t *slave);
 

--- a/src/devices/lcec_el9410.c
+++ b/src/devices/lcec_el9410.c
@@ -59,8 +59,8 @@ static int lcec_el9410_init(int comp_id, lcec_slave_t *slave) {
     return err;
   }
 
-  *(hal_data->us_undervoltage) = 0;
-  *(hal_data->up_undervoltage) = 0;
+  LCEC_PIN_BIT_SET(hal_data->us_undervoltage, 0);
+  LCEC_PIN_BIT_SET(hal_data->up_undervoltage, 0);
 
   slave->proc_read = lcec_el9410_read;
   return 0;
@@ -76,6 +76,6 @@ static void lcec_el9410_read(lcec_slave_t *slave, long period) {
     return;
   }
 
-  *(hal_data->us_undervoltage) = EC_READ_BIT(&pd[hal_data->us_undervoltage_os], hal_data->us_undervoltage_bp);
-  *(hal_data->up_undervoltage) = EC_READ_BIT(&pd[hal_data->up_undervoltage_os], hal_data->up_undervoltage_bp);
+  LCEC_PIN_BIT_SET(hal_data->us_undervoltage, EC_READ_BIT(&pd[hal_data->us_undervoltage_os], hal_data->us_undervoltage_bp));
+  LCEC_PIN_BIT_SET(hal_data->up_undervoltage, EC_READ_BIT(&pd[hal_data->up_undervoltage_os], hal_data->up_undervoltage_bp));
 }

--- a/src/devices/lcec_el95xx.c
+++ b/src/devices/lcec_el95xx.c
@@ -86,6 +86,6 @@ static void lcec_el95xx_read(lcec_slave_t *slave, long period) {
   }
 
   // check inputs
-  *(hal_data->power_ok) = EC_READ_BIT(&pd[hal_data->power_ok_pdo_os], hal_data->power_ok_pdo_bp);
-  *(hal_data->overload) = EC_READ_BIT(&pd[hal_data->overload_pdo_os], hal_data->overload_pdo_bp);
+  LCEC_PIN_BIT_SET(hal_data->power_ok, EC_READ_BIT(&pd[hal_data->power_ok_pdo_os], hal_data->power_ok_pdo_bp));
+  LCEC_PIN_BIT_SET(hal_data->overload, EC_READ_BIT(&pd[hal_data->overload_pdo_os], hal_data->overload_pdo_bp));
 }

--- a/src/devices/lcec_em7004.c
+++ b/src/devices/lcec_em7004.c
@@ -42,7 +42,7 @@ typedef struct {
 
 typedef struct {
   hal_bit_t *out;
-  hal_bit_t invert;
+  lcec_param_bit_t invert;
   unsigned int pdo_os;
   unsigned int pdo_bp;
 } lcec_em7004_dout_t;
@@ -353,7 +353,7 @@ static void lcec_em7004_read(lcec_slave_t *slave, long period) {
     LCEC_PIN_S32_SET(enc->count, LCEC_PIN_S32_GET(enc->count) + raw_delta);
 
     // scale count to make floating point position
-    LCEC_PIN_BIT_SET(enc->pos, LCEC_PIN_S32_GET(enc->count) * enc->scale);
+    LCEC_PIN_FLOAT_SET(enc->pos, LCEC_PIN_S32_GET(enc->count) * enc->scale);
   }
 
   hal_data->last_operational = 1;
@@ -372,7 +372,7 @@ static void lcec_em7004_write(lcec_slave_t *slave, long period) {
   // set digital outputs
   for (i = 0, dout = hal_data->douts; i < LCEC_EM7004_DOUT_COUNT; i++, dout++) {
     s = LCEC_PIN_BIT_GET(dout->out);
-    if (dout->invert) {
+    if (LCEC_PARAM_BIT_GET(dout->invert)) {
       s = !s;
     }
     EC_WRITE_BIT(&pd[dout->pdo_os], dout->pdo_bp, s);

--- a/src/devices/lcec_em7004.c
+++ b/src/devices/lcec_em7004.c
@@ -224,12 +224,12 @@ static int lcec_em7004_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // set default pin values
-    *(aout->scale) = 1.0;
-    *(aout->min_dc) = -1.0;
-    *(aout->max_dc) = 1.0;
+    LCEC_PIN_FLOAT_SET(aout->scale, 1.0);
+    LCEC_PIN_FLOAT_SET(aout->min_dc, -1.0);
+    LCEC_PIN_FLOAT_SET(aout->max_dc, 1.0);
 
     // init other fields
-    aout->old_scale = *(aout->scale) + 1.0;
+    aout->old_scale = LCEC_PIN_FLOAT_GET(aout->scale) + 1.0;
     aout->scale_recip = 1.0;
   }
 
@@ -255,12 +255,12 @@ static int lcec_em7004_init(int comp_id, lcec_slave_t *slave) {
     }
 
     // initialize pins
-    *(enc->pos_scale) = 1.0;
+    LCEC_PIN_FLOAT_SET(enc->pos_scale, 1.0);
 
     // initialize variables
     enc->do_init = 1;
     enc->last_count = 0;
-    enc->old_scale = *(enc->pos_scale) + 1.0;
+    enc->old_scale = LCEC_PIN_FLOAT_GET(enc->pos_scale) + 1.0;
     enc->scale = 1.0;
   }
 
@@ -285,31 +285,31 @@ static void lcec_em7004_read(lcec_slave_t *slave, long period) {
   // check digital inputs
   for (i = 0, din = hal_data->dins; i < LCEC_EM7004_DIN_COUNT; i++, din++) {
     s = EC_READ_BIT(&pd[din->pdo_os], din->pdo_bp);
-    *(din->in) = s;
-    *(din->in_not) = !s;
+    LCEC_PIN_BIT_SET(din->in, s);
+    LCEC_PIN_BIT_SET(din->in_not, !s);
   }
 
   // read encoder data
   for (i = 0, enc = hal_data->encs; i < LCEC_EM7004_ENC_COUNT; i++, enc++) {
     // check for change in scale value
-    if (*(enc->pos_scale) != enc->old_scale) {
+    if (LCEC_PIN_FLOAT_GET(enc->pos_scale) != enc->old_scale) {
       // scale value has changed, test and update it
-      if ((*(enc->pos_scale) < 1e-20) && (*(enc->pos_scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(enc->pos_scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(enc->pos_scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(enc->pos_scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(enc->pos_scale, 1.0);
       }
       // save new scale to detect future changes
-      enc->old_scale = *(enc->pos_scale);
+      enc->old_scale = LCEC_PIN_FLOAT_GET(enc->pos_scale);
       // we actually want the reciprocal
-      enc->scale = 1.0 / *(enc->pos_scale);
+      enc->scale = 1.0 / LCEC_PIN_FLOAT_GET(enc->pos_scale);
     }
 
     // get bit states
-    *(enc->ina) = EC_READ_BIT(&pd[enc->ina_pdo_os], enc->ina_pdo_bp);
-    *(enc->inb) = EC_READ_BIT(&pd[enc->inb_pdo_os], enc->inb_pdo_bp);
-    *(enc->ingate) = EC_READ_BIT(&pd[enc->ingate_pdo_os], enc->ingate_pdo_bp);
-    *(enc->inext) = EC_READ_BIT(&pd[enc->inext_pdo_os], enc->inext_pdo_bp);
-    *(enc->latch_ext_valid) = EC_READ_BIT(&pd[enc->latch_ext_valid_pdo_os], enc->latch_ext_valid_pdo_bp);
+    LCEC_PIN_BIT_SET(enc->ina, EC_READ_BIT(&pd[enc->ina_pdo_os], enc->ina_pdo_bp));
+    LCEC_PIN_BIT_SET(enc->inb, EC_READ_BIT(&pd[enc->inb_pdo_os], enc->inb_pdo_bp));
+    LCEC_PIN_BIT_SET(enc->ingate, EC_READ_BIT(&pd[enc->ingate_pdo_os], enc->ingate_pdo_bp));
+    LCEC_PIN_BIT_SET(enc->inext, EC_READ_BIT(&pd[enc->inext_pdo_os], enc->inext_pdo_bp));
+    LCEC_PIN_BIT_SET(enc->latch_ext_valid, EC_READ_BIT(&pd[enc->latch_ext_valid_pdo_os], enc->latch_ext_valid_pdo_bp));
 
     // read raw values
     raw_count = EC_READ_S16(&pd[enc->count_pdo_os]);
@@ -323,37 +323,37 @@ static void lcec_em7004_read(lcec_slave_t *slave, long period) {
     // check for counter set done
     if (EC_READ_BIT(&pd[enc->set_count_done_pdo_os], enc->set_count_done_pdo_bp)) {
       enc->last_count = raw_count;
-      *(enc->set_raw_count) = 0;
+      LCEC_PIN_BIT_SET(enc->set_raw_count, 0);
     }
 
     // update raw values
-    if (!*(enc->set_raw_count)) {
-      *(enc->raw_count) = raw_count;
+    if (!LCEC_PIN_BIT_GET(enc->set_raw_count)) {
+      LCEC_PIN_S32_SET(enc->raw_count, raw_count);
     }
 
     // handle initialization
-    if (enc->do_init || *(enc->reset)) {
+    if (enc->do_init || LCEC_PIN_BIT_GET(enc->reset)) {
       enc->do_init = 0;
       enc->last_count = raw_count;
-      *(enc->count) = 0;
+      LCEC_PIN_S32_SET(enc->count, 0);
     }
 
     // handle index
-    if (*(enc->latch_ext_valid)) {
-      *(enc->raw_latch) = raw_latch;
+    if (LCEC_PIN_BIT_GET(enc->latch_ext_valid)) {
+      LCEC_PIN_S32_SET(enc->raw_latch, raw_latch);
       enc->last_count = raw_latch;
-      *(enc->count) = 0;
-      *(enc->ena_latch_ext_pos) = 0;
-      *(enc->ena_latch_ext_neg) = 0;
+      LCEC_PIN_S32_SET(enc->count, 0);
+      LCEC_PIN_BIT_SET(enc->ena_latch_ext_pos, 0);
+      LCEC_PIN_BIT_SET(enc->ena_latch_ext_neg, 0);
     }
 
     // compute net counts
     raw_delta = raw_count - enc->last_count;
     enc->last_count = raw_count;
-    *(enc->count) += raw_delta;
+    LCEC_PIN_S32_SET(enc->count, LCEC_PIN_S32_GET(enc->count) + raw_delta);
 
     // scale count to make floating point position
-    *(enc->pos) = *(enc->count) * enc->scale;
+    LCEC_PIN_BIT_SET(enc->pos, LCEC_PIN_S32_GET(enc->count) * enc->scale);
   }
 
   hal_data->last_operational = 1;
@@ -371,7 +371,7 @@ static void lcec_em7004_write(lcec_slave_t *slave, long period) {
 
   // set digital outputs
   for (i = 0, dout = hal_data->douts; i < LCEC_EM7004_DOUT_COUNT; i++, dout++) {
-    s = *(dout->out);
+    s = LCEC_PIN_BIT_GET(dout->out);
     if (dout->invert) {
       s = !s;
     }
@@ -382,53 +382,53 @@ static void lcec_em7004_write(lcec_slave_t *slave, long period) {
   for (i = 0, aout = hal_data->aouts; i < LCEC_EM7004_AOUT_COUNT; i++, aout++) {
     // validate duty cycle limits, both limits must be between
     // 0.0 and 1.0 (inclusive) and max must be greater then min
-    if (*(aout->max_dc) > 1.0) {
-      *(aout->max_dc) = 1.0;
+    if (LCEC_PIN_FLOAT_GET(aout->max_dc) > 1.0) {
+      LCEC_PIN_FLOAT_SET(aout->max_dc, 1.0);
     }
-    if (*(aout->min_dc) > *(aout->max_dc)) {
-      *(aout->min_dc) = *(aout->max_dc);
+    if (LCEC_PIN_FLOAT_GET(aout->min_dc) > LCEC_PIN_FLOAT_GET(aout->max_dc)) {
+      LCEC_PIN_FLOAT_SET(aout->min_dc, LCEC_PIN_FLOAT_GET(aout->max_dc));
     }
-    if (*(aout->min_dc) < -1.0) {
-      *(aout->min_dc) = -1.0;
+    if (LCEC_PIN_FLOAT_GET(aout->min_dc) < -1.0) {
+      LCEC_PIN_FLOAT_SET(aout->min_dc, -1.0);
     }
-    if (*(aout->max_dc) < *(aout->min_dc)) {
-      *(aout->max_dc) = *(aout->min_dc);
+    if (LCEC_PIN_FLOAT_GET(aout->max_dc) < LCEC_PIN_FLOAT_GET(aout->min_dc)) {
+      LCEC_PIN_FLOAT_SET(aout->max_dc, LCEC_PIN_FLOAT_GET(aout->min_dc));
     }
 
     // do scale calcs only when scale changes
-    if (*(aout->scale) != aout->old_scale) {
+    if (LCEC_PIN_FLOAT_GET(aout->scale) != aout->old_scale) {
       // validate the new scale value
-      if ((*(aout->scale) < 1e-20) && (*(aout->scale) > -1e-20)) {
+      if ((LCEC_PIN_FLOAT_GET(aout->scale) < 1e-20) && (LCEC_PIN_FLOAT_GET(aout->scale) > -1e-20)) {
         // value too small, divide by zero is a bad thing
-        *(aout->scale) = 1.0;
+        LCEC_PIN_FLOAT_SET(aout->scale, 1.0);
       }
       // get ready to detect future scale changes
-      aout->old_scale = *(aout->scale);
+      aout->old_scale = LCEC_PIN_FLOAT_GET(aout->scale);
       // we will need the reciprocal
-      aout->scale_recip = 1.0 / *(aout->scale);
+      aout->scale_recip = 1.0 / LCEC_PIN_FLOAT_GET(aout->scale);
     }
 
     // get command
-    tmpval = *(aout->value);
-    if (*(aout->absmode) && (tmpval < 0)) {
+    tmpval = LCEC_PIN_FLOAT_GET(aout->value);
+    if (LCEC_PIN_BIT_GET(aout->absmode) && (tmpval < 0)) {
       tmpval = -tmpval;
     }
 
     // convert value command to duty cycle
-    tmpdc = tmpval * aout->scale_recip + *(aout->offset);
-    if (tmpdc < *(aout->min_dc)) {
-      tmpdc = *(aout->min_dc);
+    tmpdc = tmpval * aout->scale_recip + LCEC_PIN_FLOAT_GET(aout->offset);
+    if (tmpdc < LCEC_PIN_FLOAT_GET(aout->min_dc)) {
+      tmpdc = LCEC_PIN_FLOAT_GET(aout->min_dc);
     }
-    if (tmpdc > *(aout->max_dc)) {
-      tmpdc = *(aout->max_dc);
+    if (tmpdc > LCEC_PIN_FLOAT_GET(aout->max_dc)) {
+      tmpdc = LCEC_PIN_FLOAT_GET(aout->max_dc);
     }
 
     // set output values
-    if (*(aout->enable) == 0) {
+    if (LCEC_PIN_BIT_GET(aout->enable) == 0) {
       raw_val = 0;
-      *(aout->pos) = 0;
-      *(aout->neg) = 0;
-      *(aout->curr_dc) = 0;
+      LCEC_PIN_BIT_SET(aout->pos, 0);
+      LCEC_PIN_BIT_SET(aout->neg, 0);
+      LCEC_PIN_FLOAT_SET(aout->curr_dc, 0);
     } else {
       raw_val = (double)0x7fff * tmpdc;
       if (raw_val > (double)0x7fff) {
@@ -437,21 +437,21 @@ static void lcec_em7004_write(lcec_slave_t *slave, long period) {
       if (raw_val < (double)-0x7fff) {
         raw_val = (double)-0x7fff;
       }
-      *(aout->pos) = (*(aout->value) > 0);
-      *(aout->neg) = (*(aout->value) < 0);
-      *(aout->curr_dc) = tmpdc;
+      LCEC_PIN_BIT_SET(aout->pos, (LCEC_PIN_FLOAT_GET(aout->value) > 0));
+      LCEC_PIN_BIT_SET(aout->neg, (LCEC_PIN_FLOAT_GET(aout->value) < 0));
+      LCEC_PIN_FLOAT_SET(aout->curr_dc, tmpdc);
     }
 
     // update value
     EC_WRITE_S16(&pd[aout->val_pdo_os], (int16_t)raw_val);
-    *(aout->raw_val) = (int32_t)raw_val;
+    LCEC_PIN_S32_SET(aout->raw_val, (int32_t)raw_val);
   }
 
   // write encoder data
   for (i = 0, enc = hal_data->encs; i < LCEC_EM7004_ENC_COUNT; i++, enc++) {
-    EC_WRITE_BIT(&pd[enc->set_count_pdo_os], enc->set_count_pdo_bp, *(enc->set_raw_count));
-    EC_WRITE_BIT(&pd[enc->ena_latch_ext_pos_pdo_os], enc->ena_latch_ext_pos_pdo_bp, *(enc->ena_latch_ext_pos));
-    EC_WRITE_BIT(&pd[enc->ena_latch_ext_neg_pdo_os], enc->ena_latch_ext_neg_pdo_bp, *(enc->ena_latch_ext_neg));
-    EC_WRITE_S16(&pd[enc->set_count_val_pdo_os], *(enc->set_raw_count_val));
+    EC_WRITE_BIT(&pd[enc->set_count_pdo_os], enc->set_count_pdo_bp, LCEC_PIN_BIT_GET(enc->set_raw_count));
+    EC_WRITE_BIT(&pd[enc->ena_latch_ext_pos_pdo_os], enc->ena_latch_ext_pos_pdo_bp, LCEC_PIN_BIT_GET(enc->ena_latch_ext_pos));
+    EC_WRITE_BIT(&pd[enc->ena_latch_ext_neg_pdo_os], enc->ena_latch_ext_neg_pdo_bp, LCEC_PIN_BIT_GET(enc->ena_latch_ext_neg));
+    EC_WRITE_S16(&pd[enc->set_count_val_pdo_os], LCEC_PIN_S32_GET(enc->set_raw_count_val));
   }
 }

--- a/src/devices/lcec_ep9214.c
+++ b/src/devices/lcec_ep9214.c
@@ -140,14 +140,14 @@ static int lcec_ep9214_init(int comp_id, lcec_slave_t *slave) {
     lcec_read_sdo16(slave, 0x8000+16*chan, 0x13, &current_up);
     lcec_read_sdo8(slave, 0x7000+16*chan, 0x1, &enable_us);
     lcec_read_sdo8(slave, 0x7000+16*chan, 0x2, &enable_up);
-    *(c->current_limit_type) = current_type;
-    *(c->current_limit_us) = current_us / 1000.0;
-    *(c->current_limit_up) = current_up / 1000.0;
-    *(c->enable_us) = !!enable_us;
-    *(c->enable_up) = !!enable_up;
-    c->current_limit_type_old = *(c->current_limit_type);
-    c->current_limit_us_old = *(c->current_limit_us);
-    c->current_limit_up_old = *(c->current_limit_up);
+    LCEC_PIN_S32_SET(c->current_limit_type, current_type);
+    LCEC_PIN_FLOAT_SET(c->current_limit_us, current_us / 1000.0);
+    LCEC_PIN_FLOAT_SET(c->current_limit_up, current_up / 1000.0);
+    LCEC_PIN_BIT_SET(c->enable_us, !!enable_us);
+    LCEC_PIN_BIT_SET(c->enable_up, !!enable_up);
+    c->current_limit_type_old = LCEC_PIN_S32_GET(c->current_limit_type);
+    c->current_limit_us_old = LCEC_PIN_FLOAT_GET(c->current_limit_us);
+    c->current_limit_up_old = LCEC_PIN_FLOAT_GET(c->current_limit_up);
   }
 
   lcec_pdo_init(slave, 0xf607, 1, &(hal_data->warning_temp_os), &(hal_data->warning_temp_bp));
@@ -182,22 +182,22 @@ static void lcec_ep9214_read(lcec_slave_t *slave, long period) {
   for (int chan=0;chan<CHANNELS;chan++) {
     lcec_ep9214_channel_data_t *c = &(hal_data->chan[chan]);
     
-    *(c->error_us) = EC_READ_BIT(&pd[c->error_us_os], c->error_us_bp);
-    *(c->error_up) = EC_READ_BIT(&pd[c->error_up_os], c->error_up_bp);
-    *(c->warning_us) = EC_READ_BIT(&pd[c->warning_us_os], c->warning_us_bp);
-    *(c->warning_up) = EC_READ_BIT(&pd[c->warning_up_os], c->warning_up_bp);
-    *(c->poweron_us) = EC_READ_BIT(&pd[c->poweron_us_os], c->poweron_us_bp);
-    *(c->poweron_up) = EC_READ_BIT(&pd[c->poweron_up_os], c->poweron_up_bp);
-    *(c->enable_us) = EC_READ_BIT(&pd[c->enable_us_os], c->enable_us_bp);
-    *(c->enable_up) = EC_READ_BIT(&pd[c->enable_up_os], c->enable_up_bp);
+    LCEC_PIN_BIT_SET(c->error_us, EC_READ_BIT(&pd[c->error_us_os], c->error_us_bp));
+    LCEC_PIN_BIT_SET(c->error_up, EC_READ_BIT(&pd[c->error_up_os], c->error_up_bp));
+    LCEC_PIN_BIT_SET(c->warning_us, EC_READ_BIT(&pd[c->warning_us_os], c->warning_us_bp));
+    LCEC_PIN_BIT_SET(c->warning_up, EC_READ_BIT(&pd[c->warning_up_os], c->warning_up_bp));
+    LCEC_PIN_BIT_SET(c->poweron_us, EC_READ_BIT(&pd[c->poweron_us_os], c->poweron_us_bp));
+    LCEC_PIN_BIT_SET(c->poweron_up, EC_READ_BIT(&pd[c->poweron_up_os], c->poweron_up_bp));
+    LCEC_PIN_BIT_SET(c->enable_us, EC_READ_BIT(&pd[c->enable_us_os], c->enable_us_bp));
+    LCEC_PIN_BIT_SET(c->enable_up, EC_READ_BIT(&pd[c->enable_up_os], c->enable_up_bp));
   }
 
-  *(hal_data->warning_temp) = EC_READ_BIT(&pd[hal_data->warning_temp_os], hal_data->warning_temp_bp);
-  *(hal_data->error_temp) = EC_READ_BIT(&pd[hal_data->error_temp_os], hal_data->error_temp_bp);
-  *(hal_data->warning_us) = EC_READ_BIT(&pd[hal_data->warning_us_os], hal_data->warning_us_bp);
-  *(hal_data->error_us) = EC_READ_BIT(&pd[hal_data->error_us_os], hal_data->error_us_bp);
-  *(hal_data->warning_us) = EC_READ_BIT(&pd[hal_data->warning_up_os], hal_data->warning_up_bp);
-  *(hal_data->error_us) = EC_READ_BIT(&pd[hal_data->error_up_os], hal_data->error_up_bp);
+  LCEC_PIN_BIT_SET(hal_data->warning_temp, EC_READ_BIT(&pd[hal_data->warning_temp_os], hal_data->warning_temp_bp));
+  LCEC_PIN_BIT_SET(hal_data->error_temp, EC_READ_BIT(&pd[hal_data->error_temp_os], hal_data->error_temp_bp));
+  LCEC_PIN_BIT_SET(hal_data->warning_us, EC_READ_BIT(&pd[hal_data->warning_us_os], hal_data->warning_us_bp));
+  LCEC_PIN_BIT_SET(hal_data->error_us, EC_READ_BIT(&pd[hal_data->error_us_os], hal_data->error_us_bp));
+  LCEC_PIN_BIT_SET(hal_data->warning_us, EC_READ_BIT(&pd[hal_data->warning_up_os], hal_data->warning_up_bp));
+  LCEC_PIN_BIT_SET(hal_data->error_us, EC_READ_BIT(&pd[hal_data->error_up_os], hal_data->error_up_bp));
 }
 
 /// @brief Write values to the device.

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -460,27 +460,27 @@ void lcec_fr4000_read(lcec_slave_t *slave, long period) {
   uint16_t raw_counts[5];
   int32_t raw_forced_counts[5];
 
-  *(hal_data->IN_0) = EC_READ_BIT(&pd[hal_data->off_dig_inp], 0);
-  *(hal_data->IN_1) = EC_READ_BIT(&pd[hal_data->off_dig_inp], 1);
-  *(hal_data->IN_2) = EC_READ_BIT(&pd[hal_data->off_dig_inp], 2);
-  *(hal_data->IN_3) = EC_READ_BIT(&pd[hal_data->off_dig_inp], 3);
-  *(hal_data->IN_4) = EC_READ_BIT(&pd[hal_data->off_dig_inp], 4);
+  LCEC_PIN_BIT_SET(hal_data->IN_0, EC_READ_BIT(&pd[hal_data->off_dig_inp], 0));
+  LCEC_PIN_BIT_SET(hal_data->IN_1, EC_READ_BIT(&pd[hal_data->off_dig_inp], 1));
+  LCEC_PIN_BIT_SET(hal_data->IN_2, EC_READ_BIT(&pd[hal_data->off_dig_inp], 2));
+  LCEC_PIN_BIT_SET(hal_data->IN_3, EC_READ_BIT(&pd[hal_data->off_dig_inp], 3));
+  LCEC_PIN_BIT_SET(hal_data->IN_4, EC_READ_BIT(&pd[hal_data->off_dig_inp], 4));
 
-  *(hal_data->DROK_0) = EC_READ_BIT(&pd[hal_data->off_DRVOK], 0);
-  *(hal_data->DROK_1) = EC_READ_BIT(&pd[hal_data->off_DRVOK], 1);
-  *(hal_data->DROK_2) = EC_READ_BIT(&pd[hal_data->off_DRVOK], 2);
-  *(hal_data->DROK_3) = EC_READ_BIT(&pd[hal_data->off_DRVOK], 3);
-  *(hal_data->DROK_4) = EC_READ_BIT(&pd[hal_data->off_DRVOK], 4);
-  *(hal_data->DROK_INVERTER) = EC_READ_BIT(&pd[hal_data->off_DRVOK], 5);
+  LCEC_PIN_BIT_SET(hal_data->DROK_0, EC_READ_BIT(&pd[hal_data->off_DRVOK], 0));
+  LCEC_PIN_BIT_SET(hal_data->DROK_1, EC_READ_BIT(&pd[hal_data->off_DRVOK], 1));
+  LCEC_PIN_BIT_SET(hal_data->DROK_2, EC_READ_BIT(&pd[hal_data->off_DRVOK], 2));
+  LCEC_PIN_BIT_SET(hal_data->DROK_3, EC_READ_BIT(&pd[hal_data->off_DRVOK], 3));
+  LCEC_PIN_BIT_SET(hal_data->DROK_4, EC_READ_BIT(&pd[hal_data->off_DRVOK], 4));
+  LCEC_PIN_BIT_SET(hal_data->DROK_INVERTER, EC_READ_BIT(&pd[hal_data->off_DRVOK], 5));
 
-  *(hal_data->HOME_0) = EC_READ_BIT(&pd[hal_data->off_HOME], 0);
-  *(hal_data->HOME_1) = EC_READ_BIT(&pd[hal_data->off_HOME], 1);
-  *(hal_data->HOME_2) = EC_READ_BIT(&pd[hal_data->off_HOME], 2);
-  *(hal_data->HOME_3) = EC_READ_BIT(&pd[hal_data->off_HOME], 3);
-  *(hal_data->HOME_4) = EC_READ_BIT(&pd[hal_data->off_HOME], 4);
+  LCEC_PIN_BIT_SET(hal_data->HOME_0, EC_READ_BIT(&pd[hal_data->off_HOME], 0));
+  LCEC_PIN_BIT_SET(hal_data->HOME_1, EC_READ_BIT(&pd[hal_data->off_HOME], 1));
+  LCEC_PIN_BIT_SET(hal_data->HOME_2, EC_READ_BIT(&pd[hal_data->off_HOME], 2));
+  LCEC_PIN_BIT_SET(hal_data->HOME_3, EC_READ_BIT(&pd[hal_data->off_HOME], 3));
+  LCEC_PIN_BIT_SET(hal_data->HOME_4, EC_READ_BIT(&pd[hal_data->off_HOME], 4));
 
-  *(hal_data->adc1) = EC_READ_U16(&pd[hal_data->off_ADC1]);
-  *(hal_data->adc2) = EC_READ_U16(&pd[hal_data->off_ADC2]);
+  LCEC_PIN_FLOAT_SET(hal_data->adc1, EC_READ_U16(&pd[hal_data->off_ADC1]));
+  LCEC_PIN_FLOAT_SET(hal_data->adc2, EC_READ_U16(&pd[hal_data->off_ADC2]));
 
   raw_counts[0] = EC_READ_U16(&pd[hal_data->off_ENC]);
   raw_counts[1] = EC_READ_U16(&pd[hal_data->off_ENC + 2]);
@@ -491,31 +491,31 @@ void lcec_fr4000_read(lcec_slave_t *slave, long period) {
   // check for index pulse detected
   if (EC_READ_BIT(&pd[hal_data->off_FLAG], 0) == 1) {
     // cancel index-enable
-    *(hal_data->enc_00_index_enable) = 0;
+    LCEC_PIN_BIT_SET(hal_data->enc_00_index_enable, 0);
 
     counts[0] = 0;
   }
   if (EC_READ_BIT(&pd[hal_data->off_FLAG], 1) == 1) {
     // cancel index-enable
-    *(hal_data->enc_01_index_enable) = 0;
+    LCEC_PIN_BIT_SET(hal_data->enc_01_index_enable, 0);
 
     counts[1] = 0;
   }
   if (EC_READ_BIT(&pd[hal_data->off_FLAG], 2) == 1) {
     // cancel index-enable
-    *(hal_data->enc_02_index_enable) = 0;
+    LCEC_PIN_BIT_SET(hal_data->enc_02_index_enable, 0);
 
     counts[2] = 0;
   }
   if (EC_READ_BIT(&pd[hal_data->off_FLAG], 3) == 1) {
     // cancel index-enable
-    *(hal_data->enc_03_index_enable) = 0;
+    LCEC_PIN_BIT_SET(hal_data->enc_03_index_enable, 0);
 
     counts[3] = 0;
   }
   if (EC_READ_BIT(&pd[hal_data->off_FLAG], 4) == 1) {
     // cancel index-enable
-    *(hal_data->enc_04_index_enable) = 0;
+    LCEC_PIN_BIT_SET(hal_data->enc_04_index_enable, 0);
 
     counts[4] = 0;
   }
@@ -571,17 +571,17 @@ void lcec_fr4000_read(lcec_slave_t *slave, long period) {
   counts[4] += (int16_t)(raw_counts[4] - raw_counts_old[4]);
   raw_counts_old[4] = raw_counts[4];
 
-  *(hal_data->enc_00_position) = counts[0] * hal_data->enc_00_scale;
-  *(hal_data->enc_01_position) = counts[1] * hal_data->enc_01_scale;
-  *(hal_data->enc_02_position) = counts[2] * hal_data->enc_02_scale;
-  *(hal_data->enc_03_position) = counts[3] * hal_data->enc_03_scale;
-  *(hal_data->enc_04_position) = counts[4] * hal_data->enc_04_scale;
+  LCEC_PIN_FLOAT_SET(hal_data->enc_00_position, counts[0] * hal_data->enc_00_scale);
+  LCEC_PIN_FLOAT_SET(hal_data->enc_01_position, counts[1] * hal_data->enc_01_scale);
+  LCEC_PIN_FLOAT_SET(hal_data->enc_02_position, counts[2] * hal_data->enc_02_scale);
+  LCEC_PIN_FLOAT_SET(hal_data->enc_03_position, counts[3] * hal_data->enc_03_scale);
+  LCEC_PIN_FLOAT_SET(hal_data->enc_04_position, counts[4] * hal_data->enc_04_scale);
 
-  *(hal_data->enc_00_count) = counts[0];
-  *(hal_data->enc_01_count) = counts[1];
-  *(hal_data->enc_02_count) = counts[2];
-  *(hal_data->enc_03_count) = counts[3];
-  *(hal_data->enc_04_count) = counts[4];
+  LCEC_PIN_S32_SET(hal_data->enc_00_count, counts[0]);
+  LCEC_PIN_S32_SET(hal_data->enc_01_count, counts[1]);
+  LCEC_PIN_S32_SET(hal_data->enc_02_count, counts[2]);
+  LCEC_PIN_S32_SET(hal_data->enc_03_count, counts[3]);
+  LCEC_PIN_S32_SET(hal_data->enc_04_count, counts[4]);
 }
 
 double calculateFvalue(double dac_value, double enc_scale, double dac_scale) {
@@ -612,35 +612,35 @@ void lcec_fr4000_write(lcec_slave_t *slave, long period) {
   EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 5, 1);
 
   // Check for index enable request from HAL
-  if (*(hal_data->enc_00_index_enable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enc_00_index_enable)) {
     // tell hardware to latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 0, 0);
   } else {
     // cancel hardware latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 0, 1);
   }
-  if (*(hal_data->enc_01_index_enable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enc_01_index_enable)) {
     // tell hardware to latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 1, 0);
   } else {
     // cancel hardware latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 1, 1);
   }
-  if (*(hal_data->enc_02_index_enable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enc_02_index_enable)) {
     // tell hardware to latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 2, 0);
   } else {
     // cancel hardware latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 2, 1);
   }
-  if (*(hal_data->enc_03_index_enable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enc_03_index_enable)) {
     // tell hardware to latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 3, 0);
   } else {
     // cancel hardware latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 3, 1);
   }
-  if (*(hal_data->enc_04_index_enable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enc_04_index_enable)) {
     // tell hardware to latch on index
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 4, 0);
   } else {
@@ -648,58 +648,58 @@ void lcec_fr4000_write(lcec_slave_t *slave, long period) {
     EC_WRITE_BIT(&pd[hal_data->off_RESET_FLAG], 4, 1);
   }
 
-  EC_WRITE_BIT(&pd[hal_data->off_dig_out], 6, *(hal_data->OUT_0));
-  EC_WRITE_BIT(&pd[hal_data->off_dig_out], 7, *(hal_data->OUT_1));
+  EC_WRITE_BIT(&pd[hal_data->off_dig_out], 6, LCEC_PIN_BIT_GET(hal_data->OUT_0));
+  EC_WRITE_BIT(&pd[hal_data->off_dig_out], 7, LCEC_PIN_BIT_GET(hal_data->OUT_1));
 
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 0, *(hal_data->ENABLE_24V_0));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 1, *(hal_data->ENABLE_24V_1));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 2, *(hal_data->ENABLE_24V_2));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 3, *(hal_data->ENABLE_24V_3));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 4, *(hal_data->ENABLE_24V_4));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 5, *(hal_data->ENABLE_24V_INVERTER));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 0, LCEC_PIN_BIT_GET(hal_data->ENABLE_24V_0));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 1, LCEC_PIN_BIT_GET(hal_data->ENABLE_24V_1));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 2, LCEC_PIN_BIT_GET(hal_data->ENABLE_24V_2));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 3, LCEC_PIN_BIT_GET(hal_data->ENABLE_24V_3));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 4, LCEC_PIN_BIT_GET(hal_data->ENABLE_24V_4));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_24V], 5, LCEC_PIN_BIT_GET(hal_data->ENABLE_24V_INVERTER));
 
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 0, *(hal_data->ENABLE_5V_0));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 1, *(hal_data->ENABLE_5V_1));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 2, *(hal_data->ENABLE_5V_2));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 3, *(hal_data->ENABLE_5V_3));
-  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 4, *(hal_data->ENABLE_5V_4));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 0, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_0));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 1, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_1));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 2, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_2));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 3, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_3));
+  EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 4, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_4));
 
   fValue = calculateFvalue(*hal_data->dac_00_value, hal_data->enc_00_scale, hal_data->dac_00_scale);
-  *(hal_data->HZ_0) = fabs(fValue);
+  LCEC_PIN_S32_SET(hal_data->HZ_0, fabs(fValue));
   iDir0 = fValue < 0 ? 1 : 0;
 
   fValue = calculateFvalue(*hal_data->dac_01_value, hal_data->enc_01_scale, hal_data->dac_01_scale);
-  *(hal_data->HZ_1) = fabs(fValue);
+  LCEC_PIN_S32_SET(hal_data->HZ_1, fabs(fValue));
   iDir1 = fValue < 0 ? 1 : 0;
 
   fValue = calculateFvalue(*hal_data->dac_02_value, hal_data->enc_02_scale, hal_data->dac_02_scale);
-  *(hal_data->HZ_2) = fabs(fValue);
+  LCEC_PIN_S32_SET(hal_data->HZ_2, fabs(fValue));
   iDir2 = fValue < 0 ? 1 : 0;
 
   fValue = calculateFvalue(*hal_data->dac_03_value, hal_data->enc_03_scale, hal_data->dac_03_scale);
-  *(hal_data->HZ_3) = fabs(fValue);
+  LCEC_PIN_S32_SET(hal_data->HZ_3, fabs(fValue));
   iDir3 = fValue < 0 ? 1 : 0;
 
   fValue = calculateFvalue(*hal_data->dac_04_value, hal_data->enc_04_scale, hal_data->dac_04_scale);
-  *(hal_data->HZ_4) = fabs(fValue);
+  LCEC_PIN_S32_SET(hal_data->HZ_4, fabs(fValue));
   iDir4 = fValue < 0 ? 1 : 0;
 
   EC_WRITE_BIT(&pd[hal_data->off_DIR], 0, iDir0);
-  EC_WRITE_U32(&pd[hal_data->off_PWM], *(hal_data->HZ_0));
+  EC_WRITE_U32(&pd[hal_data->off_PWM], LCEC_PIN_S32_GET(hal_data->HZ_0));
 
   EC_WRITE_BIT(&pd[hal_data->off_DIR], 1, iDir1);
-  EC_WRITE_U32(&pd[hal_data->off_PWM + 4], *(hal_data->HZ_1));
+  EC_WRITE_U32(&pd[hal_data->off_PWM + 4], LCEC_PIN_S32_GET(hal_data->HZ_1));
 
   EC_WRITE_BIT(&pd[hal_data->off_DIR], 2, iDir2);
-  EC_WRITE_U32(&pd[hal_data->off_PWM + 8], *(hal_data->HZ_2));
+  EC_WRITE_U32(&pd[hal_data->off_PWM + 8], LCEC_PIN_S32_GET(hal_data->HZ_2));
 
   EC_WRITE_BIT(&pd[hal_data->off_DIR], 3, iDir3);
-  EC_WRITE_U32(&pd[hal_data->off_PWM + 12], *(hal_data->HZ_3));
+  EC_WRITE_U32(&pd[hal_data->off_PWM + 12], LCEC_PIN_S32_GET(hal_data->HZ_3));
 
   EC_WRITE_BIT(&pd[hal_data->off_DIR], 4, iDir4);
-  EC_WRITE_U32(&pd[hal_data->off_PWM + 16], *(hal_data->HZ_4));
+  EC_WRITE_U32(&pd[hal_data->off_PWM + 16], LCEC_PIN_S32_GET(hal_data->HZ_4));
 
-  fValue = *(hal_data->dac_inverter_value) / 10 * 0x7fff;
+  fValue = LCEC_PIN_FLOAT_GET(hal_data->dac_inverter_value) / 10 * 0x7fff;
 
   EC_WRITE_U16(&pd[hal_data->off_INVERTER], (uint16_t)fValue);
 }

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -664,23 +664,23 @@ void lcec_fr4000_write(lcec_slave_t *slave, long period) {
   EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 3, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_3));
   EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 4, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_4));
 
-  fValue = calculateFvalue(*hal_data->dac_00_value, hal_data->enc_00_scale, hal_data->dac_00_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_00_value), hal_data->enc_00_scale, hal_data->dac_00_scale);
   LCEC_PIN_S32_SET(hal_data->HZ_0, fabs(fValue));
   iDir0 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(*hal_data->dac_01_value, hal_data->enc_01_scale, hal_data->dac_01_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_01_value), hal_data->enc_01_scale, hal_data->dac_01_scale);
   LCEC_PIN_S32_SET(hal_data->HZ_1, fabs(fValue));
   iDir1 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(*hal_data->dac_02_value, hal_data->enc_02_scale, hal_data->dac_02_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_02_value), hal_data->enc_02_scale, hal_data->dac_02_scale);
   LCEC_PIN_S32_SET(hal_data->HZ_2, fabs(fValue));
   iDir2 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(*hal_data->dac_03_value, hal_data->enc_03_scale, hal_data->dac_03_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_03_value), hal_data->enc_03_scale, hal_data->dac_03_scale);
   LCEC_PIN_S32_SET(hal_data->HZ_3, fabs(fValue));
   iDir3 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(*hal_data->dac_04_value, hal_data->enc_04_scale, hal_data->dac_04_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_04_value), hal_data->enc_04_scale, hal_data->dac_04_scale);
   LCEC_PIN_S32_SET(hal_data->HZ_4, fabs(fValue));
   iDir4 = fValue < 0 ? 1 : 0;
 

--- a/src/devices/lcec_epocat.c
+++ b/src/devices/lcec_epocat.c
@@ -79,11 +79,11 @@ typedef struct {
   hal_s32_t *enc_03_count;
   hal_s32_t *enc_04_count;
 
-  hal_float_t enc_00_scale;
-  hal_float_t enc_01_scale;
-  hal_float_t enc_02_scale;
-  hal_float_t enc_03_scale;
-  hal_float_t enc_04_scale;
+  lcec_param_float_t enc_00_scale;
+  lcec_param_float_t enc_01_scale;
+  lcec_param_float_t enc_02_scale;
+  lcec_param_float_t enc_03_scale;
+  lcec_param_float_t enc_04_scale;
 
   hal_bit_t *enc_00_index_enable;
   hal_bit_t *enc_01_index_enable;
@@ -101,11 +101,11 @@ typedef struct {
   hal_bit_t *inverter_forward;
   hal_bit_t *inverter_reverse;
 
-  hal_float_t dac_00_scale;
-  hal_float_t dac_01_scale;
-  hal_float_t dac_02_scale;
-  hal_float_t dac_03_scale;
-  hal_float_t dac_04_scale;
+  lcec_param_float_t dac_00_scale;
+  lcec_param_float_t dac_01_scale;
+  lcec_param_float_t dac_02_scale;
+  lcec_param_float_t dac_03_scale;
+  lcec_param_float_t dac_04_scale;
 
   hal_float_t *adc1;
   hal_float_t *adc2;
@@ -126,17 +126,17 @@ typedef struct {
   unsigned int off_FLAG;
   unsigned int off_RESET_FLAG;
 
-  hal_float_t set_00_position;
-  hal_float_t set_01_position;
-  hal_float_t set_02_position;
-  hal_float_t set_03_position;
-  hal_float_t set_04_position;
+  lcec_param_float_t set_00_position;
+  lcec_param_float_t set_01_position;
+  lcec_param_float_t set_02_position;
+  lcec_param_float_t set_03_position;
+  lcec_param_float_t set_04_position;
 
-  hal_bit_t update_00_position;
-  hal_bit_t update_01_position;
-  hal_bit_t update_02_position;
-  hal_bit_t update_03_position;
-  hal_bit_t update_04_position;
+  lcec_param_bit_t update_00_position;
+  lcec_param_bit_t update_01_position;
+  lcec_param_bit_t update_02_position;
+  lcec_param_bit_t update_03_position;
+  lcec_param_bit_t update_04_position;
 } lcec_fr4000_data_t;
 
 static const lcec_pindesc_t slave_pins[] = {
@@ -425,29 +425,29 @@ int lcec_fr4000_init(int comp_id, lcec_slave_t *slave) {
   counts[3] = 0;
   counts[4] = 0;
 
-  hal_data->enc_00_scale = 1;
-  hal_data->enc_01_scale = 1;
-  hal_data->enc_02_scale = 1;
-  hal_data->enc_03_scale = 1;
-  hal_data->enc_04_scale = 1;
+  LCEC_PARAM_FLOAT_SET(hal_data->enc_00_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->enc_01_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->enc_02_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->enc_03_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->enc_04_scale, 1);
 
-  hal_data->dac_00_scale = 1;
-  hal_data->dac_01_scale = 1;
-  hal_data->dac_02_scale = 1;
-  hal_data->dac_03_scale = 1;
-  hal_data->dac_04_scale = 1;
+  LCEC_PARAM_FLOAT_SET(hal_data->dac_00_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->dac_01_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->dac_02_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->dac_03_scale, 1);
+  LCEC_PARAM_FLOAT_SET(hal_data->dac_04_scale, 1);
 
-  hal_data->set_00_position = 0;
-  hal_data->set_01_position = 0;
-  hal_data->set_02_position = 0;
-  hal_data->set_03_position = 0;
-  hal_data->set_04_position = 0;
+  LCEC_PARAM_FLOAT_SET(hal_data->set_00_position, 0);
+  LCEC_PARAM_FLOAT_SET(hal_data->set_01_position, 0);
+  LCEC_PARAM_FLOAT_SET(hal_data->set_02_position, 0);
+  LCEC_PARAM_FLOAT_SET(hal_data->set_03_position, 0);
+  LCEC_PARAM_FLOAT_SET(hal_data->set_04_position, 0);
 
-  hal_data->update_00_position = false;
-  hal_data->update_01_position = false;
-  hal_data->update_02_position = false;
-  hal_data->update_03_position = false;
-  hal_data->update_04_position = false;
+  LCEC_PARAM_BIT_SET(hal_data->update_00_position, false);
+  LCEC_PARAM_BIT_SET(hal_data->update_01_position, false);
+  LCEC_PARAM_BIT_SET(hal_data->update_02_position, false);
+  LCEC_PARAM_BIT_SET(hal_data->update_03_position, false);
+  LCEC_PARAM_BIT_SET(hal_data->update_04_position, false);
 
   return 0;
 }
@@ -520,38 +520,38 @@ void lcec_fr4000_read(lcec_slave_t *slave, long period) {
     counts[4] = 0;
   }
 
-  if (hal_data->update_00_position == true) {
-    hal_data->update_00_position = false;
+  if (LCEC_PARAM_BIT_GET(hal_data->update_00_position) == true) {
+    LCEC_PARAM_BIT_SET(hal_data->update_00_position, false);
 
-    raw_forced_counts[0] = hal_data->set_00_position / hal_data->enc_00_scale;
+    raw_forced_counts[0] = LCEC_PARAM_FLOAT_GET(hal_data->set_00_position) / LCEC_PARAM_FLOAT_GET(hal_data->enc_00_scale);
 
     counts[0] = (int32_t)raw_forced_counts[0];
   }
-  if (hal_data->update_01_position == true) {
-    hal_data->update_01_position = false;
+  if (LCEC_PARAM_BIT_GET(hal_data->update_01_position) == true) {
+    LCEC_PARAM_BIT_SET(hal_data->update_01_position, false);
 
-    raw_forced_counts[1] = hal_data->set_01_position / hal_data->enc_01_scale;
+    raw_forced_counts[1] = LCEC_PARAM_FLOAT_GET(hal_data->set_01_position) / LCEC_PARAM_FLOAT_GET(hal_data->enc_01_scale);
 
     counts[1] = (int32_t)raw_forced_counts[1];
   }
-  if (hal_data->update_02_position == true) {
-    hal_data->update_02_position = false;
+  if (LCEC_PARAM_BIT_GET(hal_data->update_02_position) == true) {
+    LCEC_PARAM_BIT_SET(hal_data->update_02_position, false);
 
-    raw_forced_counts[2] = hal_data->set_02_position / hal_data->enc_02_scale;
+    raw_forced_counts[2] = LCEC_PARAM_FLOAT_GET(hal_data->set_02_position) / LCEC_PARAM_FLOAT_GET(hal_data->enc_02_scale);
 
     counts[2] = (int32_t)raw_forced_counts[2];
   }
-  if (hal_data->update_03_position == true) {
-    hal_data->update_03_position = false;
+  if (LCEC_PARAM_BIT_GET(hal_data->update_03_position) == true) {
+    LCEC_PARAM_BIT_SET(hal_data->update_03_position, false);
 
-    raw_forced_counts[3] = hal_data->set_03_position / hal_data->enc_03_scale;
+    raw_forced_counts[3] = LCEC_PARAM_FLOAT_GET(hal_data->set_03_position) / LCEC_PARAM_FLOAT_GET(hal_data->enc_03_scale);
 
     counts[3] = (int32_t)raw_forced_counts[3];
   }
-  if (hal_data->update_04_position == true) {
-    hal_data->update_04_position = false;
+  if (LCEC_PARAM_BIT_GET(hal_data->update_04_position) == true) {
+    LCEC_PARAM_BIT_SET(hal_data->update_04_position, false);
 
-    raw_forced_counts[4] = hal_data->set_04_position / hal_data->enc_04_scale;
+    raw_forced_counts[4] = LCEC_PARAM_FLOAT_GET(hal_data->set_04_position) / LCEC_PARAM_FLOAT_GET(hal_data->enc_04_scale);
 
     counts[4] = (int32_t)raw_forced_counts[4];
   }
@@ -571,11 +571,11 @@ void lcec_fr4000_read(lcec_slave_t *slave, long period) {
   counts[4] += (int16_t)(raw_counts[4] - raw_counts_old[4]);
   raw_counts_old[4] = raw_counts[4];
 
-  LCEC_PIN_FLOAT_SET(hal_data->enc_00_position, counts[0] * hal_data->enc_00_scale);
-  LCEC_PIN_FLOAT_SET(hal_data->enc_01_position, counts[1] * hal_data->enc_01_scale);
-  LCEC_PIN_FLOAT_SET(hal_data->enc_02_position, counts[2] * hal_data->enc_02_scale);
-  LCEC_PIN_FLOAT_SET(hal_data->enc_03_position, counts[3] * hal_data->enc_03_scale);
-  LCEC_PIN_FLOAT_SET(hal_data->enc_04_position, counts[4] * hal_data->enc_04_scale);
+  LCEC_PIN_FLOAT_SET(hal_data->enc_00_position, counts[0] * LCEC_PARAM_FLOAT_GET(hal_data->enc_00_scale));
+  LCEC_PIN_FLOAT_SET(hal_data->enc_01_position, counts[1] * LCEC_PARAM_FLOAT_GET(hal_data->enc_01_scale));
+  LCEC_PIN_FLOAT_SET(hal_data->enc_02_position, counts[2] * LCEC_PARAM_FLOAT_GET(hal_data->enc_02_scale));
+  LCEC_PIN_FLOAT_SET(hal_data->enc_03_position, counts[3] * LCEC_PARAM_FLOAT_GET(hal_data->enc_03_scale));
+  LCEC_PIN_FLOAT_SET(hal_data->enc_04_position, counts[4] * LCEC_PARAM_FLOAT_GET(hal_data->enc_04_scale));
 
   LCEC_PIN_S32_SET(hal_data->enc_00_count, counts[0]);
   LCEC_PIN_S32_SET(hal_data->enc_01_count, counts[1]);
@@ -664,23 +664,23 @@ void lcec_fr4000_write(lcec_slave_t *slave, long period) {
   EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 3, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_3));
   EC_WRITE_BIT(&pd[hal_data->off_ENABLE_5V], 4, LCEC_PIN_BIT_GET(hal_data->ENABLE_5V_4));
 
-  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_00_value), hal_data->enc_00_scale, hal_data->dac_00_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_00_value), LCEC_PARAM_FLOAT_GET(hal_data->enc_00_scale), LCEC_PARAM_FLOAT_GET(hal_data->dac_00_scale));
   LCEC_PIN_S32_SET(hal_data->HZ_0, fabs(fValue));
   iDir0 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_01_value), hal_data->enc_01_scale, hal_data->dac_01_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_01_value), LCEC_PARAM_FLOAT_GET(hal_data->enc_01_scale), LCEC_PARAM_FLOAT_GET(hal_data->dac_01_scale));
   LCEC_PIN_S32_SET(hal_data->HZ_1, fabs(fValue));
   iDir1 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_02_value), hal_data->enc_02_scale, hal_data->dac_02_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_02_value), LCEC_PARAM_FLOAT_GET(hal_data->enc_02_scale), LCEC_PARAM_FLOAT_GET(hal_data->dac_02_scale));
   LCEC_PIN_S32_SET(hal_data->HZ_2, fabs(fValue));
   iDir2 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_03_value), hal_data->enc_03_scale, hal_data->dac_03_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_03_value), LCEC_PARAM_FLOAT_GET(hal_data->enc_03_scale), LCEC_PARAM_FLOAT_GET(hal_data->dac_03_scale));
   LCEC_PIN_S32_SET(hal_data->HZ_3, fabs(fValue));
   iDir3 = fValue < 0 ? 1 : 0;
 
-  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_04_value), hal_data->enc_04_scale, hal_data->dac_04_scale);
+  fValue = calculateFvalue(LCEC_PIN_FLOAT_GET(hal_data->dac_04_value), LCEC_PARAM_FLOAT_GET(hal_data->enc_04_scale), LCEC_PARAM_FLOAT_GET(hal_data->dac_04_scale));
   LCEC_PIN_S32_SET(hal_data->HZ_4, fabs(fValue));
   iDir4 = fValue < 0 ? 1 : 0;
 

--- a/src/devices/lcec_ex260.c
+++ b/src/devices/lcec_ex260.c
@@ -87,14 +87,14 @@ static void lcec_ex260_write(lcec_slave_t *slave, long period) {
 
   // set outputs
   for (i = 0, pin = hal_data; i < slave->flags; i++, pin++) {
-    s = *(pin->sol_1a);
-    s |= *(pin->sol_1b) << 1;
-    s |= *(pin->sol_2a) << 2;
-    s |= *(pin->sol_2b) << 3;
-    s |= *(pin->sol_3a) << 4;
-    s |= *(pin->sol_3b) << 5;
-    s |= *(pin->sol_4a) << 6;
-    s |= *(pin->sol_4b) << 7;
+    s = LCEC_PIN_BIT_GET(pin->sol_1a);
+    s |= LCEC_PIN_BIT_GET(pin->sol_1b) << 1;
+    s |= LCEC_PIN_BIT_GET(pin->sol_2a) << 2;
+    s |= LCEC_PIN_BIT_GET(pin->sol_2b) << 3;
+    s |= LCEC_PIN_BIT_GET(pin->sol_3a) << 4;
+    s |= LCEC_PIN_BIT_GET(pin->sol_3b) << 5;
+    s |= LCEC_PIN_BIT_GET(pin->sol_4a) << 6;
+    s |= LCEC_PIN_BIT_GET(pin->sol_4b) << 7;
     EC_WRITE_U8(&pd[pin->pdo_os], s);
   }
 }

--- a/src/devices/lcec_generic.c
+++ b/src/devices/lcec_generic.c
@@ -137,16 +137,16 @@ void lcec_generic_read(lcec_slave_t *slave, long period) {
       case HAL_BIT:
         offset = ((hal_data->pdo_os << 3) | (hal_data->pdo_bp & 0x07)) + hal_data->bitOffset;
         for (j = 0; j < LCEC_CONF_GENERIC_MAX_SUBPINS && hal_data->pin[j] != NULL; j++, offset++) {
-          *((hal_bit_t *)hal_data->pin[j]) = EC_READ_BIT(&pd[offset >> 3], offset & 0x07);
+          LCEC_PIN_BIT_SET((hal_bit_t *)hal_data->pin[j], EC_READ_BIT(&pd[offset >> 3], offset & 0x07));
         }
         break;
 
       case HAL_S32:
-        *((hal_s32_t *)hal_data->pin[0]) = lcec_generic_read_s32(pd, hal_data);
+        LCEC_PIN_S32_SET((hal_s32_t *)hal_data->pin[0], lcec_generic_read_s32(pd, hal_data));
         break;
 
       case HAL_U32:
-        *((hal_u32_t *)hal_data->pin[0]) = lcec_generic_read_u32(pd, hal_data);
+        LCEC_PIN_U32_SET((hal_u32_t *)hal_data->pin[0], lcec_generic_read_u32(pd, hal_data));
         break;
 
       case HAL_FLOAT:
@@ -162,7 +162,7 @@ void lcec_generic_read(lcec_slave_t *slave, long period) {
 
         fval *= hal_data->floatScale;
         fval += hal_data->floatOffset;
-        *((hal_float_t *)hal_data->pin[0]) = fval;
+        LCEC_PIN_FLOAT_SET((hal_float_t *)hal_data->pin[0], fval);
         break;
 
       default:
@@ -190,20 +190,20 @@ void lcec_generic_write(lcec_slave_t *slave, long period) {
       case HAL_BIT:
         offset = ((hal_data->pdo_os << 3) | (hal_data->pdo_bp & 0x07)) + hal_data->bitOffset;
         for (j = 0; j < LCEC_CONF_GENERIC_MAX_SUBPINS && hal_data->pin[j] != NULL; j++, offset++) {
-          EC_WRITE_BIT(&pd[offset >> 3], offset & 0x07, *((hal_bit_t *)hal_data->pin[j]));
+          EC_WRITE_BIT(&pd[offset >> 3], offset & 0x07, LCEC_PIN_BIT_GET((hal_bit_t *)hal_data->pin[j]));
         }
         break;
 
       case HAL_S32:
-        lcec_generic_write_s32(pd, hal_data, *((hal_s32_t *)hal_data->pin[0]));
+        lcec_generic_write_s32(pd, hal_data, LCEC_PIN_S32_GET((hal_s32_t *)hal_data->pin[0]));
         break;
 
       case HAL_U32:
-        lcec_generic_write_u32(pd, hal_data, *((hal_u32_t *)hal_data->pin[0]));
+        lcec_generic_write_u32(pd, hal_data, LCEC_PIN_U32_GET((hal_u32_t *)hal_data->pin[0]));
         break;
 
       case HAL_FLOAT:
-        fval = *((hal_float_t *)hal_data->pin[0]);
+        fval = LCEC_PIN_FLOAT_GET((hal_float_t *)hal_data->pin[0]);
         fval += hal_data->floatOffset;
         fval *= hal_data->floatScale;
 

--- a/src/devices/lcec_il2301.c
+++ b/src/devices/lcec_il2301.c
@@ -387,8 +387,7 @@ static void lcec_il2301_read(lcec_slave_t *slave, long period) {
   if (!slave->state.operational) return;
 
   if (hal_data->state_pdo_valid && hal_data->coupler_state != NULL) {
-    *(hal_data->coupler_state) =
-        EC_READ_U16(pd + hal_data->state_pdo_os);
+    LCEC_PIN_U32_SET(hal_data->coupler_state, EC_READ_U16(pd + hal_data->state_pdo_os));
   }
 
   if (hal_data->din != NULL) lcec_din_read_all(slave, hal_data->din);

--- a/src/devices/lcec_leadshine_stepper.c
+++ b/src/devices/lcec_leadshine_stepper.c
@@ -351,7 +351,7 @@ static void lcec_leadshine_stepper_read(lcec_slave_t *slave, long period) {
   // XXXX: If you need to read device-specific PDOs and set pins, then you should do this here.
   //
   // uint8_t *pd = slave->master->process_data;
-  // *(hal_data->alarm_code) = EC_READ_U16(&pd[hal_data->alarm_code_os]);
+  // LCEC_PIN_U32_SET(hal_data->alarm_code, EC_READ_U16(&pd[hal_data->alarm_code_os]));
 
   lcec_cia402_read_all(slave, hal_data->cia402);
   lcec_din_read_all(slave, hal_data->din);

--- a/src/devices/lcec_ommx2.c
+++ b/src/devices/lcec_ommx2.c
@@ -216,7 +216,7 @@ static void lcec_ommx2_read(lcec_slave_t *slave, long period) {
   // XXXX: If you need to read device-specific PDOs and set pins, then you should do this here.
   //
   // uint8_t *pd = slave->master->process_data;
-  // *(hal_data->alarm_code) = EC_READ_U16(&pd[hal_data->alarm_code_os]);
+  // LCEC_PIN_U32_SET(hal_data->alarm_code, EC_READ_U16(&pd[hal_data->alarm_code_os]));
 
   lcec_cia402_read_all(slave, hal_data->cia402);
   // XXXX: If you want digital in pins, then uncomment this:

--- a/src/devices/lcec_omr1s.c
+++ b/src/devices/lcec_omr1s.c
@@ -94,8 +94,8 @@ typedef struct {
   hal_bit_t *stat_warning;
   hal_bit_t *stat_remote;
 
-  hal_float_t pos_scale;
-  hal_bit_t auto_fault_reset;
+  lcec_param_float_t pos_scale;
+  lcec_param_bit_t auto_fault_reset;
 
   hal_float_t pos_scale_old;
   double pos_scale_rcpt;
@@ -253,28 +253,28 @@ static int lcec_omr1s_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // initialize variables
-  hal_data->pos_scale = (double)OMR1S_PULSES_PER_REV_DEFLT;
-  hal_data->pos_scale_old = hal_data->pos_scale + 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, (double)OMR1S_PULSES_PER_REV_DEFLT);
+  hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) + 1.0;
   hal_data->pos_scale_rcpt = 1.0;
-  hal_data->auto_fault_reset = 1;
+  LCEC_PARAM_BIT_SET(hal_data->auto_fault_reset, 1);
 
   return 0;
 }
 
 static void lcec_omr1s_check_scales(lcec_omr1s_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->pos_scale != hal_data->pos_scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) != hal_data->pos_scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->pos_scale < 1e-20) && (hal_data->pos_scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->pos_scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
     }
 
     // save new scale to detect future changes
-    hal_data->pos_scale_old = hal_data->pos_scale;
+    hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
 
     // we actually want the reciprocal
-    hal_data->pos_scale_rcpt = 1.0 / hal_data->pos_scale;
+    hal_data->pos_scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
   }
 }
 
@@ -360,7 +360,7 @@ static void lcec_omr1s_write(lcec_slave_t *slave, long period) {
     if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) {
       control |= (1 << 7);  // fault reset
     }
-    if (hal_data->auto_fault_reset && enable_edge) {
+    if (LCEC_PARAM_BIT_GET(hal_data->auto_fault_reset) && enable_edge) {
       hal_data->auto_fault_reset_delay = OMR1S_FAULT_AUTORESET_DELAY_NS;
       control |= (1 << 7);  // fault reset
     }
@@ -378,6 +378,6 @@ static void lcec_omr1s_write(lcec_slave_t *slave, long period) {
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // write position command
-  LCEC_PIN_S32_SET(hal_data->pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->pos_cmd) * hal_data->pos_scale));
+  LCEC_PIN_S32_SET(hal_data->pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->pos_cmd) * LCEC_PARAM_FLOAT_GET(hal_data->pos_scale)));
   EC_WRITE_S32(&pd[hal_data->target_pos_pdo_os], LCEC_PIN_S32_GET(hal_data->pos_cmd_raw));
 }

--- a/src/devices/lcec_omr1s.c
+++ b/src/devices/lcec_omr1s.c
@@ -290,56 +290,56 @@ static void lcec_omr1s_read(lcec_slave_t *slave, long period) {
 
   // read status
   status = EC_READ_U16(&pd[hal_data->status_pdo_os]);
-  *(hal_data->stat_switchon_ready) = (status >> 0) & 1;
-  *(hal_data->stat_switched_on) = (status >> 1) & 1;
-  *(hal_data->stat_op_enabled) = (status >> 2) & 1;
-  *(hal_data->stat_fault) = (status >> 3) & 1;
-  *(hal_data->stat_volt_enabled) = (status >> 4) & 1;
-  *(hal_data->stat_quick_stop) = (status >> 5) & 1;
-  *(hal_data->stat_switchon_disabled) = (status >> 6) & 1;
-  *(hal_data->stat_warning) = (status >> 7) & 1;
-  *(hal_data->stat_remote) = (status >> 9) & 1;
+  LCEC_PIN_BIT_SET(hal_data->stat_switchon_ready, (status >> 0) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_switched_on, (status >> 1) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_op_enabled, (status >> 2) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_fault, (status >> 3) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_volt_enabled, (status >> 4) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_quick_stop, (status >> 5) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_switchon_disabled, (status >> 6) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_warning, (status >> 7) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_remote, (status >> 9) & 1);
 
   // read digital inputs
   din = EC_READ_U32(&pd[hal_data->din_pdo_os]);
-  *(hal_data->din_not) = (din >> 0) & 1;
-  *(hal_data->din_pot) = (din >> 1) & 1;
-  *(hal_data->din_dec) = (din >> 2) & 1;
-  *(hal_data->din_pc) = (din >> 16) & 1;
-  *(hal_data->din_ext1) = (din >> 17) & 1;
-  *(hal_data->din_ext2) = (din >> 18) & 1;
-  *(hal_data->din_ext3) = (din >> 19) & 1;
-  *(hal_data->din_mon0) = (din >> 20) & 1;
-  *(hal_data->din_mon1) = (din >> 21) & 1;
-  *(hal_data->din_mon2) = (din >> 22) & 1;
-  *(hal_data->din_pcl) = (din >> 23) & 1;
-  *(hal_data->din_ncl) = (din >> 24) & 1;
-  *(hal_data->din_stop) = (din >> 25) & 1;
-  *(hal_data->din_bkir) = (din >> 26) & 1;
-  *(hal_data->din_sf1) = (din >> 27) & 1;
-  *(hal_data->din_sf2) = (din >> 28) & 1;
-  *(hal_data->din_edm) = (din >> 29) & 1;
+  LCEC_PIN_BIT_SET(hal_data->din_not, (din >> 0) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_pot, (din >> 1) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_dec, (din >> 2) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_pc, (din >> 16) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ext1, (din >> 17) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ext2, (din >> 18) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ext3, (din >> 19) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_mon0, (din >> 20) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_mon1, (din >> 21) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_mon2, (din >> 22) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_pcl, (din >> 23) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ncl, (din >> 24) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_stop, (din >> 25) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_bkir, (din >> 26) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_sf1, (din >> 27) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_sf2, (din >> 28) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_edm, (din >> 29) & 1);
 
   // read position feedback
-  *(hal_data->pos_fb_raw) = EC_READ_S32(&pd[hal_data->curr_pos_pdo_os]);
-  *(hal_data->pos_fb) = ((double)*(hal_data->pos_fb_raw)) * hal_data->pos_scale_rcpt;
+  LCEC_PIN_S32_SET(hal_data->pos_fb_raw, EC_READ_S32(&pd[hal_data->curr_pos_pdo_os]));
+  LCEC_PIN_FLOAT_SET(hal_data->pos_fb, ((double)LCEC_PIN_S32_GET(hal_data->pos_fb_raw)) * hal_data->pos_scale_rcpt);
 
   // read following error
-  *(hal_data->pos_ferr_raw) = EC_READ_S32(&pd[hal_data->curr_ferr_pdo_os]);
-  *(hal_data->pos_ferr) = ((double)*(hal_data->pos_ferr_raw)) * hal_data->pos_scale_rcpt;
+  LCEC_PIN_S32_SET(hal_data->pos_ferr_raw, EC_READ_S32(&pd[hal_data->curr_ferr_pdo_os]));
+  LCEC_PIN_FLOAT_SET(hal_data->pos_ferr, ((double)LCEC_PIN_S32_GET(hal_data->pos_ferr_raw)) * hal_data->pos_scale_rcpt);
 
   // read torque error
-  *(hal_data->torque_fb) = ((double)EC_READ_S16(&pd[hal_data->curr_torque_pdo_os])) * 0.1;
+  LCEC_PIN_FLOAT_SET(hal_data->torque_fb, ((double)EC_READ_S16(&pd[hal_data->curr_torque_pdo_os])) * 0.1);
 
   // read error code
-  *(hal_data->error_code) = EC_READ_U16(&pd[hal_data->error_pdo_os]);
+  LCEC_PIN_U32_SET(hal_data->error_code, EC_READ_U16(&pd[hal_data->error_pdo_os]));
 
   // update fault output
   if (hal_data->auto_fault_reset_delay > 0) {
     hal_data->auto_fault_reset_delay -= period;
-    *(hal_data->fault) = 0;
+    LCEC_PIN_BIT_SET(hal_data->fault, 0);
   } else {
-    *(hal_data->fault) = *(hal_data->stat_fault) && *(hal_data->enable);
+    LCEC_PIN_BIT_SET(hal_data->fault, LCEC_PIN_BIT_GET(hal_data->stat_fault) && LCEC_PIN_BIT_GET(hal_data->enable));
   }
 }
 
@@ -351,13 +351,13 @@ static void lcec_omr1s_write(lcec_slave_t *slave, long period) {
   uint16_t control;
 
   // detect enable edge
-  enable_edge = *(hal_data->enable) && !hal_data->enable_old;
-  hal_data->enable_old = *(hal_data->enable);
+  enable_edge = LCEC_PIN_BIT_GET(hal_data->enable) && !hal_data->enable_old;
+  hal_data->enable_old = LCEC_PIN_BIT_GET(hal_data->enable);
 
   // write control register
   control = (1 << 2);  // quick stop is not supported
-  if (*(hal_data->stat_fault)) {
-    if (*(hal_data->fault_reset)) {
+  if (LCEC_PIN_BIT_GET(hal_data->stat_fault)) {
+    if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) {
       control |= (1 << 7);  // fault reset
     }
     if (hal_data->auto_fault_reset && enable_edge) {
@@ -365,11 +365,11 @@ static void lcec_omr1s_write(lcec_slave_t *slave, long period) {
       control |= (1 << 7);  // fault reset
     }
   } else {
-    if (*(hal_data->enable)) {
+    if (LCEC_PIN_BIT_GET(hal_data->enable)) {
       control |= (1 << 1);  // enable voltage
-      if (*(hal_data->stat_switchon_ready)) {
+      if (LCEC_PIN_BIT_GET(hal_data->stat_switchon_ready)) {
         control |= (1 << 0);  // switch on
-        if (*(hal_data->stat_switched_on)) {
+        if (LCEC_PIN_BIT_GET(hal_data->stat_switched_on)) {
           control |= (1 << 3);  // enable op
         }
       }
@@ -378,6 +378,6 @@ static void lcec_omr1s_write(lcec_slave_t *slave, long period) {
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // write position command
-  *(hal_data->pos_cmd_raw) = (int32_t)(*(hal_data->pos_cmd) * hal_data->pos_scale);
-  EC_WRITE_S32(&pd[hal_data->target_pos_pdo_os], *(hal_data->pos_cmd_raw));
+  LCEC_PIN_S32_SET(hal_data->pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->pos_cmd) * hal_data->pos_scale));
+  EC_WRITE_S32(&pd[hal_data->target_pos_pdo_os], LCEC_PIN_S32_GET(hal_data->pos_cmd_raw));
 }

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -321,56 +321,56 @@ static void lcec_omrg5_read(lcec_slave_t *slave, long period) {
 
   // read status
   status = EC_READ_U16(&pd[hal_data->status_pdo_os]);
-  *(hal_data->stat_switchon_ready) = (status >> 0) & 1;
-  *(hal_data->stat_switched_on) = (status >> 1) & 1;
-  *(hal_data->stat_op_enabled) = (status >> 2) & 1;
-  *(hal_data->stat_fault) = (status >> 3) & 1;
-  *(hal_data->stat_volt_enabled) = (status >> 4) & 1;
-  *(hal_data->stat_quick_stop) = (status >> 5) & 1;
-  *(hal_data->stat_switchon_disabled) = (status >> 6) & 1;
-  *(hal_data->stat_warning) = (status >> 7) & 1;
-  *(hal_data->stat_remote) = (status >> 9) & 1;
+  LCEC_PIN_BIT_SET(hal_data->stat_switchon_ready, (status >> 0) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_switched_on, (status >> 1) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_op_enabled, (status >> 2) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_fault, (status >> 3) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_volt_enabled, (status >> 4) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_quick_stop, (status >> 5) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_switchon_disabled, (status >> 6) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_warning, (status >> 7) & 1);
+  LCEC_PIN_BIT_SET(hal_data->stat_remote, (status >> 9) & 1);
 
   // read digital inputs
   din = EC_READ_U32(&pd[hal_data->din_pdo_os]);
-  *(hal_data->din_not) = (din >> 0) & 1;
-  *(hal_data->din_pot) = (din >> 1) & 1;
-  *(hal_data->din_dec) = (din >> 2) & 1;
-  *(hal_data->din_pc) = (din >> 16) & 1;
-  *(hal_data->din_ext1) = (din >> 17) & 1;
-  *(hal_data->din_ext2) = (din >> 18) & 1;
-  *(hal_data->din_ext3) = (din >> 19) & 1;
-  *(hal_data->din_mon0) = (din >> 20) & 1;
-  *(hal_data->din_mon1) = (din >> 21) & 1;
-  *(hal_data->din_mon2) = (din >> 22) & 1;
-  *(hal_data->din_pcl) = (din >> 23) & 1;
-  *(hal_data->din_ncl) = (din >> 24) & 1;
-  *(hal_data->din_stop) = (din >> 25) & 1;
-  *(hal_data->din_bkir) = (din >> 26) & 1;
-  *(hal_data->din_sf1) = (din >> 27) & 1;
-  *(hal_data->din_sf2) = (din >> 28) & 1;
-  *(hal_data->din_edm) = (din >> 29) & 1;
+  LCEC_PIN_BIT_SET(hal_data->din_not, (din >> 0) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_pot, (din >> 1) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_dec, (din >> 2) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_pc, (din >> 16) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ext1, (din >> 17) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ext2, (din >> 18) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ext3, (din >> 19) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_mon0, (din >> 20) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_mon1, (din >> 21) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_mon2, (din >> 22) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_pcl, (din >> 23) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_ncl, (din >> 24) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_stop, (din >> 25) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_bkir, (din >> 26) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_sf1, (din >> 27) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_sf2, (din >> 28) & 1);
+  LCEC_PIN_BIT_SET(hal_data->din_edm, (din >> 29) & 1);
 
   // read position feedback
-  *(hal_data->pos_fb_raw) = EC_READ_S32(&pd[hal_data->curr_pos_pdo_os]);
-  *(hal_data->pos_fb) = ((double)*(hal_data->pos_fb_raw)) * hal_data->pos_scale_rcpt;
+  LCEC_PIN_S32_SET(hal_data->pos_fb_raw, EC_READ_S32(&pd[hal_data->curr_pos_pdo_os]));
+  LCEC_PIN_FLOAT_SET(hal_data->pos_fb, ((double)LCEC_PIN_S32_GET(hal_data->pos_fb_raw)) * hal_data->pos_scale_rcpt);
 
   // read following error
-  *(hal_data->pos_ferr_raw) = EC_READ_S32(&pd[hal_data->curr_ferr_pdo_os]);
-  *(hal_data->pos_ferr) = ((double)*(hal_data->pos_ferr_raw)) * hal_data->pos_scale_rcpt;
+  LCEC_PIN_S32_SET(hal_data->pos_ferr_raw, EC_READ_S32(&pd[hal_data->curr_ferr_pdo_os]));
+  LCEC_PIN_FLOAT_SET(hal_data->pos_ferr, ((double)LCEC_PIN_S32_GET(hal_data->pos_ferr_raw)) * hal_data->pos_scale_rcpt);
 
   // read torque error
-  *(hal_data->torque_fb) = ((double)EC_READ_S16(&pd[hal_data->curr_torque_pdo_os])) * 0.1;
+  LCEC_PIN_FLOAT_SET(hal_data->torque_fb, ((double)EC_READ_S16(&pd[hal_data->curr_torque_pdo_os])) * 0.1);
 
   // read error code
-  *(hal_data->error_code) = EC_READ_U16(&pd[hal_data->error_pdo_os]);
+  LCEC_PIN_U32_SET(hal_data->error_code, EC_READ_U16(&pd[hal_data->error_pdo_os]));
 
   // update fault output
   if (hal_data->auto_fault_reset_delay > 0) {
     hal_data->auto_fault_reset_delay -= period;
-    *(hal_data->fault) = 0;
+    LCEC_PIN_BIT_SET(hal_data->fault, 0);
   } else {
-    *(hal_data->fault) = *(hal_data->stat_fault) && *(hal_data->enable);
+    LCEC_PIN_BIT_SET(hal_data->fault, LCEC_PIN_BIT_GET(hal_data->stat_fault) && LCEC_PIN_BIT_GET(hal_data->enable));
   }
 }
 
@@ -382,13 +382,13 @@ static void lcec_omrg5_write(lcec_slave_t *slave, long period) {
   uint16_t control;
 
   // detect enable edge
-  enable_edge = *(hal_data->enable) && !hal_data->enable_old;
-  hal_data->enable_old = *(hal_data->enable);
+  enable_edge = LCEC_PIN_BIT_GET(hal_data->enable) && !hal_data->enable_old;
+  hal_data->enable_old = LCEC_PIN_BIT_GET(hal_data->enable);
 
   // write control register
   control = (1 << 2);  // quick stop is not supported
-  if (*(hal_data->stat_fault)) {
-    if (*(hal_data->fault_reset)) {
+  if (LCEC_PIN_BIT_GET(hal_data->stat_fault)) {
+    if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) {
       control |= (1 << 7);  // fault reset
     }
     if (hal_data->auto_fault_reset && enable_edge) {
@@ -396,11 +396,11 @@ static void lcec_omrg5_write(lcec_slave_t *slave, long period) {
       control |= (1 << 7);  // fault reset
     }
   } else {
-    if (*(hal_data->enable)) {
+    if (LCEC_PIN_BIT_GET(hal_data->enable)) {
       control |= (1 << 1);  // enable voltage
-      if (*(hal_data->stat_switchon_ready)) {
+      if (LCEC_PIN_BIT_GET(hal_data->stat_switchon_ready)) {
         control |= (1 << 0);  // switch on
-        if (*(hal_data->stat_switched_on)) {
+        if (LCEC_PIN_BIT_GET(hal_data->stat_switched_on)) {
           control |= (1 << 3);  // enable op
         }
       }
@@ -409,6 +409,6 @@ static void lcec_omrg5_write(lcec_slave_t *slave, long period) {
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // write position command
-  *(hal_data->pos_cmd_raw) = (int32_t)(*(hal_data->pos_cmd) * hal_data->pos_scale);
-  EC_WRITE_S32(&pd[hal_data->target_pos_pdo_os], *(hal_data->pos_cmd_raw));
+  LCEC_PIN_S32_SET(hal_data->pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->pos_cmd) * hal_data->pos_scale));
+  EC_WRITE_S32(&pd[hal_data->target_pos_pdo_os], LCEC_PIN_S32_GET(hal_data->pos_cmd_raw));
 }

--- a/src/devices/lcec_omrg5.c
+++ b/src/devices/lcec_omrg5.c
@@ -125,8 +125,8 @@ typedef struct {
   hal_bit_t *stat_warning;
   hal_bit_t *stat_remote;
 
-  hal_float_t pos_scale;
-  hal_bit_t auto_fault_reset;
+  lcec_param_float_t pos_scale;
+  lcec_param_bit_t auto_fault_reset;
 
   hal_float_t pos_scale_old;
   double pos_scale_rcpt;
@@ -284,28 +284,28 @@ static int lcec_omrg5_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // initialize variables
-  hal_data->pos_scale = (double)OMRG5_PULSES_PER_REV_DEFLT;
-  hal_data->pos_scale_old = hal_data->pos_scale + 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, (double)OMRG5_PULSES_PER_REV_DEFLT);
+  hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) + 1.0;
   hal_data->pos_scale_rcpt = 1.0;
-  hal_data->auto_fault_reset = 1;
+  LCEC_PARAM_BIT_SET(hal_data->auto_fault_reset, 1);
 
   return 0;
 }
 
 static void lcec_omrg5_check_scales(lcec_omrg5_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->pos_scale != hal_data->pos_scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) != hal_data->pos_scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->pos_scale < 1e-20) && (hal_data->pos_scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->pos_scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
     }
 
     // save new scale to detect future changes
-    hal_data->pos_scale_old = hal_data->pos_scale;
+    hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
 
     // we actually want the reciprocal
-    hal_data->pos_scale_rcpt = 1.0 / hal_data->pos_scale;
+    hal_data->pos_scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
   }
 }
 
@@ -391,7 +391,7 @@ static void lcec_omrg5_write(lcec_slave_t *slave, long period) {
     if (LCEC_PIN_BIT_GET(hal_data->fault_reset)) {
       control |= (1 << 7);  // fault reset
     }
-    if (hal_data->auto_fault_reset && enable_edge) {
+    if (LCEC_PARAM_BIT_GET(hal_data->auto_fault_reset) && enable_edge) {
       hal_data->auto_fault_reset_delay = OMRG5_FAULT_AUTORESET_DELAY_NS;
       control |= (1 << 7);  // fault reset
     }
@@ -409,6 +409,6 @@ static void lcec_omrg5_write(lcec_slave_t *slave, long period) {
   EC_WRITE_U16(&pd[hal_data->control_pdo_os], control);
 
   // write position command
-  LCEC_PIN_S32_SET(hal_data->pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->pos_cmd) * hal_data->pos_scale));
+  LCEC_PIN_S32_SET(hal_data->pos_cmd_raw, (int32_t)(LCEC_PIN_FLOAT_GET(hal_data->pos_cmd) * LCEC_PARAM_FLOAT_GET(hal_data->pos_scale)));
   EC_WRITE_S32(&pd[hal_data->target_pos_pdo_os], LCEC_PIN_S32_GET(hal_data->pos_cmd_raw));
 }

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -281,8 +281,8 @@ static void lcec_ph3lm2rm_read(lcec_slave_t *slave, long period) {
   for (i = 0, lm = hal_data->lms; i < LCEC_PH3LM2RM_LM_COUNT; i++, lm++) {
     lcec_ph3lm2rm_enc_read(pd, &lm->ch);
     LCEC_PIN_U32_SET(lm->signal_level, EC_READ_U32(&pd[lm->signal_level_os]));
-    LCEC_PIN_BIT_SET(lm->signal_level_warn, lm->signal_level_warn_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < LCEC_PARAM_U32_GET(lm->signal_level_warn_val));
-    LCEC_PIN_BIT_SET(lm->signal_level_err, lm->signal_level_err_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < LCEC_PARAM_U32_GET(lm->signal_level_err_val));
+    LCEC_PIN_BIT_SET(lm->signal_level_warn, LCEC_PARAM_U32_GET(lm->signal_level_warn_val) > 0 && LCEC_PIN_U32_GET(lm->signal_level) < LCEC_PARAM_U32_GET(lm->signal_level_warn_val));
+    LCEC_PIN_BIT_SET(lm->signal_level_err, LCEC_PARAM_U32_GET(lm->signal_level_err_val) > 0 && LCEC_PIN_U32_GET(lm->signal_level) < LCEC_PARAM_U32_GET(lm->signal_level_err_val));
   }
 
   for (i = 0, rm = hal_data->rms; i < LCEC_PH3LM2RM_RM_COUNT; i++, rm++) {

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -42,7 +42,7 @@ typedef struct {
   hal_bit_t *latch_state;
   hal_bit_t *latch_state_not;
 
-  hal_float_t scale;
+  lcec_param_float_t scale;
 
   lcec_class_enc_data_t enc;
 
@@ -68,8 +68,8 @@ typedef struct {
   hal_bit_t *signal_level_warn;
   hal_bit_t *signal_level_err;
 
-  hal_u32_t signal_level_warn_val;
-  hal_u32_t signal_level_err_val;
+  lcec_param_u32_t signal_level_warn_val;
+  lcec_param_u32_t signal_level_err_val;
 
   unsigned int signal_level_os;
 } lcec_ph3lm2rm_lm_data_t;
@@ -204,7 +204,7 @@ static int lcec_ph3lm2rm_enc_init(lcec_slave_t *slave, lcec_ph3lm2rm_enc_data_t 
   }
 
   // initialize variables
-  hal_data->scale = scale;
+  LCEC_PARAM_FLOAT_SET(hal_data->scale, scale);
 
   return 0;
 }
@@ -281,8 +281,8 @@ static void lcec_ph3lm2rm_read(lcec_slave_t *slave, long period) {
   for (i = 0, lm = hal_data->lms; i < LCEC_PH3LM2RM_LM_COUNT; i++, lm++) {
     lcec_ph3lm2rm_enc_read(pd, &lm->ch);
     LCEC_PIN_U32_SET(lm->signal_level, EC_READ_U32(&pd[lm->signal_level_os]));
-    LCEC_PIN_BIT_SET(lm->signal_level_warn, lm->signal_level_warn_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < lm->signal_level_warn_val);
-    LCEC_PIN_BIT_SET(lm->signal_level_err, lm->signal_level_err_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < lm->signal_level_err_val);
+    LCEC_PIN_BIT_SET(lm->signal_level_warn, lm->signal_level_warn_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < LCEC_PARAM_U32_GET(lm->signal_level_warn_val));
+    LCEC_PIN_BIT_SET(lm->signal_level_err, lm->signal_level_err_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < LCEC_PARAM_U32_GET(lm->signal_level_err_val));
   }
 
   for (i = 0, rm = hal_data->rms; i < LCEC_PH3LM2RM_RM_COUNT; i++, rm++) {
@@ -304,7 +304,7 @@ static void lcec_ph3lm2rm_enc_read(uint8_t *pd, lcec_ph3lm2rm_enc_data_t *ch) {
   latch = EC_READ_U32(&pd[ch->latch_os]);
 
   // update encoder
-  class_enc_update(&ch->enc, 0, ch->scale, counter, latch, LCEC_PIN_BIT_GET(ch->latch_valid));
+  class_enc_update(&ch->enc, 0, LCEC_PARAM_FLOAT_GET(ch->scale), counter, latch, LCEC_PIN_BIT_GET(ch->latch_valid));
 
   // reset latch enable, if captured
   if (LCEC_PIN_BIT_GET(ch->latch_valid)) {

--- a/src/devices/lcec_ph3lm2rm.c
+++ b/src/devices/lcec_ph3lm2rm.c
@@ -276,13 +276,13 @@ static void lcec_ph3lm2rm_read(lcec_slave_t *slave, long period) {
   lcec_ph3lm2rm_rm_data_t *rm;
   lcec_ph3lm2rm_lm_data_t *lm;
 
-  *(hal_data->sync_locked) = EC_READ_BIT(&pd[hal_data->sync_locked_os], hal_data->sync_locked_bp);
+  LCEC_PIN_BIT_SET(hal_data->sync_locked, EC_READ_BIT(&pd[hal_data->sync_locked_os], hal_data->sync_locked_bp));
 
   for (i = 0, lm = hal_data->lms; i < LCEC_PH3LM2RM_LM_COUNT; i++, lm++) {
     lcec_ph3lm2rm_enc_read(pd, &lm->ch);
-    *(lm->signal_level) = EC_READ_U32(&pd[lm->signal_level_os]);
-    *(lm->signal_level_warn) = lm->signal_level_warn_val > 0 && *(lm->signal_level) < lm->signal_level_warn_val;
-    *(lm->signal_level_err) = lm->signal_level_err_val > 0 && *(lm->signal_level) < lm->signal_level_err_val;
+    LCEC_PIN_U32_SET(lm->signal_level, EC_READ_U32(&pd[lm->signal_level_os]));
+    LCEC_PIN_BIT_SET(lm->signal_level_warn, lm->signal_level_warn_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < lm->signal_level_warn_val);
+    LCEC_PIN_BIT_SET(lm->signal_level_err, lm->signal_level_err_val > 0 && LCEC_PIN_U32_GET(lm->signal_level) < lm->signal_level_err_val);
   }
 
   for (i = 0, rm = hal_data->rms; i < LCEC_PH3LM2RM_RM_COUNT; i++, rm++) {
@@ -294,22 +294,22 @@ static void lcec_ph3lm2rm_enc_read(uint8_t *pd, lcec_ph3lm2rm_enc_data_t *ch) {
   uint32_t counter, latch;
 
   // read bit values
-  *(ch->error) = EC_READ_BIT(&pd[ch->error_os], ch->error_bp);
-  *(ch->latch_valid) = EC_READ_BIT(&pd[ch->latch_valid_os], ch->latch_valid_bp);
-  *(ch->latch_state) = EC_READ_BIT(&pd[ch->latch_state_os], ch->latch_state_bp);
-  *(ch->latch_state_not) = !*(ch->latch_state);
+  LCEC_PIN_BIT_SET(ch->error, EC_READ_BIT(&pd[ch->error_os], ch->error_bp));
+  LCEC_PIN_BIT_SET(ch->latch_valid, EC_READ_BIT(&pd[ch->latch_valid_os], ch->latch_valid_bp));
+  LCEC_PIN_BIT_SET(ch->latch_state, EC_READ_BIT(&pd[ch->latch_state_os], ch->latch_state_bp));
+  LCEC_PIN_BIT_SET(ch->latch_state_not, !LCEC_PIN_BIT_GET(ch->latch_state));
 
   // read counter values
   counter = EC_READ_U32(&pd[ch->counter_os]);
   latch = EC_READ_U32(&pd[ch->latch_os]);
 
   // update encoder
-  class_enc_update(&ch->enc, 0, ch->scale, counter, latch, *(ch->latch_valid));
+  class_enc_update(&ch->enc, 0, ch->scale, counter, latch, LCEC_PIN_BIT_GET(ch->latch_valid));
 
   // reset latch enable, if captured
-  if (*(ch->latch_valid)) {
-    *(ch->latch_ena_pos) = 0;
-    *(ch->latch_ena_neg) = 0;
+  if (LCEC_PIN_BIT_GET(ch->latch_valid)) {
+    LCEC_PIN_BIT_SET(ch->latch_ena_pos, 0);
+    LCEC_PIN_BIT_SET(ch->latch_ena_neg, 0);
   }
 }
 
@@ -321,7 +321,7 @@ static void lcec_ph3lm2rm_write(lcec_slave_t *slave, long period) {
   lcec_ph3lm2rm_rm_data_t *rm;
   lcec_ph3lm2rm_lm_data_t *lm;
 
-  EC_WRITE_BIT(&pd[hal_data->err_reset_os], hal_data->err_reset_bp, *(hal_data->err_reset));
+  EC_WRITE_BIT(&pd[hal_data->err_reset_os], hal_data->err_reset_bp, LCEC_PIN_BIT_GET(hal_data->err_reset));
 
   for (i = 0, lm = hal_data->lms; i < LCEC_PH3LM2RM_LM_COUNT; i++, lm++) {
     lcec_ph3lm2rm_enc_write(pd, &lm->ch);
@@ -329,12 +329,12 @@ static void lcec_ph3lm2rm_write(lcec_slave_t *slave, long period) {
 
   for (i = 0, rm = hal_data->rms; i < LCEC_PH3LM2RM_RM_COUNT; i++, rm++) {
     lcec_ph3lm2rm_enc_write(pd, &rm->ch);
-    EC_WRITE_BIT(&pd[rm->latch_sel_idx_os], rm->latch_sel_idx_bp, *(rm->latch_sel_idx));
+    EC_WRITE_BIT(&pd[rm->latch_sel_idx_os], rm->latch_sel_idx_bp, LCEC_PIN_BIT_GET(rm->latch_sel_idx));
   }
 }
 
 static void lcec_ph3lm2rm_enc_write(uint8_t *pd, lcec_ph3lm2rm_enc_data_t *ch) {
   // write bit values
-  EC_WRITE_BIT(&pd[ch->latch_ena_pos_os], ch->latch_ena_pos_bp, *(ch->latch_ena_pos));
-  EC_WRITE_BIT(&pd[ch->latch_ena_neg_os], ch->latch_ena_neg_bp, *(ch->latch_ena_neg));
+  EC_WRITE_BIT(&pd[ch->latch_ena_pos_os], ch->latch_ena_pos_bp, LCEC_PIN_BIT_GET(ch->latch_ena_pos));
+  EC_WRITE_BIT(&pd[ch->latch_ena_neg_os], ch->latch_ena_neg_bp, LCEC_PIN_BIT_GET(ch->latch_ena_neg));
 }

--- a/src/devices/lcec_rtec.c
+++ b/src/devices/lcec_rtec.c
@@ -583,9 +583,9 @@ static void lcec_rtec_read(lcec_slave_t *slave, long period) {
   }
 
   if (!(slave->flags & F_NOEXTRAS)) {
-    *(hal_data->alarm_code) = EC_READ_U16(&pd[hal_data->alarm_code_os]);
-    *(hal_data->status_code) = EC_READ_U16(&pd[hal_data->status_code_os]);
-    *(hal_data->voltage) = EC_READ_U16(&pd[hal_data->voltage_os]) / 100.0;
+    LCEC_PIN_U32_SET(hal_data->alarm_code, EC_READ_U16(&pd[hal_data->alarm_code_os]));
+    LCEC_PIN_U32_SET(hal_data->status_code, EC_READ_U16(&pd[hal_data->status_code_os]));
+    LCEC_PIN_FLOAT_SET(hal_data->voltage, EC_READ_U16(&pd[hal_data->voltage_os]) / 100.0);
   }
   lcec_cia402_read_all(slave, hal_data->cia402);
 }

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -360,7 +360,7 @@ static int lcec_stmds5k_init(int comp_id, lcec_slave_t *slave) {
   }
 
   // set default pin values
-  *(hal_data->torque_lim) = 1.0;
+  LCEC_PIN_FLOAT_SET(hal_data->torque_lim, 1.0);
 
   // initialize variables
   hal_data->torque_reference = sdo_torque_reference;
@@ -424,13 +424,13 @@ static void lcec_stmds5k_read(lcec_slave_t *slave, long period) {
 
   // wait for slave to be operational
   if (!slave->state.operational) {
-    *(hal_data->ready) = 0;
-    *(hal_data->error) = 1;
-    *(hal_data->loc_ena) = 0;
-    *(hal_data->toggle) = 0;
-    *(hal_data->stopped) = 0;
-    *(hal_data->at_speed) = 0;
-    *(hal_data->overload) = 0;
+    LCEC_PIN_BIT_SET(hal_data->ready, 0);
+    LCEC_PIN_BIT_SET(hal_data->error, 1);
+    LCEC_PIN_BIT_SET(hal_data->loc_ena, 0);
+    LCEC_PIN_BIT_SET(hal_data->toggle, 0);
+    LCEC_PIN_BIT_SET(hal_data->stopped, 0);
+    LCEC_PIN_BIT_SET(hal_data->at_speed, 0);
+    LCEC_PIN_BIT_SET(hal_data->overload, 0);
     return;
   }
 
@@ -439,32 +439,32 @@ static void lcec_stmds5k_read(lcec_slave_t *slave, long period) {
 
   // read device state
   dev_state = EC_READ_U8(&pd[hal_data->dev_state_pdo_os]);
-  *(hal_data->ready) = (dev_state >> 0) & 0x01;
-  *(hal_data->error) = (dev_state >> 1) & 0x01;
-  *(hal_data->loc_ena) = (dev_state >> 6) & 0x01;
-  *(hal_data->toggle) = (dev_state >> 7) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->ready, (dev_state >> 0) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->error, (dev_state >> 1) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->loc_ena, (dev_state >> 6) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->toggle, (dev_state >> 7) & 0x01);
 
   // read speed state
   speed_state = EC_READ_U16(&pd[hal_data->speed_state_pdo_os]);
-  *(hal_data->stopped) = (speed_state >> 0) & 0x01;
-  *(hal_data->at_speed) = (speed_state >> 1) & 0x01;
-  *(hal_data->overload) = (speed_state >> 2) & 0x01;
+  LCEC_PIN_BIT_SET(hal_data->stopped, (speed_state >> 0) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->at_speed, (speed_state >> 1) & 0x01);
+  LCEC_PIN_BIT_SET(hal_data->overload, (speed_state >> 2) & 0x01);
 
   // read current speed
   speed_raw = EC_READ_S16(&pd[hal_data->speed_mot_pdo_os]);
   rpm = hal_data->speed_max_rpm * (double)speed_raw * STMDS5K_PCT_REG_DIV;
-  *(hal_data->vel_fb_rpm) = rpm;
-  *(hal_data->vel_fb_rpm_abs) = fabs(rpm);
-  *(hal_data->vel_fb) = rpm * STMDS5K_RPM_DIV * hal_data->pos_scale_rcpt;
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm, rpm);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(rpm));
+  LCEC_PIN_FLOAT_SET(hal_data->vel_fb, rpm * STMDS5K_RPM_DIV * hal_data->pos_scale_rcpt);
 
   // read torque
   // E02 : torque motor filterd (x 0,1 Nm)
   torque_raw = EC_READ_S16(&pd[hal_data->torque_mot_pdo_os]);
   torque = (double)torque_raw * STMDS5K_TORQUE_DIV;
-  *(hal_data->torque_fb_pct) = fabs(torque * 100.0);
+  LCEC_PIN_FLOAT_SET(hal_data->torque_fb_pct, fabs(torque * 100.0));
   torque = torque * hal_data->torque_reference;
-  *(hal_data->torque_fb) = torque;
-  *(hal_data->torque_fb_abs) = fabs(torque);
+  LCEC_PIN_FLOAT_SET(hal_data->torque_fb, torque);
+  LCEC_PIN_FLOAT_SET(hal_data->torque_fb_abs, fabs(torque));
 
   // update position feedback
   pos_cnt = EC_READ_U32(&pd[hal_data->pos_mot_pdo_os]);
@@ -488,31 +488,31 @@ static void lcec_stmds5k_write(lcec_slave_t *slave, long period) {
 
   // write dev ctrl
   dev_ctrl = 0;
-  if (*(hal_data->enable)) {
+  if (LCEC_PIN_BIT_GET(hal_data->enable)) {
     dev_ctrl |= (1 << 0);
   }
-  if (*(hal_data->err_reset)) {
+  if (LCEC_PIN_BIT_GET(hal_data->err_reset)) {
     dev_ctrl |= (1 << 1);
   }
-  if (*(hal_data->fast_ramp)) {
+  if (LCEC_PIN_BIT_GET(hal_data->fast_ramp)) {
     dev_ctrl |= (1 << 2);
   }
-  if (*(hal_data->brake)) {
+  if (LCEC_PIN_BIT_GET(hal_data->brake)) {
     dev_ctrl |= (1 << 6);
   }
-  if (!*(hal_data->toggle)) {
+  if (!LCEC_PIN_BIT_GET(hal_data->toggle)) {
     dev_ctrl |= (1 << 7);
   }
   EC_WRITE_U8(&pd[hal_data->dev_ctrl_pdo_os], dev_ctrl);
 
   // set maximum torque
-  if (*(hal_data->torque_lim) > 2.0) {
-    *(hal_data->torque_lim) = 2.0;
+  if (LCEC_PIN_FLOAT_GET(hal_data->torque_lim) > 2.0) {
+    LCEC_PIN_FLOAT_SET(hal_data->torque_lim, 2.0);
   }
-  if (*(hal_data->torque_lim) < -2.0) {
-    *(hal_data->torque_lim) = -2.0;
+  if (LCEC_PIN_FLOAT_GET(hal_data->torque_lim) < -2.0) {
+    LCEC_PIN_FLOAT_SET(hal_data->torque_lim, -2.0);
   }
-  torque_raw = *(hal_data->torque_lim) * STMDS5K_PCT_REG_FACTOR;
+  torque_raw = LCEC_PIN_FLOAT_GET(hal_data->torque_lim) * STMDS5K_PCT_REG_FACTOR;
   if (torque_raw > (double)0x7fff) {
     torque_raw = (double)0x7fff;
   }
@@ -522,23 +522,23 @@ static void lcec_stmds5k_write(lcec_slave_t *slave, long period) {
   EC_WRITE_S16(&pd[hal_data->torque_max_pdo_os], (int16_t)torque_raw);
 
   // calculate rpm command
-  *(hal_data->vel_rpm) = *(hal_data->vel_cmd) * hal_data->pos_scale * STMDS5K_RPM_FACTOR;
+  LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) * hal_data->pos_scale * STMDS5K_RPM_FACTOR);
 
   // set RPM
-  if (*(hal_data->vel_rpm) > hal_data->speed_max_rpm) {
-    *(hal_data->vel_rpm) = hal_data->speed_max_rpm;
+  if (LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) > hal_data->speed_max_rpm) {
+    LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, hal_data->speed_max_rpm);
   }
-  if (*(hal_data->vel_rpm) < -hal_data->speed_max_rpm) {
-    *(hal_data->vel_rpm) = -hal_data->speed_max_rpm;
+  if (LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) < -hal_data->speed_max_rpm) {
+    LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, -hal_data->speed_max_rpm);
   }
-  speed_raw = *(hal_data->vel_rpm) * hal_data->speed_max_rpm_sp_rcpt * STMDS5K_PCT_REG_FACTOR;
+  speed_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) * hal_data->speed_max_rpm_sp_rcpt * STMDS5K_PCT_REG_FACTOR;
   if (speed_raw > (double)0x7fff) {
     speed_raw = (double)0x7fff;
   }
   if (speed_raw < (double)-0x7fff) {
     speed_raw = (double)-0x7fff;
   }
-  if (!*(hal_data->enable)) {
+  if (!LCEC_PIN_BIT_GET(hal_data->enable)) {
     speed_raw = 0.0;
   }
   EC_WRITE_S16(&pd[hal_data->speed_sp_rel_pdo_os], (int16_t)speed_raw);

--- a/src/devices/lcec_stmds5k.c
+++ b/src/devices/lcec_stmds5k.c
@@ -107,11 +107,11 @@ typedef struct {
   hal_bit_t *fast_ramp;
   hal_bit_t *brake;
 
-  hal_float_t speed_max_rpm;
-  hal_float_t speed_max_rpm_sp;
-  hal_float_t torque_reference;
-  hal_float_t pos_scale;
-  hal_float_t extenc_scale;
+  lcec_param_float_t speed_max_rpm;
+  lcec_param_float_t speed_max_rpm_sp;
+  lcec_param_float_t torque_reference;
+  lcec_param_float_t pos_scale;
+  lcec_param_float_t extenc_scale;
   double speed_max_rpm_sp_rcpt;
 
   double pos_scale_old;
@@ -363,15 +363,15 @@ static int lcec_stmds5k_init(int comp_id, lcec_slave_t *slave) {
   LCEC_PIN_FLOAT_SET(hal_data->torque_lim, 1.0);
 
   // initialize variables
-  hal_data->torque_reference = sdo_torque_reference;
-  hal_data->speed_max_rpm = sdo_speed_max_rpm;
-  hal_data->speed_max_rpm_sp = sdo_speed_max_rpm_sp;
-  hal_data->pos_scale = 1.0;
-  hal_data->pos_scale_old = hal_data->pos_scale + 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->torque_reference, sdo_torque_reference);
+  LCEC_PARAM_FLOAT_SET(hal_data->speed_max_rpm, sdo_speed_max_rpm);
+  LCEC_PARAM_FLOAT_SET(hal_data->speed_max_rpm_sp, sdo_speed_max_rpm_sp);
+  LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
+  hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) + 1.0;
   hal_data->pos_scale_rcpt = 1.0;
   hal_data->extenc_conf = extenc_conf;
-  hal_data->extenc_scale = 1.0;
-  hal_data->extenc_scale_old = hal_data->extenc_scale + 1.0;
+  LCEC_PARAM_FLOAT_SET(hal_data->extenc_scale, 1.0);
+  hal_data->extenc_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale) + 1.0;
   hal_data->extenc_scale_rcpt = 1.0;
 
   return 0;
@@ -387,28 +387,28 @@ static const lcec_stmds5k_extenc_conf_t *lcec_stmds5k_get_extenc_conf(uint32_t t
 
 static void lcec_stmds5k_check_scales(lcec_stmds5k_data_t *hal_data) {
   // check for change in scale value
-  if (hal_data->pos_scale != hal_data->pos_scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) != hal_data->pos_scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->pos_scale < 1e-20) && (hal_data->pos_scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->pos_scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->pos_scale, 1.0);
     }
     // save new scale to detect future changes
-    hal_data->pos_scale_old = hal_data->pos_scale;
+    hal_data->pos_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
     // we actually want the reciprocal
-    hal_data->pos_scale_rcpt = 1.0 / hal_data->pos_scale;
+    hal_data->pos_scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->pos_scale);
   }
 
-  if (hal_data->extenc_scale != hal_data->extenc_scale_old) {
+  if (LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale) != hal_data->extenc_scale_old) {
     // scale value has changed, test and update it
-    if ((hal_data->extenc_scale < 1e-20) && (hal_data->extenc_scale > -1e-20)) {
+    if ((LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale) < 1e-20) && (LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale) > -1e-20)) {
       // value too small, divide by zero is a bad thing
-      hal_data->extenc_scale = 1.0;
+      LCEC_PARAM_FLOAT_SET(hal_data->extenc_scale, 1.0);
     }
     // save new scale to detect future changes
-    hal_data->extenc_scale_old = hal_data->extenc_scale;
+    hal_data->extenc_scale_old = LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale);
     // we actually want the reciprocal
-    hal_data->extenc_scale_rcpt = 1.0 / hal_data->extenc_scale;
+    hal_data->extenc_scale_rcpt = 1.0 / LCEC_PARAM_FLOAT_GET(hal_data->extenc_scale);
   }
 }
 
@@ -452,7 +452,7 @@ static void lcec_stmds5k_read(lcec_slave_t *slave, long period) {
 
   // read current speed
   speed_raw = EC_READ_S16(&pd[hal_data->speed_mot_pdo_os]);
-  rpm = hal_data->speed_max_rpm * (double)speed_raw * STMDS5K_PCT_REG_DIV;
+  rpm = LCEC_PARAM_FLOAT_GET(hal_data->speed_max_rpm) * (double)speed_raw * STMDS5K_PCT_REG_DIV;
   LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm, rpm);
   LCEC_PIN_FLOAT_SET(hal_data->vel_fb_rpm_abs, fabs(rpm));
   LCEC_PIN_FLOAT_SET(hal_data->vel_fb, rpm * STMDS5K_RPM_DIV * hal_data->pos_scale_rcpt);
@@ -462,7 +462,7 @@ static void lcec_stmds5k_read(lcec_slave_t *slave, long period) {
   torque_raw = EC_READ_S16(&pd[hal_data->torque_mot_pdo_os]);
   torque = (double)torque_raw * STMDS5K_TORQUE_DIV;
   LCEC_PIN_FLOAT_SET(hal_data->torque_fb_pct, fabs(torque * 100.0));
-  torque = torque * hal_data->torque_reference;
+  torque = torque * LCEC_PARAM_FLOAT_GET(hal_data->torque_reference);
   LCEC_PIN_FLOAT_SET(hal_data->torque_fb, torque);
   LCEC_PIN_FLOAT_SET(hal_data->torque_fb_abs, fabs(torque));
 
@@ -522,14 +522,14 @@ static void lcec_stmds5k_write(lcec_slave_t *slave, long period) {
   EC_WRITE_S16(&pd[hal_data->torque_max_pdo_os], (int16_t)torque_raw);
 
   // calculate rpm command
-  LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) * hal_data->pos_scale * STMDS5K_RPM_FACTOR);
+  LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, LCEC_PIN_FLOAT_GET(hal_data->vel_cmd) * LCEC_PARAM_FLOAT_GET(hal_data->pos_scale) * STMDS5K_RPM_FACTOR);
 
   // set RPM
-  if (LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) > hal_data->speed_max_rpm) {
-    LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, hal_data->speed_max_rpm);
+  if (LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) > LCEC_PARAM_FLOAT_GET(hal_data->speed_max_rpm)) {
+    LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, LCEC_PARAM_FLOAT_GET(hal_data->speed_max_rpm));
   }
-  if (LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) < -hal_data->speed_max_rpm) {
-    LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, -hal_data->speed_max_rpm);
+  if (LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) < -LCEC_PARAM_FLOAT_GET(hal_data->speed_max_rpm)) {
+    LCEC_PIN_FLOAT_SET(hal_data->vel_rpm, -LCEC_PARAM_FLOAT_GET(hal_data->speed_max_rpm));
   }
   speed_raw = LCEC_PIN_FLOAT_GET(hal_data->vel_rpm) * hal_data->speed_max_rpm_sp_rcpt * STMDS5K_PCT_REG_FACTOR;
   if (speed_raw > (double)0x7fff) {

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -26,14 +26,14 @@
 extern "C" {
 #endif
 
-#include "ecrt.h"
-#include "hal.h"
+#include <ecrt.h>
+#include <hal.h>
 #include "lcec_conf.h"
 #include "lcec_hal_compat.h"
 #include "lcec_rtapi.h"
-#include "rtapi_ctype.h"
-#include "rtapi_math.h"
-#include "rtapi_string.h"
+#include <rtapi_ctype.h>
+#include <rtapi_math.h>
+#include <rtapi_string.h>
 
 #ifdef __cplusplus
 }

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -29,6 +29,7 @@ extern "C" {
 #include "ecrt.h"
 #include "hal.h"
 #include "lcec_conf.h"
+#include "lcec_hal_compat.h"
 #include "lcec_rtapi.h"
 #include "rtapi_ctype.h"
 #include "rtapi_math.h"

--- a/src/lcec.h
+++ b/src/lcec.h
@@ -189,8 +189,8 @@ typedef struct lcec_master_data {
 #ifdef RTAPI_TASK_PLL_SUPPORT
   hal_s32_t *pll_err;
   hal_s32_t *pll_out;
-  hal_u32_t pll_step;
-  hal_u32_t pll_max_err;
+  lcec_param_u32_t pll_step;
+  lcec_param_u32_t pll_max_err;
   hal_u32_t *pll_reset_cnt;
   hal_u32_t dc_phase_max_err;
   hal_s32_t *app_phase;         // Our execution phase in local cycle (ns, real-time)
@@ -212,8 +212,8 @@ typedef struct lcec_master_data {
   // DC synchrony monitoring (broadcast read of 0x092C system time difference)
   hal_u32_t *dc_sync_diff;       // Output: upper estimate of max slave time diff (ns)
   hal_bit_t *dc_sync_converged;  // Output: dc_sync_diff below dc-sync-max threshold
-  hal_u32_t dc_sync_max;         // Param: convergence threshold (ns)
-  hal_bit_t dc_sync_monitor;     // Param: enable the per-cycle monitor datagram (default on)
+  lcec_param_u32_t dc_sync_max;         // Param: convergence threshold (ns)
+  lcec_param_bit_t dc_sync_monitor;     // Param: enable the per-cycle monitor datagram (default on)
   int dc_sync_miss_cnt;          // Internal: consecutive cycles without a monitor response
   // Phase calibration for sync_to_ref_clock=false mode
   int32_t phase_measure_cnt;  // Internal: measurement cycle counter

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -29,11 +29,11 @@
 #include <sys/eventfd.h>
 #include <unistd.h>
 
-#include "hal.h"
+#include <hal.h>
 #include "lcec.h"
 #include "lcec_conf_priv.h"
 #include "lcec_rtapi.h"
-#include "rtapi.h"
+#include <rtapi.h>
 
 typedef struct {
   hal_u32_t *master_count;

--- a/src/lcec_conf.c
+++ b/src/lcec_conf.c
@@ -131,6 +131,18 @@ int main(int argc, char **argv) {
   }
 
   // register pins
+#ifdef LCEC_HAL_NEW_API
+  if (hal_pin_new_ui32(hal_comp_id, HAL_OUT, (hal_uint_t *)&(conf_hal_data->master_count), 0, "%s.conf.master-count",
+          LCEC_MODULE_NAME) != 0) {
+    fprintf(stderr, "%s: ERROR: unable to register pin %s.conf.master-count\n", modname, LCEC_MODULE_NAME);
+    goto fail1;
+  }
+  if (hal_pin_new_ui32(hal_comp_id, HAL_OUT, (hal_uint_t *)&(conf_hal_data->slave_count), 0, "%s.conf.slave-count",
+          LCEC_MODULE_NAME) != 0) {
+    fprintf(stderr, "%s: ERROR: unable to register pin %s.conf.slave-count\n", modname, LCEC_MODULE_NAME);
+    goto fail1;
+  }
+#else
   if (hal_pin_u32_newf(HAL_OUT, &(conf_hal_data->master_count), hal_comp_id, "%s.conf.master-count", LCEC_MODULE_NAME) != 0) {
     fprintf(stderr, "%s: ERROR: unable to register pin %s.conf.master-count\n", modname, LCEC_MODULE_NAME);
     goto fail1;
@@ -139,8 +151,9 @@ int main(int argc, char **argv) {
     fprintf(stderr, "%s: ERROR: unable to register pin %s.conf.slave-count\n", modname, LCEC_MODULE_NAME);
     goto fail1;
   }
-  *(conf_hal_data->master_count) = 0;
-  *(conf_hal_data->slave_count) = 0;
+#endif
+  LCEC_PIN_U32_SET(conf_hal_data->master_count, 0);
+  LCEC_PIN_U32_SET(conf_hal_data->slave_count, 0);
 
   // initialize signal handling
   exitEvent = eventfd(0, 0);
@@ -361,7 +374,7 @@ static void parseMasterAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **
     snprintf(p->name, LCEC_CONF_STR_MAXLEN, "%d", p->index);
   }
 
-  (*(conf_hal_data->master_count))++;
+  LCEC_PIN_U32_SET(conf_hal_data->master_count, LCEC_PIN_U32_GET(conf_hal_data->master_count) + 1);
   state->currMaster = p;
 }
 
@@ -501,7 +514,7 @@ static void parseSlaveAttrs(LCEC_CONF_XML_INST_T *inst, int next, const char **a
     return;
   }
 
-  (*(conf_hal_data->slave_count))++;
+  LCEC_PIN_U32_SET(conf_hal_data->slave_count, LCEC_PIN_U32_GET(conf_hal_data->slave_count) + 1);
   state->currSlaveType = slaveType;
   state->currSlave = p;
 }

--- a/src/lcec_conf.h
+++ b/src/lcec_conf.h
@@ -21,8 +21,8 @@
 #ifndef _LCEC_CONF_H_
 #define _LCEC_CONF_H_
 
-#include "ecrt.h"
-#include "hal.h"
+#include <ecrt.h>
+#include <hal.h>
 
 #define LCEC_MODULE_NAME "lcec"
 

--- a/src/lcec_configgen.c
+++ b/src/lcec_configgen.c
@@ -30,11 +30,11 @@
 #include <string.h>
 #include <strings.h>
 
-#include "hal.h"
+#include <hal.h>
 #include "lcec.h"
 #include "lcec_conf.h"
 #include "lcec_rtapi.h"
-#include "rtapi.h"
+#include <rtapi.h>
 
 extern lcec_typelinkedlist_t *typeslist;
 

--- a/src/lcec_devices.c
+++ b/src/lcec_devices.c
@@ -27,12 +27,12 @@
 #include <sys/eventfd.h>
 #include <unistd.h>
 
-#include "hal.h"
+#include <hal.h>
 #include "lcec.h"
 #include "lcec_conf.h"
 #include "lcec_conf_priv.h"
 #include "lcec_rtapi.h"
-#include "rtapi.h"
+#include <rtapi.h>
 
 extern lcec_typelinkedlist_t *typeslist;
 

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -542,18 +542,23 @@ static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_add
     return err;
   }
 
+  // Note: params use caller-provided value storage (unlike pins, whose
+  // storage is HAL's 8-byte slot). Keep these writes narrow - the new-API
+  // setters always write the full 64-bit slot and would overflow the
+  // struct field (upstream's "parameter trap"). Param creation moves to
+  // the new API at stage 2, then this becomes a non-issue.
   switch (type) {
     case HAL_BIT:
-      LCEC_PIN_BIT_SET((hal_bit_t *)data_addr, 0);
+      *((hal_bit_t *)data_addr) = 0;
       break;
     case HAL_FLOAT:
-      LCEC_PIN_FLOAT_SET((hal_float_t *)data_addr, 0.0);
+      *((hal_float_t *)data_addr) = 0.0;
       break;
     case HAL_S32:
-      LCEC_PIN_S32_SET((hal_s32_t *)data_addr, 0);
+      *((hal_s32_t *)data_addr) = 0;
       break;
     case HAL_U32:
-      LCEC_PIN_U32_SET((hal_u32_t *)data_addr, 0);
+      *((hal_u32_t *)data_addr) = 0;
       break;
     default:
       break;

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -544,16 +544,16 @@ static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_add
 
   switch (type) {
     case HAL_BIT:
-      *((hal_bit_t *)data_addr) = 0;
+      LCEC_PIN_BIT_SET((hal_bit_t *)data_addr, 0);
       break;
     case HAL_FLOAT:
-      *((hal_float_t *)data_addr) = 0.0;
+      LCEC_PIN_FLOAT_SET((hal_float_t *)data_addr, 0.0);
       break;
     case HAL_S32:
-      *((hal_s32_t *)data_addr) = 0;
+      LCEC_PIN_S32_SET((hal_s32_t *)data_addr, 0);
       break;
     case HAL_U32:
-      *((hal_u32_t *)data_addr) = 0;
+      LCEC_PIN_U32_SET((hal_u32_t *)data_addr, 0);
       break;
     default:
       break;

--- a/src/lcec_ethercat.c
+++ b/src/lcec_ethercat.c
@@ -536,17 +536,42 @@ static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_add
     return -ENOMEM;
   }
 
+#ifdef LCEC_HAL_NEW_API
+  // New API: typed creators. Storage is HAL-owned and the creator applies
+  // the default and writes the opaque reference into the param field (which
+  // is an lcec_param_*_t reference under the new API - see lcec_hal_compat.h).
+  switch (type) {
+    case HAL_BIT:
+      err = hal_param_new_bool(lcec_comp_id, dir, (hal_bool_t *)data_addr, 0, "%s", name);
+      break;
+    case HAL_FLOAT:
+      err = hal_param_new_real(lcec_comp_id, dir, (hal_real_t *)data_addr, 0.0, "%s", name);
+      break;
+    case HAL_S32:
+      err = hal_param_new_si32(lcec_comp_id, dir, (hal_sint_t *)data_addr, 0, "%s", name);
+      break;
+    case HAL_U32:
+      err = hal_param_new_ui32(lcec_comp_id, dir, (hal_uint_t *)data_addr, 0, "%s", name);
+      break;
+    default:
+      err = -EINVAL;
+      break;
+  }
+  if (err) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "exporting param %s failed\n", name);
+    return err;
+  }
+#else
   err = hal_param_new(name, type, dir, data_addr, lcec_comp_id);
   if (err) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "exporting param %s failed\n", name);
     return err;
   }
 
-  // Note: params use caller-provided value storage (unlike pins, whose
+  // Old API: params use caller-provided value storage (unlike pins, whose
   // storage is HAL's 8-byte slot). Keep these writes narrow - the new-API
   // setters always write the full 64-bit slot and would overflow the
-  // struct field (upstream's "parameter trap"). Param creation moves to
-  // the new API at stage 2, then this becomes a non-issue.
+  // struct field (upstream's "parameter trap").
   switch (type) {
     case HAL_BIT:
       *((hal_bit_t *)data_addr) = 0;
@@ -563,6 +588,7 @@ static int lcec_param_newfv(hal_type_t type, hal_param_dir_t dir, void *data_add
     default:
       break;
   }
+#endif
 
   return 0;
 }

--- a/src/lcec_hal_compat.h
+++ b/src/lcec_hal_compat.h
@@ -1,0 +1,72 @@
+//
+//    Copyright (C) 2026 Luca Toniolo
+//
+//    This program is free software; you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation; either version 2 of the License, or
+//    (at your option) any later version.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with this program; if not, write to the Free Software
+//    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+//
+
+/// @file
+/// @brief Compatibility layer for the LinuxCNC HAL getter/setter API transition.
+///
+/// LinuxCNC PR #4099 introduced typed opaque pin/param references
+/// (`hal_bool_t`, `hal_sint_t`, `hal_uint_t`, `hal_real_t`) with
+/// `hal_get_*()`/`hal_set_*()` inline accessors.  The old API
+/// (`hal_pin_bit_new()` and direct dereferencing of `hal_bit_t *` etc.)
+/// remains available until upstream performs the announced "API break"
+/// (see draft PR #4247), at which point `HAL_S32`/`HAL_U32`/`HAL_S64`/
+/// `HAL_U64` and direct data access disappear.
+///
+/// The `LCEC_PIN_*` macros below let lcec code access pin data through the
+/// new getter/setter inlines when building against a new-enough LinuxCNC,
+/// and fall back to direct dereferencing on older LinuxCNC (2.9.x).  Both
+/// variants interoperate on shared HAL signals: the new setters always write
+/// the full 64-bit storage slot (sign-extended), and both reader styles use
+/// the low bytes of the same little-endian slot.
+///
+/// Detection relies on `HAL_BOOL`, which is only defined by post-#4099 hal.h.
+
+#ifndef _LCEC_HAL_COMPAT_H_
+#define _LCEC_HAL_COMPAT_H_
+
+#include "hal.h"
+
+#ifdef HAL_BOOL
+#define LCEC_HAL_NEW_API 1
+
+// New API: access through the typed inline accessors.  Pin storage pointers
+// in lcec hal_data structs are still declared with the old `hal_*_t *`
+// pointer types; the casts are safe because the opaque reference types are
+// plain pointers to the same little-endian storage slot, and the accessors
+// reach it through volatile union members.
+#define LCEC_PIN_BIT_SET(p, v) hal_set_bool((hal_bool_t)(p), (v))
+#define LCEC_PIN_BIT_GET(p) hal_get_bool((hal_bool_t)(p))
+#define LCEC_PIN_FLOAT_SET(p, v) hal_set_real((hal_real_t)(p), (v))
+#define LCEC_PIN_FLOAT_GET(p) hal_get_real((hal_real_t)(p))
+#define LCEC_PIN_S32_SET(p, v) hal_set_si32((hal_sint_t)(p), (v))
+#define LCEC_PIN_S32_GET(p) hal_get_si32((hal_sint_t)(p))
+#define LCEC_PIN_U32_SET(p, v) hal_set_ui32((hal_uint_t)(p), (v))
+#define LCEC_PIN_U32_GET(p) hal_get_ui32((hal_uint_t)(p))
+#else
+// Old API (LinuxCNC 2.9.x): direct dereference.
+#define LCEC_PIN_BIT_SET(p, v) (*(p) = (v))
+#define LCEC_PIN_BIT_GET(p) (*(p))
+#define LCEC_PIN_FLOAT_SET(p, v) (*(p) = (v))
+#define LCEC_PIN_FLOAT_GET(p) (*(p))
+#define LCEC_PIN_S32_SET(p, v) (*(p) = (v))
+#define LCEC_PIN_S32_GET(p) (*(p))
+#define LCEC_PIN_U32_SET(p, v) (*(p) = (v))
+#define LCEC_PIN_U32_GET(p) (*(p))
+#endif
+
+#endif  // _LCEC_HAL_COMPAT_H_

--- a/src/lcec_hal_compat.h
+++ b/src/lcec_hal_compat.h
@@ -72,4 +72,21 @@
 #define LCEC_PIN_U32_GET(p) (*(p))
 #endif
 
+// Type-dispatching variants for macro-generated code where the pin type
+// varies per instantiation (e.g. lcec_class_cia402).  Dispatch is on the
+// declared field pointer type; must be revisited if the field declarations
+// move to the opaque new-API reference types.
+#define LCEC_PIN_GET(p)                         \
+  _Generic((p),                                 \
+      hal_bit_t *: LCEC_PIN_BIT_GET(p),         \
+      hal_float_t *: LCEC_PIN_FLOAT_GET(p),     \
+      hal_s32_t *: LCEC_PIN_S32_GET(p),         \
+      hal_u32_t *: LCEC_PIN_U32_GET(p))
+#define LCEC_PIN_SET(p, v)                      \
+  _Generic((p),                                 \
+      hal_bit_t *: LCEC_PIN_BIT_SET(p, v),      \
+      hal_float_t *: LCEC_PIN_FLOAT_SET(p, v),  \
+      hal_s32_t *: LCEC_PIN_S32_SET(p, v),      \
+      hal_u32_t *: LCEC_PIN_U32_SET(p, v))
+
 #endif  // _LCEC_HAL_COMPAT_H_

--- a/src/lcec_hal_compat.h
+++ b/src/lcec_hal_compat.h
@@ -34,14 +34,17 @@
 /// the full 64-bit storage slot (sign-extended), and both reader styles use
 /// the low bytes of the same little-endian slot.
 ///
-/// Detection relies on `HAL_BOOL`, which is only defined by post-#4099 hal.h.
+/// Detection: post-#4099 hal.h moved `HAL_COMP_TYPE_*` from hal_priv.h and
+/// added `#define COMPONENT_TYPE_*` aliases (see upstream discussion; the
+/// `HAL_BOOL` define was explicitly marked as temporary).  Pre-#4099 hal.h
+/// defines neither, so either marker means the new API is present.
 
 #ifndef _LCEC_HAL_COMPAT_H_
 #define _LCEC_HAL_COMPAT_H_
 
-#include "hal.h"
+#include <hal.h>
 
-#ifdef HAL_BOOL
+#if defined(COMPONENT_TYPE_USER) || defined(HAL_BOOL)
 #define LCEC_HAL_NEW_API 1
 
 // New API: access through the typed inline accessors.  Pin storage pointers

--- a/src/lcec_hal_compat.h
+++ b/src/lcec_hal_compat.h
@@ -34,17 +34,22 @@
 /// the full 64-bit storage slot (sign-extended), and both reader styles use
 /// the low bytes of the same little-endian slot.
 ///
-/// Detection: post-#4099 hal.h moved `HAL_COMP_TYPE_*` from hal_priv.h and
-/// added `#define COMPONENT_TYPE_*` aliases (see upstream discussion; the
-/// `HAL_BOOL` define was explicitly marked as temporary).  Pre-#4099 hal.h
-/// defines neither, so either marker means the new API is present.
+/// Detection: upstream will add `#define HAL_API_VERSION 1` to hal.h once the
+/// getter/setter + query API are in place (per B. Stultiens).  Until that
+/// lands, fall back to COMPONENT_TYPE_* (define aliases added to hal.h with
+/// the query API) or HAL_BOOL (temporary, will become an enum entry).
+/// Pre-#4099 hal.h defines none of these.
 
 #ifndef _LCEC_HAL_COMPAT_H_
 #define _LCEC_HAL_COMPAT_H_
 
 #include <hal.h>
 
-#if defined(COMPONENT_TYPE_USER) || defined(HAL_BOOL)
+#if defined(HAL_API_VERSION) && HAL_API_VERSION != 1
+#error "Unsupported HAL_API_VERSION detected"
+#endif
+
+#if defined(HAL_API_VERSION) || defined(COMPONENT_TYPE_USER) || defined(HAL_BOOL)
 #define LCEC_HAL_NEW_API 1
 
 // New API: access through the typed inline accessors.  Pin storage pointers

--- a/src/lcec_hal_compat.h
+++ b/src/lcec_hal_compat.h
@@ -65,6 +65,23 @@
 #define LCEC_PIN_S32_GET(p) hal_get_si32((hal_sint_t)(p))
 #define LCEC_PIN_U32_SET(p, v) hal_set_ui32((hal_uint_t)(p), (v))
 #define LCEC_PIN_U32_GET(p) hal_get_ui32((hal_uint_t)(p))
+
+// Params. Storage is HAL-owned on the new API (the creators return an
+// opaque reference), but caller-provided struct fields on the old API.
+// The typedefs below make param fields a reference on the new API and a
+// value on the old API; all access must go through LCEC_PARAM_*.
+typedef hal_bool_t lcec_param_bit_t;
+typedef hal_real_t lcec_param_float_t;
+typedef hal_sint_t lcec_param_s32_t;
+typedef hal_uint_t lcec_param_u32_t;
+#define LCEC_PARAM_BIT_SET(f, v) hal_set_bool((f), (v))
+#define LCEC_PARAM_BIT_GET(f) hal_get_bool((f))
+#define LCEC_PARAM_FLOAT_SET(f, v) hal_set_real((f), (v))
+#define LCEC_PARAM_FLOAT_GET(f) hal_get_real((f))
+#define LCEC_PARAM_S32_SET(f, v) hal_set_si32((f), (v))
+#define LCEC_PARAM_S32_GET(f) hal_get_si32((f))
+#define LCEC_PARAM_U32_SET(f, v) hal_set_ui32((f), (v))
+#define LCEC_PARAM_U32_GET(f) hal_get_ui32((f))
 #else
 // Old API (LinuxCNC 2.9.x): direct dereference.
 #define LCEC_PIN_BIT_SET(p, v) (*(p) = (v))
@@ -75,6 +92,20 @@
 #define LCEC_PIN_S32_GET(p) (*(p))
 #define LCEC_PIN_U32_SET(p, v) (*(p) = (v))
 #define LCEC_PIN_U32_GET(p) (*(p))
+
+// Old API: params are plain value fields in the component's hal_data.
+typedef hal_bit_t lcec_param_bit_t;
+typedef hal_float_t lcec_param_float_t;
+typedef hal_s32_t lcec_param_s32_t;
+typedef hal_u32_t lcec_param_u32_t;
+#define LCEC_PARAM_BIT_SET(f, v) ((f) = (v))
+#define LCEC_PARAM_BIT_GET(f) (f)
+#define LCEC_PARAM_FLOAT_SET(f, v) ((f) = (v))
+#define LCEC_PARAM_FLOAT_GET(f) (f)
+#define LCEC_PARAM_S32_SET(f, v) ((f) = (v))
+#define LCEC_PARAM_S32_GET(f) (f)
+#define LCEC_PARAM_U32_SET(f, v) ((f) = (v))
+#define LCEC_PARAM_U32_GET(f) (f)
 #endif
 
 // Type-dispatching variants for macro-generated code where the pin type

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -366,18 +366,18 @@ int rtapi_app_main(void) {
 
 #ifdef RTAPI_TASK_PLL_SUPPORT
     // set default PLL_STEP: use +/-0.1% of period
-    master->hal_data->pll_step = master->app_time_period / 1000;
+    LCEC_PARAM_U32_SET(master->hal_data->pll_step, master->app_time_period / 1000);
     // set default PLL_MAX_ERR: one period
-    master->hal_data->pll_max_err = master->app_time_period;
+    LCEC_PARAM_U32_SET(master->hal_data->pll_max_err, master->app_time_period);
     // Initialize auto-drift delay counter (wait 100 cycles before applying)
     master->hal_data->auto_drift_delay = 100;
 #endif
     // DC synchrony convergence threshold: 4% of period (10 us at 4 kHz);
     // app_time_period can be 0 here when the XML omits appTimePeriod.
-    master->hal_data->dc_sync_max = (master->app_time_period != 0) ? master->app_time_period / 25 : 10000;
+    LCEC_PARAM_U32_SET(master->hal_data->dc_sync_max, (master->app_time_period != 0) ? master->app_time_period / 25 : 10000);
     // Monitor on by default (one broadcast datagram per cycle); setp to 0
     // for zero overhead when the dc-sync pins are unused.
-    master->hal_data->dc_sync_monitor = 1;
+    LCEC_PARAM_BIT_SET(master->hal_data->dc_sync_monitor, 1);
 
     // Activate master (only when initf is unavailable; otherwise lcec.activate
     // funct does it from RT context after the user's `initf lcec.activate <thread>`).
@@ -1328,7 +1328,7 @@ void lcec_read_master(void *arg, long period) {
     }
   }
   domain_state.wc_state = all_domains_complete ? EC_WC_COMPLETE : (all_domains_zero ? EC_WC_ZERO : EC_WC_INCOMPLETE);
-  dc_sync_diff = master->hal_data->dc_sync_monitor ? ecrt_master_sync_monitor_process(master->master) : 0xffffffffu;
+  dc_sync_diff = LCEC_PARAM_BIT_GET(master->hal_data->dc_sync_monitor) ? ecrt_master_sync_monitor_process(master->master) : 0xffffffffu;
   if (check_states) {
     ecrt_master_state(master->master, &master->ms);
   }
@@ -1380,11 +1380,11 @@ void lcec_read_master(void *arg, long period) {
     // 0xffffffff means the monitor datagram was not received this cycle.
     // Tolerate a few consecutive misses (startup, single datagram timeouts),
     // then invalidate so a dead bus cannot keep showing stale-converged.
-    if (hd->dc_sync_monitor) {
+    if (LCEC_PARAM_BIT_GET(hd->dc_sync_monitor)) {
       if (dc_sync_diff != 0xffffffffu) {
         hd->dc_sync_miss_cnt = 0;
         LCEC_PIN_U32_SET(hd->dc_sync_diff, dc_sync_diff);
-        LCEC_PIN_BIT_SET(hd->dc_sync_converged, (dc_sync_diff < hd->dc_sync_max));
+        LCEC_PIN_BIT_SET(hd->dc_sync_converged, (dc_sync_diff < LCEC_PARAM_U32_GET(hd->dc_sync_max)));
       } else if (hd->dc_sync_miss_cnt < LCEC_DC_SYNC_MISS_MAX) {
         hd->dc_sync_miss_cnt++;
       } else {
@@ -1539,7 +1539,7 @@ void lcec_write_master(void *arg, long period) {
 
   // queue DC synchrony monitor datagram (broadcast read of 0x092C),
   // processed next cycle in lcec_read_master
-  if (master->hal_data->dc_sync_monitor) {
+  if (LCEC_PARAM_BIT_GET(master->hal_data->dc_sync_monitor)) {
     ecrt_master_sync_monitor_queue(master->master);
   }
 
@@ -1639,9 +1639,9 @@ void lcec_write_master(void *arg, long period) {
       if (lock_threshold < app_period / 100) {
         lock_threshold = app_period / 100;
       }
-      if (abs(phase_error) < abs(hal_data->pll_step) * 3) {
+      if (abs(phase_error) < abs(LCEC_PARAM_U32_GET(hal_data->pll_step)) * 3) {
         LCEC_PIN_BIT_SET(hal_data->dc_phased, 1);
-      } else if (abs(phase_error) > abs(hal_data->pll_step) * 20) {
+      } else if (abs(phase_error) > abs(LCEC_PARAM_U32_GET(hal_data->pll_step)) * 20) {
         LCEC_PIN_BIT_SET(hal_data->dc_phased, 0);
       }
 
@@ -1652,9 +1652,9 @@ void lcec_write_master(void *arg, long period) {
         LCEC_PIN_S32_SET(hal_data->pll_out, 0);
       } else {
         if (phase_error > 0) {
-          LCEC_PIN_S32_SET(hal_data->pll_out, -(hal_data->pll_step));  // Speed up to reduce app_phase
+          LCEC_PIN_S32_SET(hal_data->pll_out, -(LCEC_PARAM_U32_GET(hal_data->pll_step)));  // Speed up to reduce app_phase
         } else if (phase_error < 0) {
-          LCEC_PIN_S32_SET(hal_data->pll_out, hal_data->pll_step);  // Slow down to increase app_phase
+          LCEC_PIN_S32_SET(hal_data->pll_out, LCEC_PARAM_U32_GET(hal_data->pll_step));  // Slow down to increase app_phase
         }
       }
 
@@ -1724,7 +1724,7 @@ void lcec_write_master(void *arg, long period) {
       // |pll_err| <= period/2 could never reach the default threshold, and
       // a whole-period displacement would go undetected. Remove only whole
       // periods; the controller drives the remainder to zero.
-      if (abs(raw_offset) > hal_data->pll_max_err) {
+      if (abs(raw_offset) > LCEC_PARAM_U32_GET(hal_data->pll_max_err)) {
         int32_t resync_corr = raw_offset;
         if (raw_offset >= app_period || raw_offset <= -app_period) {
           // the division runs only on the cycle a resync fires
@@ -1741,7 +1741,7 @@ void lcec_write_master(void *arg, long period) {
           hal_data->auto_drift_delay = 100;
         }
       } else {
-        LCEC_PIN_S32_SET(hal_data->pll_out, (pll_err < 0) ? -(hal_data->pll_step) : (hal_data->pll_step));
+        LCEC_PIN_S32_SET(hal_data->pll_out, (pll_err < 0) ? -(LCEC_PARAM_U32_GET(hal_data->pll_step)) : (LCEC_PARAM_U32_GET(hal_data->pll_step)));
       }
     }
     // Note: When sync_to_ref_clock = false, pll_out is set in the phase calibration code above

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -1111,23 +1111,23 @@ lcec_slave_state_t *lcec_init_slave_state_hal(char *master_name, char *slave_nam
 
 /// @brief Update HAL pins for the master.
 void lcec_update_master_hal(lcec_master_data_t *hal_data, ec_master_state_t *ms) {
-  *(hal_data->slaves_responding) = ms->slaves_responding;
-  *(hal_data->state_init) = (ms->al_states & 0x01) != 0;
-  *(hal_data->state_preop) = (ms->al_states & 0x02) != 0;
-  *(hal_data->state_safeop) = (ms->al_states & 0x04) != 0;
-  *(hal_data->state_op) = (ms->al_states & 0x08) != 0;
-  *(hal_data->link_up) = ms->link_up;
-  *(hal_data->all_op) = (ms->al_states == 0x08);
+  LCEC_PIN_U32_SET(hal_data->slaves_responding, ms->slaves_responding);
+  LCEC_PIN_BIT_SET(hal_data->state_init, (ms->al_states & 0x01) != 0);
+  LCEC_PIN_BIT_SET(hal_data->state_preop, (ms->al_states & 0x02) != 0);
+  LCEC_PIN_BIT_SET(hal_data->state_safeop, (ms->al_states & 0x04) != 0);
+  LCEC_PIN_BIT_SET(hal_data->state_op, (ms->al_states & 0x08) != 0);
+  LCEC_PIN_BIT_SET(hal_data->link_up, ms->link_up);
+  LCEC_PIN_BIT_SET(hal_data->all_op, (ms->al_states == 0x08));
 }
 
 /// @brief Update generic HAL pins for a slave.
 void lcec_update_slave_state_hal(lcec_slave_state_t *hal_data, ec_slave_config_state_t *ss) {
-  *(hal_data->online) = ss->online;
-  *(hal_data->operational) = ss->operational;
-  *(hal_data->state_init) = (ss->al_state & 0x01) != 0;
-  *(hal_data->state_preop) = (ss->al_state & 0x02) != 0;
-  *(hal_data->state_safeop) = (ss->al_state & 0x04) != 0;
-  *(hal_data->state_op) = (ss->al_state & 0x08) != 0;
+  LCEC_PIN_BIT_SET(hal_data->online, ss->online);
+  LCEC_PIN_BIT_SET(hal_data->operational, ss->operational);
+  LCEC_PIN_BIT_SET(hal_data->state_init, (ss->al_state & 0x01) != 0);
+  LCEC_PIN_BIT_SET(hal_data->state_preop, (ss->al_state & 0x02) != 0);
+  LCEC_PIN_BIT_SET(hal_data->state_safeop, (ss->al_state & 0x04) != 0);
+  LCEC_PIN_BIT_SET(hal_data->state_op, (ss->al_state & 0x08) != 0);
 }
 
 /// @brief Update all input pins across all masters and slaves.
@@ -1349,29 +1349,29 @@ void lcec_read_master(void *arg, long period) {
 
     // user-requested stats reset: clear min/change tracking and re-arm the
     // first-complete-exchange gate so wkc-min re-anchors; pin self-clears
-    if (*(hd->wkc_reset)) {
-      *(hd->wkc_reset) = 0;
+    if (LCEC_PIN_BIT_GET(hd->wkc_reset)) {
+      LCEC_PIN_BIT_SET(hd->wkc_reset, 0);
       hd->wkc_full_seen = 0;
-      *(hd->wkc_min) = 0;
-      *(hd->wkc_change_cnt) = 0;
+      LCEC_PIN_U32_SET(hd->wkc_min, 0);
+      LCEC_PIN_U32_SET(hd->wkc_change_cnt, 0);
     }
 
-    *(hd->wkc) = wkc_now;
-    *(hd->wkc_state) = (hal_s32_t)domain_state.wc_state;
+    LCEC_PIN_U32_SET(hd->wkc, wkc_now);
+    LCEC_PIN_S32_SET(hd->wkc_state, (hal_s32_t)domain_state.wc_state);
     if (!hd->wkc_full_seen) {
       if (domain_state.wc_state == EC_WC_COMPLETE) {
         hd->wkc_full_seen = 1;
-        *(hd->wkc_min) = wkc_now;
-        *(hd->wkc_change_cnt) = 0;
+        LCEC_PIN_U32_SET(hd->wkc_min, wkc_now);
+        LCEC_PIN_U32_SET(hd->wkc_change_cnt, 0);
       }
     } else {
-      if (wkc_now < *(hd->wkc_min)) {
-        *(hd->wkc_min) = wkc_now;
+      if (wkc_now < LCEC_PIN_U32_GET(hd->wkc_min)) {
+        LCEC_PIN_U32_SET(hd->wkc_min, wkc_now);
       }
       // no rtapi_print here: a flapping bus would emit at cycle rate from the
       // RT thread; the change counter pin + recorder are the log
       if (wkc_now != hd->wkc_last) {
-        (*(hd->wkc_change_cnt))++;
+        LCEC_PIN_U32_SET(hd->wkc_change_cnt, LCEC_PIN_U32_GET(hd->wkc_change_cnt) + 1);
       }
     }
     hd->wkc_last = wkc_now;
@@ -1383,13 +1383,13 @@ void lcec_read_master(void *arg, long period) {
     if (hd->dc_sync_monitor) {
       if (dc_sync_diff != 0xffffffffu) {
         hd->dc_sync_miss_cnt = 0;
-        *(hd->dc_sync_diff) = dc_sync_diff;
-        *(hd->dc_sync_converged) = (dc_sync_diff < hd->dc_sync_max);
+        LCEC_PIN_U32_SET(hd->dc_sync_diff, dc_sync_diff);
+        LCEC_PIN_BIT_SET(hd->dc_sync_converged, (dc_sync_diff < hd->dc_sync_max));
       } else if (hd->dc_sync_miss_cnt < LCEC_DC_SYNC_MISS_MAX) {
         hd->dc_sync_miss_cnt++;
       } else {
-        *(hd->dc_sync_converged) = 0;
-        *(hd->dc_sync_diff) = 0xffffffffu;
+        LCEC_PIN_BIT_SET(hd->dc_sync_converged, 0);
+        LCEC_PIN_U32_SET(hd->dc_sync_diff, 0xffffffffu);
       }
     }
   }
@@ -1551,16 +1551,16 @@ void lcec_write_master(void *arg, long period) {
   // BANG-BANG controller for master thread PLL sync
   // this part is done after ecrt_master_send() to reduce jitter
   hal_data = master->hal_data;
-  *(hal_data->pll_err) = 0;
-  *(hal_data->pll_out) = 0;
-  *(hal_data->dc_phased) = 0;
+  LCEC_PIN_S32_SET(hal_data->pll_err, 0);
+  LCEC_PIN_S32_SET(hal_data->pll_out, 0);
+  LCEC_PIN_BIT_SET(hal_data->dc_phased, 0);
 
   // Calculate app_phase: our execution position in local cycle
   // This is relative to dc_ref_time (the time we set at activation)
   // app_phase = (app_time - dc_ref_time) % period
   // This represents where we are within the current cycle since activation
   int32_t current_app_phase = (int32_t)((app_time - master->dc_ref_time) % master->app_time_period);
-  *(hal_data->app_phase) = current_app_phase;
+  LCEC_PIN_S32_SET(hal_data->app_phase, current_app_phase);
   int32_t app_period = (int32_t)master->app_time_period;
 
   // When sync_to_ref_clock = false: adjust app_phase to a stable position using PLL
@@ -1603,7 +1603,7 @@ void lcec_write_master(void *arg, long period) {
       } else {
         // Phase 2: Calculate jitter and target position
         hal_data->phase_jitter = hal_data->phase_max - hal_data->phase_min;
-        *(hal_data->phase_jitter_out) = hal_data->phase_jitter;  // Output jitter for debugging
+        LCEC_PIN_S32_SET(hal_data->phase_jitter_out, hal_data->phase_jitter);  // Output jitter for debugging
 
         // Target position: jitter + jitter/2 = jitter * 1.5
         int32_t target = hal_data->phase_jitter + hal_data->phase_jitter / 2;
@@ -1632,7 +1632,7 @@ void lcec_write_master(void *arg, long period) {
       int32_t phase_error = current_app_phase - hal_data->phase_target;
 
       // Set pll_err for monitoring
-      //*(hal_data->pll_err) = raw_offset + drift;
+      //LCEC_PIN_S32_SET(hal_data->pll_err, raw_offset + drift);
 
       // Check if locked (within 10% of jitter or 1% of app_period, whichever is larger)
       int32_t lock_threshold = 0;  // hal_data->phase_jitter;
@@ -1640,21 +1640,21 @@ void lcec_write_master(void *arg, long period) {
         lock_threshold = app_period / 100;
       }
       if (abs(phase_error) < abs(hal_data->pll_step) * 3) {
-        *(hal_data->dc_phased) = 1;
+        LCEC_PIN_BIT_SET(hal_data->dc_phased, 1);
       } else if (abs(phase_error) > abs(hal_data->pll_step) * 20) {
-        *(hal_data->dc_phased) = 0;
+        LCEC_PIN_BIT_SET(hal_data->dc_phased, 0);
       }
 
       // BANG-BANG control: small steps to move towards target
       // Positive pll_out = slow down = app_phase increases
       // Negative pll_out = speed up = app_phase decreases
-      if (*(hal_data->dc_phased)) {
-        *(hal_data->pll_out) = 0;
+      if (LCEC_PIN_BIT_GET(hal_data->dc_phased)) {
+        LCEC_PIN_S32_SET(hal_data->pll_out, 0);
       } else {
         if (phase_error > 0) {
-          *(hal_data->pll_out) = -(hal_data->pll_step);  // Speed up to reduce app_phase
+          LCEC_PIN_S32_SET(hal_data->pll_out, -(hal_data->pll_step));  // Speed up to reduce app_phase
         } else if (phase_error < 0) {
-          *(hal_data->pll_out) = hal_data->pll_step;  // Slow down to increase app_phase
+          LCEC_PIN_S32_SET(hal_data->pll_out, hal_data->pll_step);  // Slow down to increase app_phase
         }
       }
 
@@ -1663,8 +1663,8 @@ void lcec_write_master(void *arg, long period) {
       // Force PLL outputs to safe values so rtapi_task_pll_get_reference does
       // not see stale BANG-BANG state. Manual pll_drift pin still applies via
       // pll_correction = pll_out + pll_drift further down.
-      *(hal_data->pll_out) = 0;
-      *(hal_data->dc_phased) = 1;
+      LCEC_PIN_S32_SET(hal_data->pll_out, 0);
+      LCEC_PIN_BIT_SET(hal_data->dc_phased, 1);
     }
   }
 
@@ -1678,7 +1678,7 @@ void lcec_write_master(void *arg, long period) {
     //   1 = manual: use pll-drift pin value
     //   other = same as 1 (manual)
     int32_t drift = 0;
-    int32_t mode = *(hal_data->drift_mode);
+    int32_t mode = LCEC_PIN_S32_GET(hal_data->drift_mode);
     if (master->sync_to_ref_clock) {
       if (mode == 0) {
         // Mode 0: simple - (app_period - app_phase) % app_period
@@ -1708,12 +1708,12 @@ void lcec_write_master(void *arg, long period) {
     } else if (pll_err < -(app_period / 2)) {
       pll_err += app_period;
     }
-    *(hal_data->pll_err) = pll_err;
+    LCEC_PIN_S32_SET(hal_data->pll_err, pll_err);
 
     // PLL is considered phased if error is within 10% of period
     int32_t lock_threshold = master->app_time_period / 10;
-    if (abs(*(hal_data->pll_err)) < lock_threshold) {
-      *(hal_data->dc_phased) = 1;
+    if (abs(LCEC_PIN_S32_GET(hal_data->pll_err)) < lock_threshold) {
+      LCEC_PIN_BIT_SET(hal_data->dc_phased, 1);
     }
 
     // Only run automatic PLL adjustment when sync_to_ref_clock is enabled
@@ -1735,13 +1735,13 @@ void lcec_write_master(void *arg, long period) {
         // skip next control cycle to allow resync
         dc_time_valid = 0;
         // increment reset counter to document this event
-        (*(hal_data->pll_reset_cnt))++;
+        LCEC_PIN_U32_SET(hal_data->pll_reset_cnt, LCEC_PIN_U32_GET(hal_data->pll_reset_cnt) + 1);
         // Reset auto-drift delay on resync
-        if (*(hal_data->drift_mode) == 0) {
+        if (LCEC_PIN_S32_GET(hal_data->drift_mode) == 0) {
           hal_data->auto_drift_delay = 100;
         }
       } else {
-        *(hal_data->pll_out) = (pll_err < 0) ? -(hal_data->pll_step) : (hal_data->pll_step);
+        LCEC_PIN_S32_SET(hal_data->pll_out, (pll_err < 0) ? -(hal_data->pll_step) : (hal_data->pll_step));
       }
     }
     // Note: When sync_to_ref_clock = false, pll_out is set in the phase calibration code above
@@ -1754,17 +1754,17 @@ void lcec_write_master(void *arg, long period) {
   int32_t pll_correction;
   if (master->sync_to_ref_clock) {
     // sync_to_ref_clock = true: always use PLL output for continuous sync
-    pll_correction = *(hal_data->pll_out) + *(hal_data->pll_drift);
+    pll_correction = LCEC_PIN_S32_GET(hal_data->pll_out) + LCEC_PIN_S32_GET(hal_data->pll_drift);
   } else {
     // sync_to_ref_clock = false: stop adjusting once locked
-    if (*(hal_data->dc_phased)) {
-      pll_correction = *(hal_data->pll_drift);
+    if (LCEC_PIN_BIT_GET(hal_data->dc_phased)) {
+      pll_correction = LCEC_PIN_S32_GET(hal_data->pll_drift);
     } else {
-      pll_correction = *(hal_data->pll_out) + *(hal_data->pll_drift);
+      pll_correction = LCEC_PIN_S32_GET(hal_data->pll_out) + LCEC_PIN_S32_GET(hal_data->pll_drift);
     }
   }
 
-  *(hal_data->pll_final) = pll_correction;
+  LCEC_PIN_S32_SET(hal_data->pll_final, pll_correction);
   rtapi_task_pll_set_correction(pll_correction);
 
   master->app_time_last = (uint32_t)app_time;

--- a/src/lcec_main.c
+++ b/src/lcec_main.c
@@ -27,7 +27,7 @@
 
 #include "devices/lcec_generic.h"
 #include "lcec.h"
-#include "rtapi_app.h"
+#include <rtapi_app.h>
 // #include <linuxcnc/rtapi_mutex.h>
 
 MODULE_LICENSE("GPL")

--- a/src/lcec_pins.c
+++ b/src/lcec_pins.c
@@ -44,16 +44,16 @@ static int lcec_pin_newfv(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_ad
 
   switch (type) {
     case HAL_BIT:
-      **((hal_bit_t **)data_ptr_addr) = 0;
+      LCEC_PIN_BIT_SET(*((hal_bit_t **)data_ptr_addr), 0);
       break;
     case HAL_FLOAT:
-      **((hal_float_t **)data_ptr_addr) = 0.0;
+      LCEC_PIN_FLOAT_SET(*((hal_float_t **)data_ptr_addr), 0.0);
       break;
     case HAL_S32:
-      **((hal_s32_t **)data_ptr_addr) = 0;
+      LCEC_PIN_S32_SET(*((hal_s32_t **)data_ptr_addr), 0);
       break;
     case HAL_U32:
-      **((hal_u32_t **)data_ptr_addr) = 0;
+      LCEC_PIN_U32_SET(*((hal_u32_t **)data_ptr_addr), 0);
       break;
     default:
       break;

--- a/src/lcec_pins.c
+++ b/src/lcec_pins.c
@@ -36,6 +36,34 @@ static int lcec_pin_newfv(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_ad
     return -ENOMEM;
   }
 
+#ifdef LCEC_HAL_NEW_API
+  // New API: typed creators, which also apply the default. Pin storage is
+  // HAL's 8-byte slot, so the full-width default write is safe here (unlike
+  // for params - see lcec_ethercat.c). The si32/ui32 creators keep 32-bit
+  // pin types pre-break and become 64-bit aliases at the API break, so a
+  // single build spans the break.
+  switch (type) {
+    case HAL_BIT:
+      err = hal_pin_new_bool(lcec_comp_id, dir, (hal_bool_t *)data_ptr_addr, 0, "%s", name);
+      break;
+    case HAL_FLOAT:
+      err = hal_pin_new_real(lcec_comp_id, dir, (hal_real_t *)data_ptr_addr, 0.0, "%s", name);
+      break;
+    case HAL_S32:
+      err = hal_pin_new_si32(lcec_comp_id, dir, (hal_sint_t *)data_ptr_addr, 0, "%s", name);
+      break;
+    case HAL_U32:
+      err = hal_pin_new_ui32(lcec_comp_id, dir, (hal_uint_t *)data_ptr_addr, 0, "%s", name);
+      break;
+    default:
+      err = -EINVAL;
+      break;
+  }
+  if (err) {
+    rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "exporting pin %s failed\n", name);
+    return err;
+  }
+#else
   err = hal_pin_new(name, type, dir, data_ptr_addr, lcec_comp_id);
   if (err) {
     rtapi_print_msg(RTAPI_MSG_ERR, LCEC_MSG_PFX "exporting pin %s failed\n", name);
@@ -58,6 +86,7 @@ static int lcec_pin_newfv(hal_type_t type, hal_pin_dir_t dir, void **data_ptr_ad
     default:
       break;
   }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
## Summary

LinuxCNC is migrating HAL pin/param access to typed creators and getter/setter inlines (LinuxCNC#4099, merged; full-tree conversion in draft LinuxCNC#4247). The old API disappears at an announced "API break" in 2.10. This branch makes linuxcnc-ethercat build against **both** API generations from a single source head.

## Design

- New central shim `src/lcec_hal_compat.h`: detects the new API at compile time (`HAL_API_VERSION` / `COMPONENT_TYPE_USER` / `HAL_BOOL`, per B. Stultiens' guidance), and provides:
  - `LCEC_PIN_{BIT,FLOAT,S32,U32}_{GET,SET}` plus `_Generic`-dispatching `LCEC_PIN_GET/SET` for token-pasting macro code
  - `lcec_param_{bit,float,s32,u32}_t` typedefs and `LCEC_PARAM_*_{GET,SET}` macros
  - On old headers everything expands to the classic direct access; on new headers to opaque refs + `hal_get_*`/`hal_set_*`
- Pin creation switches to `hal_pin_new_bool/real/si32/ui32` under the new API (`lcec_pins.c`, `lcec_conf.c`); param creation to `hal_param_new_*` (`lcec_ethercat.c`).
- All ~700 pin and ~160 param access sites converted across 60+ files. Internal look-alike fields (scale caches, const config tables) deliberately left as plain accesses.
- The parameter-storage trap (old `hal_param_new` uses caller storage as small as 1 byte, new setters write 8 bytes) is avoided by using the new creators, which use HAL-owned storage; the legacy zero-init path keeps narrow direct writes.

## Compatibility

- Builds verified clean against both a pre-#4099 tree and current linuxcnc master (which contains the new API).
- At the API break, `hal_pin_new_si32/ui32` become aliases of the 64-bit creators upstream, so a new-API build spans the break without changes here.
- User-facing: XML configs unchanged; halfiles unchanged (net-only setups adopt pin types automatically).

## CI

Every push and every release now builds both flavors (matrix axis `hal_api`): legacy debs from repo headers, `+getset` debs against linuxcnc master built from source (no public 2.10 debs exist). The `+getset` deb's shlibs-derived `Depends: linuxcnc-uspace (>= 1:2.10~)` makes apt auto-select the right flavor per system. Bullseye is legacy-only (linuxcnc master needs C++20, bullseye ships gcc 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)